### PR TITLE
docs: update all documentation for v2.6 - Research Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [2.6.0] — upcoming · [#16](https://github.com/manojmallick/sigmap/issues/16) · branch: `feat/v2.6-research-mode`
+
+### Planned additions
+- **`benchmarks/repos/`** — register 5 real open-source repos (express, flask, gin, spring-petclinic, rails) as git submodules or clone targets for evaluation
+- **`benchmarks/tasks/retrieval-real.jsonl`** — 50 real evaluation tasks across all 5 repos; structured JSONL format compatible with the v2.1 benchmark runner
+- **`--benchmark --repo <path>` CLI flag** — run benchmark against external repository; supports any git-cloned project
+- **`--report --paper` CLI flag** — generates `benchmarks/reports/paper-metrics.md`: token reduction table (baseline vs SigMap per repo), hit@5 and MRR per repo, latency table (p50, p95, p99 in ms), LaTeX-ready table block for copy-paste into academic papers
+- **`src/eval/paper.js`** — formats paper-ready markdown + LaTeX tables; zero dependencies
+- **`test/integration/paper.test.js`** — 8 tests: `--report --paper` creates the report file, report contains all required sections, LaTeX table block present and syntactically valid, `--benchmark --repo <missing>` fails gracefully
+
+### Go / No-go criteria
+- All tests green (21 extractor + all integration suites)
+- `--report --paper` generates a valid markdown file
+- LaTeX table block present in report
+- Overall hit@5 across all repos ≥ 0.75
+- `--benchmark --repo .` completes in < 30 s on SigMap repo
+
+---
+
 ## [2.5.0] — upcoming · [#14](https://github.com/manojmallick/sigmap/issues/14) · branch: `feat/v2.5-impact-layer`
 
 ### Planned additions

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ AI agent session starts with full context
 
 ---
 
-## 🔭 What's next — v2.5 (in progress · [#14](https://github.com/manojmallick/sigmap/issues/14))
+## 🔭 What's next — v2.5-v2.6 (in progress · [#14](https://github.com/manojmallick/sigmap/issues/14) · [#16](https://github.com/manojmallick/sigmap/issues/16))
+
+### v2.5 — Impact Layer
 
 | Feature | Description |
 |---|---|
@@ -95,6 +97,16 @@ AI agent session starts with full context
 | **`get_impact` MCP tool** | 9th MCP tool — `{ file, depth? }` → impacted files + signatures |
 | **`src/map/dep-graph.js`** | Reverse-dependency graph built from the import analysis; circular deps handled safely |
 | **15 new tests** | `impact.test.js` — direct deps, transitive deps, depth limit, JSON output |
+
+### v2.6 — Research Mode
+
+| Feature | Description |
+|---|---|
+| **`--benchmark --repo <path>`** | Run benchmarks against any external repository (express, flask, gin, spring-petclinic, rails) |
+| **`--report --paper`** | Generate paper-ready metrics: markdown + LaTeX tables for academic publishing |
+| **50 real eval tasks** | JSONL task file covering 5 real open-source repos — `benchmarks/tasks/retrieval-real.jsonl` |
+| **`src/eval/paper.js`** | Zero-dependency LaTeX table formatter for token reduction, hit@5, MRR, latency (p50/p95/p99) |
+| **8 new tests** | `paper.test.js` — report generation, LaTeX syntax validation, graceful failures |
 
 ## 🆕 What's new in 2.4
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -438,7 +438,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px;t
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.5" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span>
+    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span>
     <div class="footer-links">
       <a href="quick-start.html">Quick start</a>
       <a href="cli.html">CLI reference</a>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -619,7 +619,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <footer>
   <div class="footer-inner">
-    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.5" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span>
+    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span>
     <div class="footer-links">
       <a href="quick-start.html">Quick start</a>
       <a href="cli.html">CLI reference</a>

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -442,7 +442,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <span class="term-title">node gen-context.js --help</span>
     </div>
     <div class="term-body">
-      <div><span class="tp">SigMap v2.4.0 &middot; <a href="roadmap.html" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span></div>
+      <div><span class="tp">SigMap v2.4.0 &middot; <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span></div>
       <div>&nbsp;</div>
       <div><span class="tc">Usage:</span> <span class="tw">node gen-context.js [flag]</span></div>
       <div>&nbsp;</div>
@@ -486,7 +486,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <div class="next-card-desc">Stack both tools for the two-layer caching strategy. SigMap for daily; Repomix for deep sessions.</div>
     </a>
     <a class="next-card" href="roadmap.html">
-      <div class="next-card-ey">v0.1 → v2.5</div>
+      <div class="next-card-ey">v0.1 → v2.6</div>
       <div class="next-card-title">Full roadmap</div>
       <div class="next-card-desc">All major versions shipped. 97% token reduction. 340 tests. MIT license.</div>
     </a>
@@ -495,7 +495,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <footer>
   <div class="footer-inner">
-    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span>
+    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span>
     <div class="footer-links">
       <a href="quick-start.html">Quick start</a>
       <a href="cli.html">CLI reference</a>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Roadmap — SigMap</title>
-<meta name="description" content="SigMap shipped v0.1 through v2.4 — v2.5 Impact layer (dependency graph + --impact) upcoming. 97% token reduction, 340 tests. Full visual timeline from baseline to complete system.">
-<meta property="og:title" content="SigMap Roadmap — v0.1 to v2.4 complete · v2.5 upcoming">
+<meta name="description" content="SigMap shipped v0.1 through v2.4 — v2.5 Impact layer + v2.6 Research Mode upcoming. 97% token reduction, 340 tests. Full visual timeline from baseline to complete system.">
+<meta property="og:title" content="SigMap Roadmap — v0.1 to v2.4 complete · v2.5-v2.6 upcoming">
 <meta property="og:description" content="21 versions shipped. 97% token reduction. 340 tests. MIT license. See how SigMap was built from first extractor to full enterprise system.">
 <meta property="og:url" content="https://manojmallick.github.io/sigmap/roadmap.html">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
 <meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
 <link rel="canonical" href="https://manojmallick.github.io/sigmap/roadmap.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap roadmap — v0.1 to v2.4 complete · v2.5 Impact layer upcoming","description":"21 versions shipped. 97% token reduction. 340 tests. MIT license. v2.5 Impact layer upcoming. See how SigMap was built from first extractor to full enterprise system.","url":"https://manojmallick.github.io/sigmap/roadmap.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap roadmap — v0.1 to v2.4 complete · v2.5-v2.6 upcoming","description":"21 versions shipped. 97% token reduction. 340 tests. MIT license. v2.5 Impact layer + v2.6 Research Mode upcoming. See how SigMap was built from first extractor to full enterprise system.","url":"https://manojmallick.github.io/sigmap/roadmap.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -145,9 +145,9 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <div class="page-hero">
   <div class="hero-inner">
-    <div class="hero-badge"><span class="dot"></span>v2.5 in progress</div>
-    <h1>v0.0 → v2.5</h1>
-    <p class="hero-sub">Twenty-one versions shipped. v2.5 Impact layer in progress. MIT open source from day one.</p>
+    <div class="hero-badge"><span class="dot"></span>v2.5-v2.6 in progress</div>
+    <h1>v0.0 → v2.6</h1>
+    <p class="hero-sub">Twenty-one versions shipped. v2.5 Impact layer + v2.6 Research Mode in progress. MIT open source from day one.</p>
     <div class="hero-stats">
       <div class="hstat"><span class="hstat-val p">97%</span><span class="hstat-lbl">Token reduction</span></div>
       <div class="hstat"><span class="hstat-val g">340</span><span class="hstat-lbl">Tests passing</span></div>
@@ -236,6 +236,11 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <div class="tp-ver">v2.5</div>
       <div class="tp-bar-bg"><div class="tp-bar" style="width:0.5%;background:var(--t2)"></div></div>
       <div class="tp-val" style="color:var(--t2)">+impact layer ↗</div>
+    </div>
+    <div class="tp-row">
+      <div class="tp-ver">v2.6</div>
+      <div class="tp-bar-bg"><div class="tp-bar" style="width:0.5%;background:var(--t2)"></div></div>
+      <div class="tp-val" style="color:var(--t2)">+research mode ↗</div>
     </div>
   </div>
 </section>
@@ -759,6 +764,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
     <div id="v2.5" class="tl-item">
       <div class="tl-rail">
         <div class="tl-dot" style="background:rgba(99,184,112,.15);border-color:var(--t2);color:var(--t2);font-size:10px">v2.5</div>
+        <div class="tl-line"></div>
       </div>
       <div class="tl-content">
         <div class="tl-header">
@@ -780,6 +786,31 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       </div>
     </div>
 
+    <!-- v2.6 -->
+    <div id="v2.6" class="tl-item">
+      <div class="tl-rail">
+        <div class="tl-dot" style="background:rgba(99,184,112,.15);border-color:var(--t2);color:var(--t2);font-size:10px">v2.6</div>
+      </div>
+      <div class="tl-content">
+        <div class="tl-header">
+          <span class="tl-version" style="background:linear-gradient(135deg,var(--t2),var(--t1));-webkit-background-clip:text;-webkit-text-fill-color:transparent">v2.6</span>
+          <span class="tl-name">Research Mode — Real Benchmarks + Paper Export</span>
+          <span class="tl-badge" style="background:rgba(99,184,112,.15);color:var(--t2);border-color:var(--t2)">⟳ In progress — <a href="https://github.com/manojmallick/sigmap/issues/16" style="color:var(--t2);text-decoration:none">#16</a></span>
+        </div>
+        <div class="tl-desc">Generate publishable evaluation results. Run against real open-source repos (express, flask, gin, spring-petclinic, rails) and output paper-ready metrics. <code>--benchmark --repo &lt;path&gt;</code> runs benchmarks on external repos. <code>--report --paper</code> generates markdown + LaTeX tables ready for academic papers: token reduction table, hit@5/MRR per repo, latency (p50/p95/p99), all copy-paste ready. 50 real evaluation tasks across 5 repos. Zero-dependency paper formatting in <code>src/eval/paper.js</code>.</div>
+        <div class="tl-tags">
+          <span class="tl-tag">benchmarks</span>
+          <span class="tl-tag">--benchmark --repo</span>
+          <span class="tl-tag">--report --paper</span>
+          <span class="tl-tag">LaTeX export</span>
+          <span class="tl-tag">50 eval tasks</span>
+          <span class="tl-tag">5 real repos</span>
+          <span class="tl-tag">issue #16</span>
+        </div>
+        <div class="tl-impact">Publishable research-grade metrics — hit@5 ≥ 0.75 target across all real-world repos</div>
+      </div>
+    </div>
+
   </div>
 </section>
 
@@ -787,7 +818,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <section class="section">
   <p class="section-ey">Final numbers</p>
-  <h2>v2.4.0 at a glance · v2.5 upcoming</h2>
+  <h2>v2.4.0 at a glance · v2.5-v2.6 upcoming</h2>
 
   <div class="final-grid">
     <div class="final-stat">
@@ -816,7 +847,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <footer>
   <div class="footer-inner">
-    <span class="footer-logo">sigmap v2.4.0 · <a href="https://github.com/manojmallick/sigmap/issues/14" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span>
+    <span class="footer-logo">sigmap v2.4.0 · <a href="https://github.com/manojmallick/sigmap/issues/16" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span>
     <div class="footer-links">
       <a href="quick-start.html">Quick start</a>
       <a href="cli.html">CLI reference</a>

--- a/docs/strategies.html
+++ b/docs/strategies.html
@@ -130,7 +130,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <div class="page-hero">
   <div class="hero-inner">
-    <div class="hero-badge">strategy guide — current as of v2.4 · <a href="roadmap.html#v2.5" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></div>
+    <div class="hero-badge">strategy guide — current as of v2.4 · <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></div>
     <h1>Choose the right context strategy</h1>
     <p class="hero-sub">SigMap supports three modes: full, per-module, and hot-cold. This page shows exactly when to use each one, what token cost to expect, and how MCP changes the decision.</p>
   </div>
@@ -295,7 +295,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
 
 <footer>
   <div class="footer-inner">
-    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.5" style="color:var(--t2);text-decoration:none">v2.5 upcoming</a></span>
+    <span class="footer-logo">sigmap v2.4.0 &middot; <a href="roadmap.html#v2.6" style="color:var(--t2);text-decoration:none">v2.6 upcoming</a></span>
     <div class="footer-links">
       <a href="quick-start.html">Quick start</a>
       <a href="cli.html">CLI reference</a>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -128,9 +128,13 @@ const health = score('/path/to/project');
 
 All existing CLI flags (`--generate`, `--watch`, `--mcp`, `--query`, `--analyze`, `--benchmark`, `--health`, …) are unchanged.
 
-## What's next — v2.5 Impact layer
+## What's next — v2.5-v2.6
 
-v2.5 adds `analyzeImpact(changedFiles, cwd)` to `packages/core` — given a list of changed files, it returns every file that transitively imports them. See [issue #14](https://github.com/manojmallick/sigmap/issues/14) and the [roadmap](https://manojmallick.github.io/sigmap/roadmap.html).
+v2.5 adds `analyzeImpact(changedFiles, cwd)` to `packages/core` — given a list of changed files, it returns every file that transitively imports them. See [issue #14](https://github.com/manojmallick/sigmap/issues/14).
+
+v2.6 adds benchmark and paper reporting capabilities — run evaluations against external repos and export metrics in LaTeX format for academic papers. See [issue #16](https://github.com/manojmallick/sigmap/issues/16).
+
+See the full [roadmap](https://manojmallick.github.io/sigmap/roadmap.html).
 
 ## Zero dependencies
 


### PR DESCRIPTION
- Add v2.6 section to CHANGELOG.md with planned features
- Update roadmap.html with v2.6 timeline entry and hero updates
- Update all HTML docs footers to reference v2.6 as upcoming
- Update README.md to include v2.6 Research Mode overview
- Update packages/core/README.md with v2.6 reference
- All roadmap links now point to #v2.6
- Version range updated to v0.0 → v2.6 across docs

Related: #16