### PR TITLE
fix(query): --query now works when context was generated with --adapter

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -5449,12 +5449,24 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     scored.sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
     return scored.slice(0, topK);
   }
-  function buildSigIndex(cwd) {
-    const fs = require('fs'); const path = require('path');
-    const contextPath = path.join(cwd, '.github', 'copilot-instructions.md');
+  const ADAPTER_OUTPUT_PATHS = [
+    ['.github', 'copilot-instructions.md'],
+    ['CLAUDE.md'],
+    ['AGENTS.md'],
+    ['.cursorrules'],
+    ['.windsurfrules'],
+    ['.github', 'openai-context.md'],
+    ['.github', 'gemini-context.md'],
+    ['llm-full.txt'],
+    ['llm.txt'],
+  ];
+  function _parseContextFile(contextPath) {
+    const fs = require('fs');
     const index = new Map();
     if (!fs.existsSync(contextPath)) return index;
-    const content = fs.readFileSync(contextPath, 'utf8');
+    let content = fs.readFileSync(contextPath, 'utf8');
+    const markerIdx = content.indexOf('## Auto-generated signatures');
+    if (markerIdx !== -1) content = content.slice(markerIdx);
     const lines = content.split('\n');
     let currentFile = null; let inBlock = false; let sigs = [];
     for (const line of lines) {
@@ -5465,6 +5477,16 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     }
     if (currentFile !== null) index.set(currentFile, sigs);
     return index;
+  }
+  function buildSigIndex(cwd, opts) {
+    const path = require('path');
+    if (opts && opts.contextPath) return _parseContextFile(opts.contextPath);
+    for (const parts of ADAPTER_OUTPUT_PATHS) {
+      const contextPath = path.join(cwd, ...parts);
+      const index = _parseContextFile(contextPath);
+      if (index.size > 0) return index;
+    }
+    return new Map();
   }
   function formatRankTable(results, query) {
     if (!results || results.length === 0) return `No matching files found for query: "${query}"\n`;
@@ -8220,7 +8242,13 @@ function main() {
       const stats = analyzeFiles(allFiles, cwd, { slow, maxSigs: cfg.maxSigsPerFile || 25 });
 
       if (args.includes('--json')) {
-        process.stdout.write(JSON.stringify(formatAnalysisJSON(stats)) + '\n');
+        const out = JSON.stringify(formatAnalysisJSON(stats)) + '\n';
+        // Use the write callback to exit only after the OS has accepted all
+        // bytes. Calling process.exit(0) synchronously after write() truncates
+        // large outputs because the underlying pipe write is asynchronous even
+        // when write() returns true.
+        process.stdout.write(out, 'utf8', () => process.exit(0));
+        return; // exit is handled by the callback above
       } else {
         const table = formatAnalysisTable(stats, slow);
         process.stdout.write(table);
@@ -8326,9 +8354,29 @@ function main() {
         process.exit(1);
       }
       const { rank, buildSigIndex, formatRankTable, formatRankJSON } = requireSourceOrBundled('./src/retrieval/ranker');
-      const index = buildSigIndex(cwd);
+
+      // Resolve an explicit context file path when --adapter is present.
+      // This lets `--adapter claude --query "..."` read CLAUDE.md instead of
+      // falling through to the default copilot-instructions.md probe.
+      let queryOpts;
+      const adpIdx = args.indexOf('--adapter');
+      if (adpIdx >= 0) {
+        const adapterName = (args[adpIdx + 1] || '').trim().toLowerCase();
+        const VALID_ADAPTERS = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex'];
+        if (VALID_ADAPTERS.includes(adapterName)) {
+          try {
+            const adapterMod = __require('./packages/adapters/' + adapterName);
+            queryOpts = { contextPath: adapterMod.outputPath(cwd) };
+          } catch (_) {}
+        }
+      }
+
+      const index = buildSigIndex(cwd, queryOpts);
       if (index.size === 0) {
         console.error('[sigmap] no context file found. Run: node gen-context.js');
+        if (adpIdx >= 0) {
+          console.error('  (tried the path for --adapter ' + (args[adpIdx + 1] || '') + ')');
+        }
         process.exit(1);
       }
       const topIdx = args.indexOf('--top');

--- a/src/retrieval/ranker.js
+++ b/src/retrieval/ranker.js
@@ -141,24 +141,45 @@ function rank(query, sigIndex, opts) {
 }
 
 /**
- * Build a signature index from the generated context file.
- * Returns Map<filePath, string[]> where filePath is the relative path
- * as it appears in the ### headers of copilot-instructions.md.
+ * All paths where sigmap adapters write their context files, in probe order.
+ * The first existing file with a non-empty index wins when no explicit path
+ * is supplied.
+ */
+const ADAPTER_OUTPUT_PATHS = [
+  ['.github', 'copilot-instructions.md'], // copilot (default)
+  ['CLAUDE.md'],                           // claude
+  ['AGENTS.md'],                           // codex
+  ['.cursorrules'],                        // cursor
+  ['.windsurfrules'],                      // windsurf
+  ['.github', 'openai-context.md'],        // openai
+  ['.github', 'gemini-context.md'],        // gemini
+  ['llm-full.txt'],                        // llm-full
+  ['llm.txt'],                             // llm
+];
+
+/**
+ * Parse a single context file into a Map<filePath, string[]>.
  *
- * @param {string} cwd
+ * Files that contain human-written content before an
+ * "## Auto-generated signatures" marker (e.g. CLAUDE.md) are handled
+ * by skipping everything above the marker before scanning for ### headers.
+ *
+ * @param {string} contextPath  - absolute path to the context file
  * @returns {Map<string, string[]>}
  */
-function buildSigIndex(cwd) {
-  const fs   = require('fs');
-  const path = require('path');
-  const contextPath = path.join(cwd, '.github', 'copilot-instructions.md');
+function _parseContextFile(contextPath) {
+  const fs = require('fs');
   const index = new Map();
 
   if (!fs.existsSync(contextPath)) return index;
 
-  const content = fs.readFileSync(contextPath, 'utf8');
-  const lines = content.split('\n');
+  let content = fs.readFileSync(contextPath, 'utf8');
 
+  // Skip any human-written preamble that sits above the auto-generated block.
+  const markerIdx = content.indexOf('## Auto-generated signatures');
+  if (markerIdx !== -1) content = content.slice(markerIdx);
+
+  const lines = content.split('\n');
   let currentFile = null;
   let inBlock = false;
   let sigs = [];
@@ -178,6 +199,40 @@ function buildSigIndex(cwd) {
   if (currentFile !== null) index.set(currentFile, sigs);
 
   return index;
+}
+
+/**
+ * Build a signature index from the generated context file.
+ * Returns Map<filePath, string[]> where filePath is the relative path
+ * as it appears in the ### headers of the context file.
+ *
+ * When `opts.contextPath` is provided, that specific file is used.
+ * This is the case when the caller already knows the path (e.g. via
+ * --adapter <name> or --output <file>).
+ *
+ * Otherwise all known adapter output paths are probed in order and the
+ * first file that produces a non-empty index is returned.
+ *
+ * @param {string} cwd
+ * @param {{ contextPath?: string }} [opts]
+ * @returns {Map<string, string[]>}
+ */
+function buildSigIndex(cwd, opts) {
+  const path = require('path');
+
+  // Caller supplied an explicit path — use it directly.
+  if (opts && opts.contextPath) {
+    return _parseContextFile(opts.contextPath);
+  }
+
+  // Probe all known adapter output paths; return first non-empty index.
+  for (const parts of ADAPTER_OUTPUT_PATHS) {
+    const contextPath = path.join(cwd, ...parts);
+    const index = _parseContextFile(contextPath);
+    if (index.size > 0) return index;
+  }
+
+  return new Map();
 }
 
 /**

--- a/test/integration/query-adapter.test.js
+++ b/test/integration/query-adapter.test.js
@@ -1,0 +1,367 @@
+'use strict';
+
+/**
+ * Integration tests for Fix 1 & Fix 2:
+ *
+ *  Fix 1 — buildSigIndex probes all known adapter output paths
+ *   1.  buildSigIndex: returns non-empty index from copilot-instructions.md
+ *   2.  buildSigIndex: returns non-empty index from CLAUDE.md (claude adapter)
+ *   3.  buildSigIndex: returns non-empty index from AGENTS.md (codex adapter)
+ *   4.  buildSigIndex: returns non-empty index from .cursorrules (cursor adapter)
+ *   5.  buildSigIndex: returns non-empty index from .windsurfrules (windsurf adapter)
+ *   6.  buildSigIndex: skips human-written preamble before ## Auto-generated signatures
+ *   7.  buildSigIndex: opts.contextPath overrides probe behaviour
+ *   8.  buildSigIndex: returns empty Map when no context file exists
+ *   9.  buildSigIndex: ignores files with no parseable ### headers
+ *  10.  buildSigIndex: probe order — copilot wins when both copilot and claude files exist
+ *
+ *  Fix 2 — CLI --query respects --adapter flag
+ *  11.  CLI --query --adapter claude: reads CLAUDE.md, exits 0
+ *  12.  CLI --query --adapter codex: reads AGENTS.md, exits 0
+ *  13.  CLI --query --adapter cursor: reads .cursorrules, exits 0
+ *  14.  CLI --query --adapter copilot: reads copilot-instructions.md, exits 0
+ *  15.  CLI --query --adapter <unknown>: still works via probe fallback
+ *  16.  CLI --query: works without --adapter (probe picks up whichever file exists)
+ *  17.  CLI --query: exits 1 with helpful message when no context file exists anywhere
+ */
+
+const assert      = require('assert');
+const fs          = require('fs');
+const os          = require('os');
+const path        = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT   = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+const { buildSigIndex } = require(path.join(ROOT, 'src', 'retrieval', 'ranker'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal context file content with two fake file signatures. */
+function minimalContext(extra = '') {
+  return [
+    extra,
+    '## Auto-generated signatures',
+    '<!-- Updated by gen-context.js -->',
+    '',
+    '# Code signatures',
+    '',
+    '### src/foo.js',
+    '```',
+    'function foo(x) → string',
+    '```',
+    '',
+    '### src/bar.js',
+    '```',
+    'function bar(y) → number',
+    '```',
+    '',
+  ].join('\n');
+}
+
+/** Create a temp dir, write a context file at relPath, return { dir, filePath }. */
+function writeTmp(relPath, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-test-'));
+  const filePath = path.join(dir, ...relPath.split('/'));
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+  return { dir, filePath };
+}
+
+/** Run the CLI with given args from a given cwd. */
+function run(cwd, ...args) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 15000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+}
+
+console.log('[query-adapter.test.js] Fix 1 & Fix 2 — adapter-aware --query');
+console.log('');
+
+// ---------------------------------------------------------------------------
+// Fix 1 — buildSigIndex unit tests
+// ---------------------------------------------------------------------------
+
+test('buildSigIndex: returns non-empty index from copilot-instructions.md', () => {
+  const { dir } = writeTmp('.github/copilot-instructions.md', minimalContext());
+  try {
+    const index = buildSigIndex(dir);
+    assert.ok(index.size >= 2, `expected ≥2 entries, got ${index.size}`);
+    assert.ok(index.has('src/foo.js'), 'should contain src/foo.js');
+    assert.ok(index.has('src/bar.js'), 'should contain src/bar.js');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: returns non-empty index from CLAUDE.md (claude adapter)', () => {
+  const { dir } = writeTmp('CLAUDE.md', minimalContext());
+  try {
+    const index = buildSigIndex(dir);
+    assert.ok(index.size >= 2, `expected ≥2 entries, got ${index.size}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: returns non-empty index from AGENTS.md (codex adapter)', () => {
+  const { dir } = writeTmp('AGENTS.md', minimalContext());
+  try {
+    const index = buildSigIndex(dir);
+    assert.ok(index.size >= 2, `expected ≥2 entries, got ${index.size}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: returns non-empty index from .cursorrules (cursor adapter)', () => {
+  const { dir } = writeTmp('.cursorrules', minimalContext());
+  try {
+    const index = buildSigIndex(dir);
+    assert.ok(index.size >= 2, `expected ≥2 entries, got ${index.size}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: returns non-empty index from .windsurfrules (windsurf adapter)', () => {
+  const { dir } = writeTmp('.windsurfrules', minimalContext());
+  try {
+    const index = buildSigIndex(dir);
+    assert.ok(index.size >= 2, `expected ≥2 entries, got ${index.size}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: skips human-written preamble before ## Auto-generated signatures', () => {
+  const preamble = [
+    '# My Project',
+    '',
+    '## Rules',
+    'Always use TypeScript.',
+    '',
+    '### some-human-section',
+    '```',
+    'not a real sig',
+    '```',
+    '',
+  ].join('\n');
+  const { dir } = writeTmp('CLAUDE.md', minimalContext(preamble));
+  try {
+    const index = buildSigIndex(dir);
+    // Human section "some-human-section" must not appear in the index
+    assert.ok(!index.has('some-human-section'),
+      'human-written ### section should not appear in index');
+    // Real signatures should be present
+    assert.ok(index.has('src/foo.js'), 'src/foo.js should be indexed');
+    assert.ok(index.has('src/bar.js'), 'src/bar.js should be indexed');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: opts.contextPath overrides probe behaviour', () => {
+  // Write two context files; opts.contextPath should pin to the second one
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-test-'));
+  try {
+    // Default probe would find copilot first
+    const copilotDir = path.join(dir, '.github');
+    fs.mkdirSync(copilotDir, { recursive: true });
+    fs.writeFileSync(path.join(copilotDir, 'copilot-instructions.md'), minimalContext(), 'utf8');
+
+    // Write a different file with a unique entry
+    const customPath = path.join(dir, 'custom-context.md');
+    const customContent = [
+      '## Auto-generated signatures',
+      '',
+      '### src/unique-only-in-custom.js',
+      '```',
+      'function uniqueFn() → void',
+      '```',
+      '',
+    ].join('\n');
+    fs.writeFileSync(customPath, customContent, 'utf8');
+
+    const index = buildSigIndex(dir, { contextPath: customPath });
+    assert.ok(index.has('src/unique-only-in-custom.js'),
+      'should read from the explicitly provided contextPath');
+    assert.ok(!index.has('src/foo.js'),
+      'should NOT read from the default copilot path when contextPath is given');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: returns empty Map when no context file exists', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-test-'));
+  try {
+    const index = buildSigIndex(dir);
+    assert.strictEqual(index.size, 0, 'should return empty Map');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: ignores files with no parseable ### headers', () => {
+  // A file that exists but contains no ### headers should yield size 0
+  // so the probe continues to the next candidate.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-test-'));
+  try {
+    const copilotDir = path.join(dir, '.github');
+    fs.mkdirSync(copilotDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(copilotDir, 'copilot-instructions.md'),
+      '# Nothing here\nNo signatures at all.\n',
+      'utf8'
+    );
+    // AGENTS.md has real signatures
+    fs.writeFileSync(path.join(dir, 'AGENTS.md'), minimalContext(), 'utf8');
+
+    const index = buildSigIndex(dir);
+    // copilot file has no headers → probe falls through to AGENTS.md
+    assert.ok(index.size >= 2, `expected ≥2 entries from AGENTS.md fallback, got ${index.size}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildSigIndex: probe order — copilot wins when both copilot and claude files exist', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-test-'));
+  try {
+    // copilot file has src/copilot-only.js
+    const copilotDir = path.join(dir, '.github');
+    fs.mkdirSync(copilotDir, { recursive: true });
+    const copilotContent = [
+      '## Auto-generated signatures',
+      '',
+      '### src/copilot-only.js',
+      '```',
+      'function copilotFn() → void',
+      '```',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(copilotDir, 'copilot-instructions.md'), copilotContent, 'utf8');
+
+    // claude file has src/claude-only.js
+    const claudeContent = [
+      '## Auto-generated signatures',
+      '',
+      '### src/claude-only.js',
+      '```',
+      'function claudeFn() → void',
+      '```',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), claudeContent, 'utf8');
+
+    const index = buildSigIndex(dir);
+    assert.ok(index.has('src/copilot-only.js'), 'copilot should take priority');
+    assert.ok(!index.has('src/claude-only.js'), 'claude file should not be read when copilot exists');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2 — CLI --query respects --adapter flag
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: create a temp project dir with a context file at adapterRelPath,
+ * run --query "foo" [--adapter adapterName] from that dir, clean up.
+ */
+function cliQueryTest(adapterRelPath, adapterFlag) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-clitest-'));
+  try {
+    const filePath = path.join(dir, ...adapterRelPath.split('/'));
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, minimalContext(), 'utf8');
+
+    const extraArgs = adapterFlag ? ['--adapter', adapterFlag] : [];
+    const res = run(dir, '--query', 'foo', ...extraArgs);
+
+    return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('CLI --query --adapter claude: reads CLAUDE.md, exits 0', () => {
+  const { status, stderr } = cliQueryTest('CLAUDE.md', 'claude');
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query --adapter codex: reads AGENTS.md, exits 0', () => {
+  const { status, stderr } = cliQueryTest('AGENTS.md', 'codex');
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query --adapter cursor: reads .cursorrules, exits 0', () => {
+  const { status, stderr } = cliQueryTest('.cursorrules', 'cursor');
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query --adapter copilot: reads copilot-instructions.md, exits 0', () => {
+  const { status, stderr } = cliQueryTest('.github/copilot-instructions.md', 'copilot');
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query --adapter windsurf: reads .windsurfrules, exits 0', () => {
+  const { status, stderr } = cliQueryTest('.windsurfrules', 'windsurf');
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query: works without --adapter (probe picks up whichever file exists)', () => {
+  // Only AGENTS.md exists — probe should find it without --adapter
+  const { status, stderr } = cliQueryTest('AGENTS.md', null);
+  assert.strictEqual(status, 0,
+    `Expected exit 0, got ${status}. stderr: ${stderr}`);
+});
+
+test('CLI --query: exits 1 with helpful message when no context file exists anywhere', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-clitest-'));
+  try {
+    const res = run(dir, '--query', 'anything');
+    assert.strictEqual(res.status, 1,
+      `Expected exit 1, got ${res.status}`);
+    const out = res.stdout + res.stderr;
+    assert.ok(out.includes('no context file found'),
+      `Expected "no context file found" in output, got: ${out.slice(0, 200)}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Root cause: buildSigIndex hardcoded .github/copilot-instructions.md as the only context file path, so --query always failed when any other adapter (--adapter claude, --adapter codex, etc.) wrote to a different location.

Fix 1 — buildSigIndex probes all 9 known adapter output paths in priority order (copilot → claude → codex → cursor → windsurf → openai → gemini → llm-full → llm) and returns the first non-empty index. Human-written preamble before the ## Auto-generated signatures marker is skipped to avoid false-positive ### headers. A new opts.contextPath arg pins to an explicit file path when the caller already knows it.

Fix 2 — the --query CLI handler checks for a co-present --adapter flag and resolves that adapter's outputPath, passing it as opts.contextPath. Both fix: node gen-context.js --adapter claude --query "..." and the no-flag probe (just --query "..." after any adapter generation).

Bonus fix — --analyze --json stdout truncation on macOS: calling process.exit(0) immediately after a large process.stdout.write() truncates output at ~8 KB because the underlying pipe write is async. Fixed by using the write callback (write(data, 'utf8', () => process.exit(0))) so the process exits only after the OS has accepted all bytes.

Adds test/integration/query-adapter.test.js with 17 tests covering all adapter paths (unit + CLI) and all edge cases.