### PR TITLE
docs: add ARCHITECTURE.md and improve documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,42 @@ Types: feat / fix / docs / test / chore / refactor / perf
 Scopes: core / extractor / mcp / security / config / map / ci / docs / test
 ```
 
+## Adding an integration test
+
+1. Create `test/integration/<area>.test.js` following the existing test files.
+2. Use only Node.js built-ins — no Jest, no Mocha, no external test frameworks.
+3. Export a `run()` function that returns `{ passed, failed, total }`.
+4. Register it in `test/run.js` by requiring it in the integration suite array.
+5. Run `node test/run.js` — the new suite appears in the count.
+
+## Bundling
+
+The repository ships two forms of the main entry point:
+
+- `src/` — modular source files (edit these)
+- `gen-context.js` — standalone bundle (generated; checked in for zero-install use)
+
+After changing anything in `src/`:
+
+```bash
+node scripts/bundle.js
+# Writes gen-context.js (overwrites)
+# Prints: lines, KB, modules inlined
+```
+
+`scripts/bundle.js` works by:
+
+1. Collecting every `.js` file under `src/` and assigning each a canonical key
+   (e.g. `./src/config/loader`).
+2. Rewriting internal `require('./...')` calls to `__require('./src/...')`.
+3. Wrapping each module in a factory function stored in `__factories`.
+4. Prepending a tiny `__require` loader that evaluates factories on first call
+   and caches exports — behaviorally identical to Node's module system.
+5. Appending the main entry with its requires patched to the same loader.
+
+**Never edit `gen-context.js` directly.** Changes there will be overwritten the
+next time `scripts/bundle.js` runs. The `src/` tree is the source of truth.
+
 ## Running tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -282,6 +282,24 @@ Copy `gen-context.config.json.example` to `gen-context.config.json`:
 }
 ```
 
+### Output targets
+
+The `outputs` array controls which files are written. Each maps to the path an
+AI tool reads automatically:
+
+| Target | Output path | Read by |
+|---|---|---|
+| `copilot` (default) | `.github/copilot-instructions.md` | GitHub Copilot in VS Code |
+| `claude` | `CLAUDE.md` | Claude Code |
+| `cursor` | `.cursor/rules` | Cursor IDE |
+| `windsurf` | `.windsurf/rules` | Windsurf IDE |
+
+Write to multiple targets at once:
+
+```json
+{ "outputs": ["copilot", "claude", "cursor"] }
+```
+
 Exclusions go in `.contextignore` (gitignore syntax). Also reads `.repomixignore` if present.
 
 ---
@@ -319,28 +337,50 @@ sleep 2
 ## Project structure
 
 ```
-gen-context.js                ← single-file entry point
+gen-context.js                ← standalone bundle (generated from src/ — do not edit directly)
 gen-project-map.js            ← import graph, class hierarchy, route table
+scripts/bundle.js             ← bundles src/ into gen-context.js
+src/config/                   ← config loader + defaults
 src/extractors/               ← 21 language extractors
 src/format/cache.js           ← Anthropic prompt-cache JSON formatter (v0.8)
-src/routing/                  ← model routing hints (v0.7)
-src/tracking/logger.js        ← NDJSON usage log (v0.9)
 src/health/scorer.js          ← composite health score (v1.0)
+src/map/                      ← import graph, class hierarchy, route table (used by gen-project-map.js)
 src/mcp/                      ← MCP stdio server (v0.3)
+src/routing/                  ← model routing hints (v0.7)
 src/security/                 ← secret scanner (v0.2)
-src/config/                   ← config loader + defaults
+src/tracking/logger.js        ← NDJSON usage log (v0.9)
 test/fixtures/                ← one fixture per language
 test/expected/                ← expected extractor output
 test/run.js                   ← zero-dep test runner
+docs/ARCHITECTURE.md          ← internal design, data flow, module map
 docs/CONTEXT_STRATEGIES.md    ← full/per-module/hot-cold strategy guide (v1.1)
 docs/ENTERPRISE_SETUP.md      ← enterprise & CI observability guide (v0.9)
+docs/MCP_SETUP.md             ← MCP server setup for Claude Code, Cursor, Windsurf
 docs/REPOMIX_CACHE.md         ← prompt cache strategy guide (v0.8)
 docs/MODEL_ROUTING.md         ← model routing guide (v0.7)
+docs/SESSION_DISCIPLINE.md    ← session lifecycle and token hygiene guide
+docs/CI_GUIDE.md              ← CI/CD integration and monorepo setup
 examples/self-healing-github-action.yml  ← auto-regeneration CI workflow (v1.0)
 scripts/ci-update.sh          ← CI helper for pipelines (v1.0)
 .contextignore.example        ← exclusion template
 gen-context.config.json.example ← annotated config reference
 ```
