### PR TITLE
feat: v2.2.0 Diagnostics Analyze Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [2.2.0] — 2026-04-06
+
+### Added
+- **Diagnostics & analyze command** — `src/eval/analyzer.js`: per-file breakdown of signature count, token cost, extractor used, and test coverage status.
+- **`--analyze` CLI flag** — prints a per-file table (File | Extractor | Sigs | Tokens | Covered) across all srcDirs; respects `exclude` config.
+- **`--analyze --json` flag** — outputs the same breakdown as structured JSON (`{ files, totalSigs, totalTokens, slowFiles, fileCount }`).
+- **`--analyze --slow` flag** — re-times each extractor and flags any file whose extraction takes >50ms in the table.
+- **`--diagnose-extractors` CLI flag** — runs all 21 language extractors against `test/fixtures/` and compares output to `test/expected/`; exits non-zero if any extractor diverges, shows first diff line per failure.
+- **`test/integration/analyze.test.js`** — 14 integration tests covering `analyzeFiles`, `formatAnalysisTable`, `formatAnalysisJSON`, and all four CLI flags.
+
+### Validation gate
+- 21/21 extractor tests passed
+- All integration suites passed (19 suites, 19 passed, 0 failed — includes 14 new analyze tests)
+- `node gen-context.js --version` → `2.2.0`
+- `node gen-context.js --analyze` runs without error on SigMap repo
+- `node gen-context.js --analyze --json` → valid JSON with required keys
+- `node gen-context.js --diagnose-extractors` → exits 0 on SigMap repo
+
+---
+
 ## [2.1.0] — 2026-04-05
 
 ### Added

--- a/gen-context.js
+++ b/gen-context.js
@@ -3630,6 +3630,143 @@ __factories["./src/eval/scorer"] = function(module, exports) {
   module.exports = { hitAtK, reciprocalRank, precisionAtK, aggregate, firstRank };
 };
 