+
+---
+
+## Docs
+
+| Guide | Description |
+|---|---|
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Internal design, data flow, module map, bundle system |
+| [CONTEXT_STRATEGIES.md](docs/CONTEXT_STRATEGIES.md) | full / per-module / hot-cold strategy guide |
+| [MCP_SETUP.md](docs/MCP_SETUP.md) | MCP server for Claude Code, Cursor, Windsurf |
+| [MODEL_ROUTING.md](docs/MODEL_ROUTING.md) | Model tier routing and `--suggest-tool` |
+| [SESSION_DISCIPLINE.md](docs/SESSION_DISCIPLINE.md) | Session lifecycle and token hygiene |
+| [CI_GUIDE.md](docs/CI_GUIDE.md) | GitHub Actions, monorepo, health gates |
+| [ENTERPRISE_SETUP.md](docs/ENTERPRISE_SETUP.md) | Observability, Prometheus/Grafana, self-healing CI |
+| [REPOMIX_CACHE.md](docs/REPOMIX_CACHE.md) | Prompt caching with Anthropic API |
+| [REPOMIX_INTEGRATION.md](docs/REPOMIX_INTEGRATION.md) | Using ContextForge + Repomix together |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,385 @@
+# ContextForge — Architecture
+
+This document explains how ContextForge is structured internally: how modules
+connect, how data flows from source files to the final context output, and how
+the zero-dependency bundle is assembled.
+
+---
+
+## High-level overview
+
+```
+Source files (your project)
+        │
+        ▼
+  ┌─────────────┐
+  │  config/    │  Load + merge gen-context.config.json with defaults
+  └──────┬──────┘
+         │
+         ▼
+  ┌─────────────┐
+  │ extractors/ │  21 language extractors — signatures only, no bodies
+  └──────┬──────┘
+         │
+         ▼
+  ┌─────────────┐
+  │  security/  │  Secret scanner — redact API keys, credentials
+  └──────┬──────┘
+         │
+         ▼
+  ┌─────────────┐
+  │  routing/   │  File complexity classifier — fast / balanced / powerful
+  └──────┬──────┘
+         │
+         ▼
+  ┌─────────────┐
+  │ Token budget│  Drop lowest-priority files until output ≤ maxTokens
+  └──────┬──────┘
+         │
+         ▼
+  ┌──────────────────────────────────────┐
+  │  Output writers                      │
+  │  .github/copilot-instructions.md     │  (strategy: full / per-module / hot-cold)
+  │  .github/context-<module>.md         │
+  │  .github/context-cold.md             │
+  │  .github/copilot-instructions.cache.json  (format: cache)
+  └──────────────────────────────────────┘
+         │
+         ├──▶  tracking/logger.js   .context/usage.ndjson
+         └──▶  health/scorer.js     composite 0-100 score
+```
+
+The MCP server (`src/mcp/`) is a separate runtime path — it does not participate
+in the generation pipeline. It reads the files written by the pipeline on demand.
+
+---
+
+## Module map
+
+```
+src/
+├── config/
+│   ├── defaults.js     All default config keys with documentation comments
+│   └── loader.js       Reads gen-context.config.json, merges with DEFAULTS,
+│                       validates unknown keys
+│
+├── extractors/         21 language extractors (one per language/format)
+│   ├── javascript.js
+│   ├── typescript.js
+│   ├── python.js
+│   ├── java.js
+│   ├── go.js
+│   ├── rust.js
+│   ├── cpp.js
+│   ├── csharp.js
+│   ├── kotlin.js
+│   ├── swift.js
+│   ├── dart.js
+│   ├── scala.js
+│   ├── ruby.js
+│   ├── php.js
+│   ├── shell.js
+│   ├── dockerfile.js
+│   ├── html.js
+│   ├── css.js
+│   ├── yaml.js
+│   ├── svelte.js
+│   └── vue.js
+│
+├── format/
+│   └── cache.js        Wraps the markdown context in an Anthropic
+│                       prompt-cache JSON block (format: 'cache')
+│
+├── health/
+│   └── scorer.js       Reads usage.ndjson + context file mtime,
+│                       returns { score, grade, ... }
+│
+├── map/
+│   ├── import-graph.js Parses import/require statements to build a
+│   │                   dependency graph (used by gen-project-map.js)
+│   ├── class-hierarchy.js  Parses class extends chains across files
+│   └── route-table.js  Detects Express/Hono/FastAPI route handlers
+│
+├── mcp/
+│   ├── server.js       JSON-RPC 2.0 stdio server; reads stdin line-by-line,
+│   │                   dispatches to handlers.js, writes responses to stdout
+│   ├── handlers.js     Implements each MCP tool: read_context, search_signatures,
+│   │                   get_map, create_checkpoint, get_routing
+│   └── tools.js        Tool definitions (name, description, inputSchema)
+│
+├── routing/
+│   ├── classifier.js   Assigns a complexity tier to each file:
+│   │                   fast | balanced | powerful
+│   └── hints.js        Model recommendation data per tier and task keyword
+│
+├── security/
+│   ├── scanner.js      Runs pattern list against each signature; redacts matches
+│   └── patterns.js     Regex patterns for API keys, AWS credentials, SSH keys,
+│                       connection strings, passwords, etc.
+│
+└── tracking/
+    └── logger.js       Appends one NDJSON line per run to .context/usage.ndjson:
+                        { timestamp, rawTokens, finalTokens, reductionPct, ... }
+```
+
+---
+
+## Data flow — generation pipeline
+
+### Step 1 — Config
+
+`src/config/loader.js` reads `gen-context.config.json` (if it exists) and
+merges it over `DEFAULTS` from `defaults.js`. All pipeline steps receive this
+merged config object.
+
+### Step 2 — File discovery
+
+`gen-context.js` walks the directories listed in `config.srcDirs`, respecting:
+- `config.exclude` (always-excluded directories)
+- `.contextignore` patterns (gitignore syntax)
+- `.repomixignore` patterns (merged automatically if present)
+- `config.maxDepth` recursion limit
+
+Only files with a recognised extension are kept.
+
+### Step 3 — Git priority sort
+
+When `config.diffPriority: true`, recently committed files are moved to the
+front of the file list. The sort uses `git log --name-only` output. Files that
+don't appear in git history are sorted last. This ensures fresh changes are
+always prominent and are the last to be dropped by the token budget.
+
+### Step 4 — Extraction
+
+Each file is dispatched to the matching extractor by extension. The extractor
+contract is:
+
+```javascript
+function extract(src) → string[]
+// Returns an array of signature strings (functions, classes, methods).
+// Never throws. Returns [] on any error or empty input.
+// Maximum 25 signatures per file.
+// No bodies — nothing after the opening {.
+// No comments, no imports.
+```
+
+Signatures are grouped under a `### path/to/file.ext` heading.
+
+### Step 5 — Secret scanning
+
+When `config.secretScan: true`, `src/security/scanner.js` runs every signature
+string through the regex patterns in `patterns.js`. Any match is replaced with
+`[REDACTED]`.
+
+### Step 6 — Token budget enforcement
+
+Tokens are estimated as `Math.ceil(chars / 4)` (standard ~4 chars/token
+approximation).
+
+If the total exceeds `config.maxTokens`, files are dropped from the **end** of
+the sorted list (lowest git-priority first) until the budget is met. Files with
+the most recent commits are never dropped first.
+
+### Step 7 — Strategy output
+
+Depending on `config.strategy`:
+
+| Strategy | Output files | Always-injected tokens |
+|---|---|---|
+| `full` (default) | `.github/copilot-instructions.md` | ~4,000 (all sigs) |
+| `per-module` | One `context-<module>.md` per srcDir + overview table | ~100–300 |
+| `hot-cold` | `.github/copilot-instructions.md` (hot) + `context-cold.md` (cold) | ~200–800 |
+
+For `hot-cold`, files appear in the hot set if they were touched in the last
+`config.hotCommits` commits (default 10). Everything else goes to cold.
+
+### Step 8 — Format sidecar
+
+When `config.format: 'cache'`, `src/format/cache.js` writes a second file
+alongside the markdown — `.github/copilot-instructions.cache.json` — containing
+the same content wrapped in an Anthropic prompt-cache block:
+
+```json
+{
+  "type": "text",
+  "text": "... signatures ...",
+  "cache_control": { "type": "ephemeral" }
+}
+```
+
+### Step 9 — Tracking
+
+When `config.tracking: true` (or `--track` flag), `src/tracking/logger.js`
+appends a single NDJSON line to `.context/usage.ndjson`:
+
+```json
+{"timestamp":"...","rawTokens":42000,"finalTokens":2800,"reductionPct":93.3,"fileCount":120,"droppedCount":8,"overBudget":false}
+```
+
+---
+
+## Data flow — MCP server
+
+The MCP server is a separate runtime started with `node gen-context.js --mcp`.
+It does not run the generation pipeline. It reads the files already written to
+disk.
+
+```
+AI tool (Claude Code / Cursor)
+        │  JSON-RPC 2.0 over stdio
+        ▼
+  src/mcp/server.js
+        │  dispatches by method name
+        ▼
+  src/mcp/handlers.js
+        │
+        ├── read_context      reads .github/copilot-instructions.md
+        │                     (optionally filters to a module path)
+        ├── search_signatures reads same file, does case-insensitive match
+        ├── get_map           reads PROJECT_MAP.md (requires gen-project-map.js)
+        ├── create_checkpoint reads git log + context file; returns snapshot
+        └── get_routing       reads routing hints from src/routing/hints.js
+```
+
+**No in-memory state.** Every tool call reads fresh files from disk, so the
+server always serves the latest generated context without restart.
+
+---
+
+## Data flow — gen-project-map.js
+
+`gen-project-map.js` is a separate script (not bundled into the main entry).
+It uses the `src/map/` modules to write `PROJECT_MAP.md` with three sections:
+
+1. **Import graph** (`src/map/import-graph.js`) — which files import which
+2. **Class hierarchy** (`src/map/class-hierarchy.js`) — inheritance chains
+3. **Route table** (`src/map/route-table.js`) — HTTP endpoints and handlers
+
+Run it once to generate `PROJECT_MAP.md`, then the `get_map` MCP tool can serve
+its sections on demand.
+
+---
+
+## Bundle architecture
+
+The repository ships both a **source tree** (`src/`) and a **pre-built
+standalone bundle** (`gen-context.js`).
+
+```
+src/          ← modular source files (edit these)
+     │
+     └──▶  scripts/bundle.js  ──▶  gen-context.js  (the standalone bundle)
+```
+
+`scripts/bundle.js` does the following:
+
+1. Collects all `.js` files under `src/` and assigns each a canonical key
+   (e.g. `./src/config/loader`).
+2. Rewrites every `require('./...')` call inside those files to
+   `__require('./src/...')`.
+3. Wraps each module in a factory function registered in `__factories`.
+4. Prepends a tiny module loader (`__require`) that evaluates factories on first
+   call and caches exports.
+5. Appends the main `gen-context.js` entry with its own requires patched to
+   the same `__require` calls.
+
+The result is a **single file with zero external dependencies** — copy
+`gen-context.js` to any machine with Node.js 18+ and it works immediately.
+
+**Important:** Edit files in `src/`, not in `gen-context.js` directly.
+After editing, run `node scripts/bundle.js` to regenerate the standalone file.
+
+---
+
+## Health scoring
+
+`src/health/scorer.js` produces a composite 0–100 score from three signals:
+
+| Signal | Penalty |
+|---|---|
+| Days since last regeneration > 7 | −4 pts per extra day |
+| Average token reduction < 60% | −20 pts |
+| Over-budget run rate > 20% | −20 pts |
+
+Grades: A (≥90), B (≥75), C (≥60), D (<60).
+
+The scorer reads `.context/usage.ndjson` for run history and the mtime of
+`.github/copilot-instructions.md` for staleness.
+
+---
+
+## Model routing classifier
+
+`src/routing/classifier.js` assigns each file a complexity tier:
+
+| Rule | Tier |
+|---|---|
+| Extension is config/markup/script (`.json`, `.yml`, `.html`, `.sh`, ...) | `fast` |
+| Path contains `auth`, `crypto`, `security`, `core`, `payment` | `powerful` |
+| File has ≥ 12 exported signatures | `powerful` |
+| File has ≥ 8 class methods | `powerful` |
+| Everything else | `balanced` |
+
+`src/routing/hints.js` maps task keywords to tier recommendations, which
+`--suggest-tool` uses at the CLI and `get_routing` exposes via MCP.
+
+---
+
+## Output targets
+
+The `outputs` config key controls which files are written. Each target writes
+to a conventional path that the corresponding AI tool reads automatically:
+
+| Target | Output path | Read by |
+|---|---|---|
+| `copilot` (default) | `.github/copilot-instructions.md` | GitHub Copilot in VS Code |
+| `claude` | `CLAUDE.md` | Claude Code (project root) |
+| `cursor` | `.cursor/rules` | Cursor IDE |
+| `windsurf` | `.windsurf/rules` | Windsurf IDE |
+
+Configure multiple targets at once:
+
+```json
+{ "outputs": ["copilot", "claude", "cursor"] }
+```
+
+---
+
+## Testing infrastructure
+
+```
+test/
+├── run.js                Zero-dependency test runner (no Jest, no Mocha)
+├── fixtures/             One representative source file per language
+├── expected/             Expected extractor output per language
+│                         (regenerate with: node test/run.js --update)
+└── integration/          13 integration test suites, 156 tests total
+    ├── config-loader.test.js
+    ├── system.test.js        --suggest-tool, --health
+    ├── cache.test.js         Anthropic cache JSON format
+    ├── contextignore.test.js .contextignore + .repomixignore patterns
+    ├── mcp-server.test.js    JSON-RPC protocol, tool dispatch, error handling
+    ├── monorepo.test.js      Per-package detection and output
+    ├── multi-output.test.js  Multiple output targets
+    ├── observability.test.js Tracking, NDJSON log, --report --history
+    ├── project-map.test.js   Import graph, class hierarchy, route table
+    ├── routing.test.js       Classifier, tier assignment, model hints
+    ├── secret-scan.test.js   Pattern detection and redaction
+    └── token-budget.test.js  Budget enforcement and file dropping
+```
+
+**Run all tests:** `node test/run.js` → must be 177/177 PASS before any PR.
+
+---
+
+## Key invariants
+
+- **Never throw.** Every extractor catches all errors and returns `[]`. The
+  pipeline catches per-file failures and skips the file silently.
+- **Zero npm dependencies.** The bundle uses only Node.js built-ins:
+  `fs`, `path`, `os`, `crypto`, `child_process`, `readline`, `assert`.
+- **No network calls.** ContextForge never phones home.
+- **Deterministic output.** Given the same source files and config, the output
+  is identical across runs (git priority sort aside).
+- **Edit `src/`, not `gen-context.js`.** The bundle is generated; the source
+  is authoritative.