+// ── ./src/eval/analyzer ──
+__factories["./src/eval/analyzer"] = function(module, exports) {
+  'use strict';
+
+  const fs   = require('fs');
+  const path = require('path');
+
+  const EXT_MAP = {
+    '.ts': 'typescript', '.tsx': 'typescript',
+    '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
+    '.py': 'python',     '.pyw': 'python',
+    '.java': 'java',
+    '.kt': 'kotlin',     '.kts': 'kotlin',
+    '.go': 'go',
+    '.rs': 'rust',
+    '.cs': 'csharp',
+    '.cpp': 'cpp', '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.cc': 'cpp',
+    '.rb': 'ruby',       '.rake': 'ruby',
+    '.php': 'php',
+    '.swift': 'swift',
+    '.dart': 'dart',
+    '.scala': 'scala',   '.sc': 'scala',
+    '.vue': 'vue',
+    '.svelte': 'svelte',
+    '.html': 'html',     '.htm': 'html',
+    '.css': 'css',       '.scss': 'css', '.sass': 'css', '.less': 'css',
+    '.yml': 'yaml',      '.yaml': 'yaml',
+    '.sh': 'shell',      '.bash': 'shell', '.zsh': 'shell', '.fish': 'shell',
+  };
+
+  function isDockerfile(name) { return name === 'Dockerfile' || name.startsWith('Dockerfile.'); }
+
+  function getExtractorName(filePath) {
+    const base = path.basename(filePath);
+    const ext  = path.extname(base).toLowerCase();
+    if (EXT_MAP[ext]) return EXT_MAP[ext];
+    if (isDockerfile(base)) return 'dockerfile';
+    return null;
+  }
+
+  function tokenCount(sigs) {
+    return Math.ceil(sigs.reduce((sum, s) => sum + s.length, 0) / 4);
+  }
+
+  function hasCoverage(filePath, cwd) {
+    const base = path.basename(filePath, path.extname(filePath));
+    const testDirs = ['test', 'tests', '__tests__', 'spec'];
+    for (const d of testDirs) {
+      const abs = path.join(cwd, d);
+      if (!fs.existsSync(abs)) continue;
+      let entries;
+      try { entries = fs.readdirSync(abs, { withFileTypes: true }); } catch (_) { continue; }
+      for (const e of entries) { if (e.name.includes(base)) return true; }
+    }
+    return false;
+  }
+
+  function analyzeFiles(files, cwd, opts) {
+    const slow    = (opts && opts.slow)    || false;
+    const slowMs  = (opts && opts.slowMs)  || 50;
+    const maxSigs = (opts && opts.maxSigs) || 25;
+    const stats   = [];
+    const cache   = {};
+
+    for (const filePath of files) {
+      const extractorName = getExtractorName(filePath);
+      if (!extractorName) continue;
+      if (!cache[extractorName]) {
+        try { cache[extractorName] = __require(`./src/extractors/${extractorName}`); } catch (_) { cache[extractorName] = null; }
+      }
+      const extractor = cache[extractorName];
+      if (!extractor || typeof extractor.extract !== 'function') continue;
+
+      let content;
+      try { content = fs.readFileSync(filePath, 'utf8'); } catch (_) { continue; }
+
+      let sigs; let elapsedMs = 0;
+      if (slow) {
+        const t0 = Date.now();
+        try { sigs = extractor.extract(content); } catch (_) { sigs = []; }
+        elapsedMs = Date.now() - t0;
+      } else {
+        try { sigs = extractor.extract(content); } catch (_) { sigs = []; }
+      }
+      sigs = (Array.isArray(sigs) ? sigs : []).slice(0, maxSigs);
+
+      stats.push({
+        file:      path.relative(cwd, filePath),
+        extractor: extractorName,
+        sigs:      sigs.length,
+        tokens:    tokenCount(sigs),
+        covered:   hasCoverage(filePath, cwd),
+        elapsedMs: slow ? elapsedMs : undefined,
+        slow:      slow ? (elapsedMs > slowMs) : undefined,
+      });
+    }
+    return stats;
+  }
+
+  function formatAnalysisTable(stats, showSlow) {
+    if (!stats || stats.length === 0) return '_(no files analyzed)_\n';
+    const maxFile = Math.max(4, ...stats.map((s) => s.file.length));
+    const header  = showSlow
+      ? `| ${'File'.padEnd(maxFile)} | Sigs | Tokens | Extractor   | Coverage   | Elapsed  |`
+      : `| ${'File'.padEnd(maxFile)} | Sigs | Tokens | Extractor   | Coverage   |`;
+    const sep = showSlow
+      ? `|${'-'.repeat(maxFile + 2)}|------|--------|-------------|------------|----------|`
+      : `|${'-'.repeat(maxFile + 2)}|------|--------|-------------|------------|`;
+    const rows = stats.map((s) => {
+      const cov  = s.covered ? '✓ tested  ' : '✗ untested';
+      const file = s.file.padEnd(maxFile);
+      const ext  = (s.extractor || '').padEnd(11);
+      const base = `| ${file} | ${String(s.sigs).padStart(4)} | ${String(s.tokens).padStart(6)} | ${ext} | ${cov} |`;
+      if (showSlow) {
+        const ms   = s.elapsedMs !== undefined ? `${s.elapsedMs}ms` : '';
+        return `${base} ${ms.padStart(6)}${s.slow ? ' ⚠️' : ''} |`;
+      }
+      return base;
+    });
+    const totalSigs   = stats.reduce((n, s) => n + s.sigs,   0);
+    const totalTokens = stats.reduce((n, s) => n + s.tokens, 0);
+    const slotFile    = ''.padEnd(maxFile);
+    const baseFoot    = `| ${slotFile} | ${String(totalSigs).padStart(4)} | ${String(totalTokens).padStart(6)} | **Total**   |            |`;
+    const footer      = showSlow ? `${baseFoot} ${' '.padStart(8)} |` : baseFoot;
+    return [header, sep, ...rows, sep, footer].join('\n') + '\n';
+  }
+
+  function formatAnalysisJSON(stats) {
+    const totalSigs   = stats.reduce((n, s) => n + s.sigs,   0);
+    const totalTokens = stats.reduce((n, s) => n + s.tokens, 0);
+    const slowFiles   = stats.filter((s) => s.slow).map((s) => ({ file: s.file, elapsedMs: s.elapsedMs }));
+    return { files: stats, totalSigs, totalTokens, slowFiles, fileCount: stats.length };
+  }
+
+  module.exports = { analyzeFiles, formatAnalysisTable, formatAnalysisJSON };
+};
+
 // ── ./src/eval/runner ──
 __factories["./src/eval/runner"] = function(module, exports) {
   'use strict';
@@ -3799,7 +3936,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '2.1.0';
+const VERSION = '2.2.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {
@@ -5008,6 +5145,10 @@ Usage:
   node gen-context.js --benchmark                       Run retrieval benchmark (benchmarks/tasks/retrieval.jsonl)
   node gen-context.js --benchmark --json                Benchmark results as JSON
   node gen-context.js --eval                            Alias for --benchmark
+  node gen-context.js --analyze                         Per-file breakdown: sigs, tokens, extractor, coverage
+  node gen-context.js --analyze --json                  Breakdown as JSON
+  node gen-context.js --analyze --slow                  Re-time each extractor; flag files >50ms
+  node gen-context.js --diagnose-extractors             Run all 21 extractors vs fixtures; show pass/fail + diff
   node gen-context.js --init                            Write example config + .contextignore scaffold
   node gen-context.js --help                            Show this message
   node gen-context.js --version                         Show version
@@ -5167,6 +5308,131 @@ function main() {
       process.exit(1);
     }
     process.exit(0);
+  }
+
+  if (args.includes('--analyze')) {
+    try {
+      const { analyzeFiles, formatAnalysisTable, formatAnalysisJSON } = requireSourceOrBundled('./src/eval/analyzer');
+      const cfg    = config || {};
+      const srcDirs = cfg.srcDirs || DEFAULTS.srcDirs;
+      const exclude = cfg.exclude || DEFAULTS.exclude;
+      const slow    = args.includes('--slow');
+
+      // Collect files (reuse existing file-walker if accessible, else inline)
+      const allFiles = [];
+      function walkForAnalyze(dir, depth) {
+        if (depth > (cfg.maxDepth || 6)) return;
+        let entries;
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+        for (const e of entries) {
+          if (exclude.some((x) => e.name === x || e.name.startsWith(x))) continue;
+          const full = path.join(dir, e.name);
+          if (e.isDirectory()) walkForAnalyze(full, depth + 1);
+          else if (e.isFile()) allFiles.push(full);
+        }
+      }
+      for (const sd of srcDirs) {
+        const abs = path.join(cwd, sd);
+        if (fs.existsSync(abs)) walkForAnalyze(abs, 0);
+      }
+
+      const stats = analyzeFiles(allFiles, cwd, { slow, maxSigs: cfg.maxSigsPerFile || 25 });
+
+      if (args.includes('--json')) {
+        process.stdout.write(JSON.stringify(formatAnalysisJSON(stats)) + '\n');
+      } else {
+        const table = formatAnalysisTable(stats, slow);
+        process.stdout.write(table);
+      }
+    } catch (err) {
+      console.error(`[sigmap] analyze error: ${err.message}`);
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
+  if (args.includes('--diagnose-extractors')) {
+    try {
+      const fixturesDir = path.join(cwd, 'test', 'fixtures');
+      const expectedDir = path.join(cwd, 'test', 'expected');
+      if (!fs.existsSync(fixturesDir) || !fs.existsSync(expectedDir)) {
+        console.error('[sigmap] test/fixtures or test/expected not found — run from the SigMap repo root');
+        process.exit(1);
+      }
+
+      const EXT_TO_LANG = {
+        '.ts': 'typescript', '.js': 'javascript', '.py': 'python',
+        '.java': 'java', '.kt': 'kotlin', '.go': 'go', '.rs': 'rust',
+        '.cs': 'csharp', '.cpp': 'cpp', '.rb': 'ruby', '.php': 'php',
+        '.swift': 'swift', '.dart': 'dart', '.scala': 'scala',
+        '.vue': 'vue', '.svelte': 'svelte', '.html': 'html',
+        '.css': 'css', '.yml': 'yaml', '.sh': 'shell',
+      };
+      const SPECIAL = { 'Dockerfile': 'dockerfile' };
+
+      let passed = 0; let failed = 0;
+      const entries = fs.readdirSync(fixturesDir).sort();
+
+      for (const filename of entries) {
+        const ext  = path.extname(filename).toLowerCase();
+        const lang = EXT_TO_LANG[ext] || SPECIAL[filename];
+        if (!lang) continue;
+
+        const fixturePath = path.join(fixturesDir, filename);
+        const expectedPath = path.join(expectedDir, `${lang}.txt`);
+        if (!fs.existsSync(expectedPath)) {
+          console.log(`  SKIP  ${lang.padEnd(12)} (no expected file)`);
+          continue;
+        }
+
+        const src      = fs.readFileSync(fixturePath, 'utf8');
+        const expected = fs.readFileSync(expectedPath, 'utf8').trim();
+
+        let mod;
+        try {
+          mod = requireSourceOrBundled(`./src/extractors/${lang}`);
+        } catch (e) {
+          console.log(`  ERROR ${lang.padEnd(12)} loader failed: ${e.message}`);
+          failed++;
+          continue;
+        }
+
+        let actual;
+        try {
+          const sigs = mod.extract(src);
+          actual = sigs.join('\n').trim();
+        } catch (e) {
+          console.log(`  ERROR ${lang.padEnd(12)} extract() threw: ${e.message}`);
+          failed++;
+          continue;
+        }
+
+        if (actual === expected) {
+          console.log(`  PASS  ${lang}`);
+          passed++;
+        } else {
+          console.log(`  FAIL  ${lang}`);
+          // Show first diff line
+          const aLines = actual.split('\n');
+          const eLines = expected.split('\n');
+          const maxLen = Math.max(aLines.length, eLines.length);
+          for (let i = 0; i < maxLen; i++) {
+            if (aLines[i] !== eLines[i]) {
+              console.log(`         expected: ${(eLines[i] || '(missing)').slice(0, 100)}`);
+              console.log(`         actual  : ${(aLines[i] || '(missing)').slice(0, 100)}`);
+              break;
+            }
+          }
+          failed++;
+        }
+      }
+
+      console.log(`\n${passed} passed, ${failed} failed`);
+      process.exit(failed > 0 ? 1 : 0);
+    } catch (err) {
+      console.error(`[sigmap] diagnose error: ${err.message}`);
+      process.exit(1);
+    }
   }
 
   if (args.includes('--report')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "bin": {

--- a/src/eval/analyzer.js
+++ b/src/eval/analyzer.js
@@ -1,0 +1,221 @@
+'use strict';
+
+/**
+ * SigMap file analyzer — per-file diagnostic statistics.
+ * Zero npm dependencies.
+ *
+ * Exports:
+ *   analyzeFiles(files, cwd, opts) → stats[]
+ *   formatAnalysisTable(stats)    → markdown table string
+ *   formatAnalysisJSON(stats)     → plain object suitable for JSON.stringify
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// Extension → extractor name (mirrors EXT_MAP in gen-context.js)
+const EXT_MAP = {
+  '.ts': 'typescript', '.tsx': 'typescript',
+  '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
+  '.py': 'python',     '.pyw': 'python',
+  '.java': 'java',
+  '.kt': 'kotlin',     '.kts': 'kotlin',
+  '.go': 'go',
+  '.rs': 'rust',
+  '.cs': 'csharp',
+  '.cpp': 'cpp', '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.cc': 'cpp',
+  '.rb': 'ruby',       '.rake': 'ruby',
+  '.php': 'php',
+  '.swift': 'swift',
+  '.dart': 'dart',
+  '.scala': 'scala',   '.sc': 'scala',
+  '.vue': 'vue',
+  '.svelte': 'svelte',
+  '.html': 'html',     '.htm': 'html',
+  '.css': 'css',       '.scss': 'css', '.sass': 'css', '.less': 'css',
+  '.yml': 'yaml',      '.yaml': 'yaml',
+  '.sh': 'shell',      '.bash': 'shell', '.zsh': 'shell', '.fish': 'shell',
+};
+
+function isDockerfile(name) {
+  return name === 'Dockerfile' || name.startsWith('Dockerfile.');
+}
+
+function getExtractorName(filePath) {
+  const base = path.basename(filePath);
+  const ext  = path.extname(base).toLowerCase();
+  if (EXT_MAP[ext]) return EXT_MAP[ext];
+  if (isDockerfile(base)) return 'dockerfile';
+  return null;
+}
+
+/** Rough token estimate: chars / 4 */
+function tokenCount(sigs) {
+  return Math.ceil(sigs.reduce((sum, s) => sum + s.length, 0) / 4);
+}
+
+/**
+ * Check whether a test file exists for this source file by looking for
+ * *.test.* / *.spec.* patterns in the test/ directory tree.
+ */
+function hasCoverage(filePath, cwd) {
+  const rel   = path.relative(cwd, filePath);
+  const base  = path.basename(rel, path.extname(rel));  // e.g. "python"
+  const testDirs = ['test', 'tests', '__tests__', 'spec'];
+  for (const d of testDirs) {
+    const abs = path.join(cwd, d);
+    if (!fs.existsSync(abs)) continue;
+    // Walk only one depth for speed
+    let entries;
+    try { entries = fs.readdirSync(abs, { withFileTypes: true }); } catch (_) { continue; }
+    for (const e of entries) {
+      if (e.name.includes(base)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Load an extractor module from src/extractors/ relative to cwd.
+ * Falls back to requiring from the module directory itself.
+ */
+function loadExtractor(name, cwd) {
+  // Try repo-local src/extractors first (for projects that embed sigmap)
+  const local = path.join(cwd, 'src', 'extractors', `${name}.js`);
+  if (fs.existsSync(local)) {
+    try { return require(local); } catch (_) {}
+  }
+  // Then standard node resolution from the current package
+  try { return require(path.join(__dirname, '..', 'extractors', `${name}.js`)); } catch (_) {}
+  return null;
+}
+
+/**
+ * Analyze a list of absolute file paths.
+ *
+ * @param {string[]} files   - absolute paths to analyze
+ * @param {string}   cwd     - project root
+ * @param {object}  [opts]
+ * @param {boolean} [opts.slow=false]  - if true, measure extraction time per file
+ * @param {number}  [opts.slowMs=50]   - threshold (ms) before a file is "slow"
+ * @param {number}  [opts.maxSigs=25]  - max sigs per file
+ * @returns {object[]} array of per-file stat objects
+ */
+function analyzeFiles(files, cwd, opts) {
+  const slow    = (opts && opts.slow)   || false;
+  const slowMs  = (opts && opts.slowMs) || 50;
+  const maxSigs = (opts && opts.maxSigs) || 25;
+
+  const stats = [];
+  const extractorCache = {};
+
+  for (const filePath of files) {
+    const extractorName = getExtractorName(filePath);
+    if (!extractorName) continue;
+
+    // Load extractor (cached)
+    if (!extractorCache[extractorName]) {
+      extractorCache[extractorName] = loadExtractor(extractorName, cwd);
+    }
+    const extractor = extractorCache[extractorName];
+    if (!extractor || typeof extractor.extract !== 'function') continue;
+
+    let content;
+    try { content = fs.readFileSync(filePath, 'utf8'); } catch (_) { continue; }
+
+    let sigs;
+    let elapsedMs = 0;
+
+    if (slow) {
+      const t0 = Date.now();
+      try { sigs = extractor.extract(content); } catch (_) { sigs = []; }
+      elapsedMs = Date.now() - t0;
+    } else {
+      try { sigs = extractor.extract(content); } catch (_) { sigs = []; }
+    }
+
+    sigs = (Array.isArray(sigs) ? sigs : []).slice(0, maxSigs);
+
+    const rel      = path.relative(cwd, filePath);
+    const tokens   = tokenCount(sigs);
+    const covered  = hasCoverage(filePath, cwd);
+    const isSlow   = slow && elapsedMs > slowMs;
+
+    stats.push({
+      file:          rel,
+      extractor:     extractorName,
+      sigs:          sigs.length,
+      tokens,
+      covered,
+      elapsedMs:     slow ? elapsedMs : undefined,
+      slow:          slow ? isSlow : undefined,
+    });
+  }
+
+  return stats;
+}
+
+/**
+ * Format stats as a markdown table.
+ *
+ * @param {object[]} stats - output of analyzeFiles()
+ * @param {boolean}  showSlow - whether to include the Elapsed column
+ * @returns {string}
+ */
+function formatAnalysisTable(stats, showSlow) {
+  if (!stats || stats.length === 0) return '_(no files analyzed)_\n';
+
+  // Column widths
+  const maxFile = Math.max(4, ...stats.map((s) => s.file.length));
+
+  const header = showSlow
+    ? `| ${'File'.padEnd(maxFile)} | Sigs | Tokens | Extractor   | Coverage   | Elapsed  |`
+    : `| ${'File'.padEnd(maxFile)} | Sigs | Tokens | Extractor   | Coverage   |`;
+
+  const sep = showSlow
+    ? `|${'-'.repeat(maxFile + 2)}|------|--------|-------------|------------|----------|`
+    : `|${'-'.repeat(maxFile + 2)}|------|--------|-------------|------------|`;
+
+  const rows = stats.map((s) => {
+    const cov  = s.covered ? '✓ tested  ' : '✗ untested';
+    const file = s.file.padEnd(maxFile);
+    const ext  = (s.extractor || '').padEnd(11);
+    const base = `| ${file} | ${String(s.sigs).padStart(4)} | ${String(s.tokens).padStart(6)} | ${ext} | ${cov} |`;
+    if (showSlow) {
+      const ms = s.elapsedMs !== undefined ? `${s.elapsedMs}ms` : '';
+      const flag = s.slow ? ' ⚠️' : '';
+      return `${base} ${ms.padStart(6)}${flag} |`;
+    }
+    return base;
+  });
+
+  const totalSigs   = stats.reduce((n, s) => n + s.sigs,   0);
+  const totalTokens = stats.reduce((n, s) => n + s.tokens, 0);
+  const slotFile    = ''.padEnd(maxFile);
+  const baseFoot    = `| ${slotFile} | ${String(totalSigs).padStart(4)} | ${String(totalTokens).padStart(6)} | **Total**   |            |`;
+  const footer = showSlow ? `${baseFoot} ${' '.padStart(8)} |` : baseFoot;
+
+  return [header, sep, ...rows, sep, footer].join('\n') + '\n';
+}
+
+/**
+ * Format stats as a plain-object suitable for JSON.stringify.
+ *
+ * @param {object[]} stats
+ * @returns {object}
+ */
+function formatAnalysisJSON(stats) {
+  const totalSigs   = stats.reduce((n, s) => n + s.sigs,   0);
+  const totalTokens = stats.reduce((n, s) => n + s.tokens, 0);
+  const slowFiles   = stats.filter((s) => s.slow);
+
+  return {
+    files:       stats,
+    totalSigs,
+    totalTokens,
+    slowFiles:   slowFiles.map((s) => ({ file: s.file, elapsedMs: s.elapsedMs })),
+    fileCount:   stats.length,
+  };
+}
+
+module.exports = { analyzeFiles, formatAnalysisTable, formatAnalysisJSON };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '2.1.0',
+  version: '2.2.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/analyze.test.js
+++ b/test/integration/analyze.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+/**
+ * Integration tests for v2.2 diagnostics & analyze command.
+ *
+ * Tests:
+ *  1.  analyzeFiles — returns array with correct shape
+ *  2.  analyzeFiles — extractor name is populated
+ *  3.  analyzeFiles — sigs count ≥ 0
+ *  4.  analyzeFiles — tokens = ceil(sigChars / 4)
+ *  5.  analyzeFiles — covered is boolean
+ *  6.  analyzeFiles — skips unknown extensions
+ *  7.  formatAnalysisTable — output contains header columns
+ *  8.  formatAnalysisTable — empty stats returns fallback string
+ *  9.  formatAnalysisJSON — has files, totalSigs, totalTokens, slowFiles, fileCount
+ * 10.  CLI --analyze prints table, no throw (exit 0)
+ * 11.  CLI --analyze --json produces valid JSON with correct keys
+ * 12.  CLI --analyze --slow runs without throw
+ * 13.  CLI --diagnose-extractors exits 0 and prints pass/fail counts
+ * 14.  CLI --version returns 2.2.0
+ */
+
+const assert = require('assert');
+const fs     = require('fs');
+const path   = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT   = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load modules directly from src/
+// ---------------------------------------------------------------------------
+const { analyzeFiles, formatAnalysisTable, formatAnalysisJSON } = require(
+  path.join(ROOT, 'src', 'eval', 'analyzer'),
+);
+
+console.log('[analyze.test.js] v2.2 diagnostics & analyze command');
+console.log('');
+
+// Collect fixture files for unit-level tests
+const fixturesDir = path.join(ROOT, 'test', 'fixtures');
+const fixtures = fs.readdirSync(fixturesDir).map((f) => path.join(fixturesDir, f));
+
+// ---------------------------------------------------------------------------
+// 1. analyzeFiles — returns array
+// ---------------------------------------------------------------------------
+test('analyzeFiles: returns an array', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  assert.ok(Array.isArray(result));
+  assert.ok(result.length > 0, 'expected at least one analyzed file');
+});
+
+// ---------------------------------------------------------------------------
+// 2. analyzeFiles — each entry has extractor name
+// ---------------------------------------------------------------------------
+test('analyzeFiles: each entry has extractor string', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  for (const s of result) {
+    assert.strictEqual(typeof s.extractor, 'string', `extractor missing for ${s.file}`);
+    assert.ok(s.extractor.length > 0);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. analyzeFiles — sigs count is non-negative integer
+// ---------------------------------------------------------------------------
+test('analyzeFiles: sigs count is non-negative integer', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  for (const s of result) {
+    assert.ok(Number.isInteger(s.sigs) && s.sigs >= 0, `bad sigs for ${s.file}: ${s.sigs}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. analyzeFiles — tokens ≥ 0
+// ---------------------------------------------------------------------------
+test('analyzeFiles: tokens is non-negative', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  for (const s of result) {
+    assert.ok(typeof s.tokens === 'number' && s.tokens >= 0, `bad tokens for ${s.file}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. analyzeFiles — covered is boolean
+// ---------------------------------------------------------------------------
+test('analyzeFiles: covered is boolean', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  for (const s of result) {
+    assert.strictEqual(typeof s.covered, 'boolean', `covered not boolean for ${s.file}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. analyzeFiles — unknown extension files are skipped
+// ---------------------------------------------------------------------------
+test('analyzeFiles: skips unknown extension files', () => {
+  const fakeFiles = ['/tmp/unknown.xyz123', '/tmp/another.unknown999'];
+  const result = analyzeFiles(fakeFiles, ROOT);
+  assert.strictEqual(result.length, 0, 'expected 0 results for unknown extensions');
+});
+
+// ---------------------------------------------------------------------------
+// 7. formatAnalysisTable — output has column headers
+// ---------------------------------------------------------------------------
+test('formatAnalysisTable: output contains header columns', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  const table  = formatAnalysisTable(result, false);
+  assert.ok(typeof table === 'string' && table.length > 0);
+  assert.ok(table.includes('File'),      'missing File column');
+  assert.ok(table.includes('Sigs'),      'missing Sigs column');
+  assert.ok(table.includes('Tokens'),    'missing Tokens column');
+  assert.ok(table.includes('Extractor'), 'missing Extractor column');
+  assert.ok(table.includes('Coverage'),  'missing Coverage column');
+});
+
+// ---------------------------------------------------------------------------
+// 8. formatAnalysisTable — empty input returns fallback
+// ---------------------------------------------------------------------------
+test('formatAnalysisTable: empty stats returns fallback string', () => {
+  const table = formatAnalysisTable([], false);
+  assert.ok(table.length > 0);
+  // Should not contain pipe-table rows
+  assert.ok(!table.includes('| File'), 'should not have table header for empty input');
+});
+
+// ---------------------------------------------------------------------------
+// 9. formatAnalysisJSON — correct top-level keys
+// ---------------------------------------------------------------------------
+test('formatAnalysisJSON: correct top-level keys', () => {
+  const result = analyzeFiles(fixtures, ROOT);
+  const json   = formatAnalysisJSON(result);
+  assert.ok('files'       in json, 'missing files');
+  assert.ok('totalSigs'   in json, 'missing totalSigs');
+  assert.ok('totalTokens' in json, 'missing totalTokens');
+  assert.ok('slowFiles'   in json, 'missing slowFiles');
+  assert.ok('fileCount'   in json, 'missing fileCount');
+  assert.strictEqual(json.fileCount, result.length);
+  assert.ok(Array.isArray(json.slowFiles));
+});
+
+// ---------------------------------------------------------------------------
+// 10. CLI --analyze exits 0 and prints a table
+// ---------------------------------------------------------------------------
+test('CLI --analyze: exits 0 and prints table', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--analyze'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  assert.strictEqual(r.status, 0, `exit ${r.status}: ${r.stderr}`);
+  const out = r.stdout || '';
+  assert.ok(out.includes('File') || out.includes('no files'), `unexpected output: ${out.slice(0, 200)}`);
+});
+
+// ---------------------------------------------------------------------------
+// 11. CLI --analyze --json: valid JSON with correct keys
+// ---------------------------------------------------------------------------
+test('CLI --analyze --json: valid JSON with correct keys', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--analyze', '--json'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  assert.strictEqual(r.status, 0, `exit ${r.status}: ${r.stderr}`);
+  let d;
+  try { d = JSON.parse(r.stdout); } catch (e) { assert.fail(`invalid JSON: ${e.message}`); }
+  assert.ok('files'       in d, 'missing files');
+  assert.ok('totalSigs'   in d, 'missing totalSigs');
+  assert.ok('totalTokens' in d, 'missing totalTokens');
+  assert.ok('slowFiles'   in d, 'missing slowFiles');
+  assert.ok('fileCount'   in d, 'missing fileCount');
+  assert.ok(Array.isArray(d.files),     'files should be array');
+  assert.ok(Array.isArray(d.slowFiles), 'slowFiles should be array');
+});
+
+// ---------------------------------------------------------------------------
+// 12. CLI --analyze --slow: exits 0, no throw
+// ---------------------------------------------------------------------------
+test('CLI --analyze --slow: exits 0', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--analyze', '--slow'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 60000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  assert.strictEqual(r.status, 0, `exit ${r.status}: ${r.stderr}`);
+  assert.ok(r.stdout.length > 0, 'expected non-empty output');
+});
+
+// ---------------------------------------------------------------------------
+// 13. CLI --diagnose-extractors: exits 0 and prints pass counts
+// ---------------------------------------------------------------------------
+test('CLI --diagnose-extractors: exits 0 and shows results', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--diagnose-extractors'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  assert.strictEqual(r.status, 0, `exit ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  // Should mention passed/failed counts
+  assert.ok(
+    r.stdout.includes('passed') || r.stdout.includes('PASS'),
+    `expected pass/fail summary, got: ${r.stdout.slice(0, 300)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 14. CLI --version returns 2.2.0
+// ---------------------------------------------------------------------------
+test('CLI --version: returns 2.2.0', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--version'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  assert.strictEqual(r.status, 0);
+  assert.ok(r.stdout.trim().includes('2.2.0'), `got: ${r.stdout.trim()}`);
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Implements the v2.2.0 Diagnostics & Analyze Command milestone.

Closes #6

## New CLI flags

| Flag | Description |
|---|---|
| `--analyze` | Per-file table: File, Extractor, Sigs, Tokens, Covered |
| `--analyze --json` | Same breakdown as structured JSON |
| `--analyze --slow` | Re-times each extractor; flags files >50ms |
| `--diagnose-extractors` | Runs all 21 extractors vs fixtures; shows pass/fail + first diff |

## New files

- `src/eval/analyzer.js` — core analysis logic (`analyzeFiles`, `formatAnalysisTable`, `formatAnalysisJSON`)
- `test/integration/analyze.test.js` — 14 integration tests

## Test gate

```
node test/run.js              → 21 passed, 0 failed
node test/integration/all.js  → 19 suites, 0 failures (14 new analyze tests included)
```

## Version

Bumped to `2.2.0` in `gen-context.js`, `src/mcp/server.js`, and `package.json`.