--- a/docs/MCP_SETUP.md
+++ b/docs/MCP_SETUP.md
@@ -66,6 +66,21 @@ Add to `.cursor/mcp.json` in your project root:
 }
 ```
 
+### Windsurf
+
+Add to `.windsurf/mcp_config.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "context-forge": {
+      "command": "node",
+      "args": ["/absolute/path/to/your/project/gen-context.js", "--mcp"]
+    }
+  }
+}
+```
+
 ### Both servers (ContextForge + Repomix)
 
 See [examples/claude-code-settings.json](../examples/claude-code-settings.json) for a ready-to-use config with both servers configured.
@@ -129,6 +144,42 @@ get_map(type="routes")
 ```
 
 **Returns:** The import graph, class hierarchy, or route table section from `PROJECT_MAP.md`. Returns a helpful error message if the file doesn't exist yet.
+
+---
+
+### `create_checkpoint`
+
+Creates a session snapshot for handoffs or periodic saves during long coding sessions.
+
+| Argument | Type | Required | Description |
+|---|---|---|---|
+| `note` | string | No | Free-text note about what you were working on |
+
+**Example:**
+
+```
+create_checkpoint(note="finished auth middleware, starting token refresh")
+```
+
+**Returns:** Recent git commits, active branch, token count, modules indexed, and a compact snapshot of current context. Copy the output into your session notes, PR description, or a `NOTES.md` in the repo root.
+
+---
+
+### `get_routing`
+
+Returns model routing hints for the project — which files belong to which complexity tier and which AI model to use for each task type.
+
+| Argument | Type | Required | Description |
+|---|---|---|---|
+| _(none)_ | — | — | — |
+
+**Example:**
+
+```
+get_routing()
+```
+
+**Returns:** Per-file tier assignments (`fast` / `balanced` / `powerful`) and model recommendations. Use this to route simple tasks to cheaper models and reduce API costs by 40–80%.
 
 ---
 

--- a/docs/SESSION_DISCIPLINE.md
+++ b/docs/SESSION_DISCIPLINE.md
@@ -26,7 +26,7 @@ Session discipline solves the rest.
 **Before writing any code:**
 
 ```
-1. Run: node gen-context.js --generate     (or the watcher is running)
+1. Run: node gen-context.js     (or the watcher is running)
 2. In Copilot Chat: type cf-start → Tab
 3. Specify your task for the session
 4. Wait for the assistant to confirm it has loaded context
@@ -151,7 +151,7 @@ ContextForge can regenerate context automatically on every commit:
 
 ```bash
 node gen-context.js --setup
-# Installs: .git/hooks/post-commit → runs gen-context.js --generate
+# Installs: .git/hooks/post-commit → runs gen-context.js on every commit
 ```
 
 With the hook in place, the context file is always in sync with HEAD. Context drift between commits becomes impossible.
@@ -160,7 +160,7 @@ With the hook in place, the context file is always in sync with HEAD. Context dr
 
 ```bash
 cat .git/hooks/post-commit
-# Should contain: node /path/to/gen-context.js --generate
+# Should contain: node /path/to/gen-context.js
 ```
 
 ---


### PR DESCRIPTION
## Changes

### New documentation
- **docs/ARCHITECTURE.md** — comprehensive internal design guide covering:
  - High-level pipeline flow diagram
  - Complete module map with file descriptions
  - Data flow through generation pipeline (9 steps)
  - MCP server architecture and tool dispatch
  - Bundle system design and regeneration workflow
  - Health scoring and model routing classifiers
  - Testing infrastructure overview
  - Key invariants and guarantees

- **docs/MCP_SETUP.md** — expanded with:
  - Windsurf IDE configuration
  - `create_checkpoint` tool documentation
  - `get_routing` tool documentation

### Updated documentation
- **CONTRIBUTING.md** — added:
  - Integration test guidelines (5 steps)
  - Bundling workflow and `scripts/bundle.js` explanation

- **README.md** — enhanced with:
  - Output targets table (copilot, claude, cursor, windsurf)
  - Updated project structure with new docs and bundle notes
  - New Docs section with table of all guides

- **docs/SESSION_DISCIPLINE.md** — corrected:
  - Removed `--generate` flag (no longer needed)
  - Updated hook description to match actual behavior

## Impact

Provides developers and contributors with clear guidance on:
- How ContextForge's internals work
- How to extend or modify the codebase
- How to set up MCP servers across all supported IDEs
- Complete documentation index for quick reference