### PR TITLE
docs(trust-sync): v6.4.0 — version labels, overclaim fix, generalization upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.4.0] — 2026-04-23
+
+### Changed
+
+- **Docs version labels** — homepage hero badge now shows Release (v6.4.0) and Benchmark (sigmap-v6.0-main) as separate labels instead of a single conflated "Latest: v6.0" pill
+- **Generalization benchmark** — upgraded all v5.9-main references in `docs-vp/guide/generalization.md` to v6.0-main snapshot
+- **README overclaim fix** — removed "every time" from the comparison table; trimmed top demo block from 4 commands to 2
+- **v6.3.0 release notes** — added release note callout blocks to benchmark, retrieval-benchmark, and task-benchmark docs
+- **MCP docs** — added v6.3 native tool registration callout to `docs-vp/guide/mcp.md`
+- **Content-consistency test** — new `test/content/v640-trust-sync.sh` bash script with 11 checks catches version/copy regressions
+
+---
+
 ## [6.3.0] — 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 ```bash
 npx sigmap
 sigmap ask "Where is auth handled?"
-sigmap validate
-sigmap judge
 ```
 
 Zero config. Zero dependencies. Under 10 seconds.
@@ -52,7 +50,7 @@ Works with Copilot, Claude, Cursor, Windsurf, and any LLM.
 
 | Without SigMap | With SigMap |
 |---|---|
-| ❌ Guessing which files are relevant | ✅ Correct file selection every time |
+| ❌ Guessing which files are relevant | ✅ Right file in context — 80% of the time |
 | ❌ Sending the full repo to your AI | ✅ Minimal context — only what matters |
 | ❌ Embeddings / vector DB required | ✅ Grounded answers, no infra needed |
 

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -38,6 +38,10 @@ This is the landing page for the public benchmark story. It answers four differe
 | SigMap reduces retries and wrong-context answers | [Task benchmark](/guide/task-benchmark) |
 | SigMap keeps large repos inside model limits | [Quality benchmark](/guide/quality-benchmark) |
 
+::: tip v6.3.0 release note
+v6.3.0 ships native tool registration for Claude Code and Codex — the MCP server now declares its tools at startup so the AI sees them without a discovery round-trip. Benchmark numbers are unchanged from v6.0; the next retrieval run will follow the v6.5 Source Root Resolver milestone.
+:::
+
 ## Official v6.0 snapshot
 
 Latest saved benchmark run: **2026-04-19 (v6.0.0)**

--- a/docs-vp/guide/generalization.md
+++ b/docs-vp/guide/generalization.md
@@ -1,6 +1,6 @@
 ---
 title: Generalization — SigMap across languages, domains & repo sizes
-description: SigMap generalizes across 18 repos, 13 languages, and 9 domains with 80.0% hit@5 in the latest saved v5.9 retrieval run.
+description: SigMap generalizes across 18 repos, 13 languages, and 9 domains with 80.0% hit@5 in the latest saved v6.0 retrieval run.
 head:
   - - meta
     - property: og:title
@@ -19,8 +19,8 @@ head:
 SigMap was not tuned for one repo. This benchmark matters because it shows the same workflow transfers across different languages, repo sizes, and architectures without manual tuning.
 :::
 
-::: info Official v5.9 benchmark snapshot
-**Benchmark ID:** sigmap-v5.9-main &nbsp;·&nbsp; **Date:** 2026-04-18
+::: info Official v6.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.0-main &nbsp;·&nbsp; **Date:** 2026-04-19
 
 | Metric | Value |
 |---|---:|
@@ -37,7 +37,7 @@ The important part of SigMap's benchmark story is not just the topline score. It
 ::: info What "generalization" means here
 SigMap's signature extractors are hand-written regex patterns, not ML models. Generalization
 means: *do the patterns hold up on codebases the authors never inspected?* The answer across
-these 90 tasks is yes — 80.0% hit@5 with no per-repo tuning in the latest saved v5.9 run.
+these 90 tasks is yes — 80.0% hit@5 with no per-repo tuning in the latest saved v6.0 run.
 :::
 
 - **18 repos**
@@ -67,7 +67,7 @@ SigMap uses hand-written extractors and lightweight ranking rather than a hosted
 
 ## Practical takeaway
 
-If you want one number to carry into launch messaging, use the shared `v5.9.0` snapshot rather than an older per-page variant:
+If you want one number to carry into launch messaging, use the shared `v6.0.0` snapshot rather than an older per-page variant:
 
 | Domain | Repos | Hit@5 | Example repo |
 |---|---|---|---|

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -98,6 +98,10 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 
 ## 9 available tools
 
+::: tip New in v6.3.0 — native tool registration
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 9 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+:::
+
 All tools are available on-demand — your AI agent calls only what it needs.
 
 | Tool | What it does | Arg(s) | Example call |

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -31,6 +31,10 @@ head:
 
 Latest saved run: **2026-04-19 (v6.0.0)**
 
+::: tip v6.3.0 release note
+v6.3.0 ships native tool registration for Claude Code and Codex. Retrieval numbers are unchanged from v6.0-main; the next retrieval run will follow the v6.5 Source Root Resolver milestone.
+:::
+
 **Result:** SigMap finds the right file in the top 5 far more often than chance — **80.0% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 
 ## Why this benchmark matters

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,13 +1,13 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.3, with the latest milestone adding native tool registration in AGENTS.md and CLAUDE.md for zero-config agent access.
+description: SigMap version history and roadmap. From v0.0 to v6.4, with the latest milestone syncing docs version labels, fixing the README overclaim, and upgrading the generalization benchmark to v6.0-main.
 head:
   - - meta
     - property: og:title
       content: "SigMap Roadmap — version history and upcoming features"
   - - meta
     - property: og:description
-      content: "29 versions shipped. See what changed in each release and what is coming next."
+      content: "45 versions shipped. See what changed in each release and what is coming next."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/roadmap"
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Thirty-plus versions shipped. MIT open source from day one.
+Forty-five versions shipped. MIT open source from day one.
 
 **Stats:** 96.9% overall token reduction · 722 tests passing · 29 languages · 0 npm deps
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -517,9 +517,26 @@ v6.3.0 closes the adapter-tool-wiring roadmap at Level 3: the two adapters with 
 
 ---
 
+### v6.4.0 — Trust sync ✓ (tagged v6.4.0 — 2026-04-23)
+
+v6.4.0 is a docs-only trust sync release that eliminates the visible mismatch between the live site and GitHub Releases.
+
+- **Homepage badge split** — hero pill now shows `Release: v6.4.0` and `Benchmark: sigmap-v6.0-main` as separate labels; the old conflated "Latest: v6.0" wording is gone
+- **Generalization upgrade** — `docs-vp/guide/generalization.md` upgraded from the stale v5.9-main snapshot to v6.0-main (matching all other benchmark pages)
+- **README overclaim fix** — "correct file selection every time" changed to "right file in context — 80% of the time"; top demo trimmed from 4 commands to 2
+- **v6.3.0 release callouts** — release note blocks added to benchmark, retrieval-benchmark, and task-benchmark docs explaining that numbers are unchanged pending v6.5
+- **MCP native tool callout** — `docs-vp/guide/mcp.md` now documents the v6.3 native tool registration behaviour
+- **Content-consistency test** — `test/content/v640-trust-sync.sh` (11 checks) guards against version/copy regressions in CI
+
+**Tags:** `trust-sync` · `docs` · `version-labels` · `overclaim-fix` · `generalization-upgrade`
+
+**Impact:** All benchmark docs now point to a single canonical v6.0-main snapshot; homepage no longer conflates release version with benchmark ID
+
+---
+
 ## Current milestone — v6.x
 
-v6.0–v6.3.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, and native tool registration in AGENTS.md and CLAUDE.md. Current focus: wire `sig-cache` into the main extraction pipeline as a first-class config toggle, benchmark the learning engine to measure hit@5 improvement from accumulated weights, and add community-submitted benchmark tracking to the dashboard. Public metrics are synchronised via `version.json` + `scripts/sync-versions.mjs`.
+v6.0–v6.4.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration in AGENTS.md and CLAUDE.md, and docs trust sync. Current focus: Source Root Resolver (v6.5) — a 6-module `src/discovery/` subsystem that detects framework-specific source roots and removes the need for manual `srcDirs` config in monorepos. Public metrics are synchronised via `version.json` + `scripts/sync-versions.mjs`.
 
 ---
 

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -31,6 +31,10 @@ head:
 
 Latest saved run: **2026-04-19 (v6.0.0)**
 
+::: tip v6.3.0 release note
+v6.3.0 ships native tool registration for Claude Code and Codex. Task numbers are unchanged from v6.0-main; the next task run will follow the v6.5 Source Root Resolver milestone.
+:::
+
 This page answers the question people care about most:
 
 > does SigMap help the developer finish the task with fewer retries?

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,11 +78,14 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Latest:</strong></span>
-  <span>v6.0 · graph-boosted retrieval</span>
-  <span>83.3% graph-boosted hit@5</span>
-  <span>incremental signature cache</span>
-  <span>MCP query_context upgrade</span>
+  <span><strong>Release:</strong> v6.3.0</span>
+  <span>·</span>
+  <span>native tool registration (Claude Code + Codex)</span>
+</div>
+<div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
+  <span><strong>Benchmark:</strong> sigmap-v6.0-main</span>
+  <span>·</span>
+  <span>80.0% hit@5 · 83.3% graph-boosted · 2026-04-19</span>
 </div>
 </div>
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,7 +78,7 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v6.3.0</span>
+  <span><strong>Release:</strong> v6.4.0</span>
   <span>·</span>
   <span>native tool registration (Claude Code + Codex)</span>
 </div>

--- a/gen-context.js
+++ b/gen-context.js
@@ -5387,7 +5387,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.3.0',
+  version: '6.4.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -7222,7 +7222,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.3.0';
+const VERSION = '6.4.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.3.0',
+  version: '6.4.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/content/v640-trust-sync.sh
+++ b/test/content/v640-trust-sync.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Content-consistency test for v6.4.0 trust sync changes.
+# Run from the repo root: bash test/content/v640-trust-sync.sh
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+check_absent() {
+  local desc="$1"; shift
+  if grep -qn "$@" 2>/dev/null; then fail "$desc"; else pass "$desc"; fi
+}
+
+check_present() {
+  local desc="$1"; shift
+  if grep -qn "$@" 2>/dev/null; then pass "$desc"; else fail "$desc"; fi
+}
+
+# 1. Homepage must not have bare "Latest: v6.0"
+check_absent "index.md: no bare 'Latest: v6.0'" 'Latest:.*v6\.0' docs-vp/index.md
+
+# 2. Homepage must have separate Release and Benchmark labels
+check_present "index.md: has Release label" '<strong>Release:</strong>' docs-vp/index.md
+check_present "index.md: has Benchmark label" '<strong>Benchmark:</strong>' docs-vp/index.md
+
+# 3. No v5.9-main references in generalization.md
+check_absent "generalization.md: no v5.9-main reference" 'v5\.9-main' docs-vp/guide/generalization.md
+
+# 4. generalization.md references v6.0-main
+check_present "generalization.md: has v6.0-main reference" 'v6\.0-main' docs-vp/guide/generalization.md
+
+# 5. README must not contain the overclaim phrase
+check_absent "README.md: no 'every time' overclaim" 'every time' README.md
+
+# 6. README demo section has at most 2 commands in the first bash block
+DEMO_LINES=$(awk '/^## Try it now/{f=1} f && /^---/{f=0} f' README.md | grep -c '^\(npx\|sigmap\)') || DEMO_LINES=0
+if [ "$DEMO_LINES" -le 2 ]; then pass "README.md: top demo has ≤2 commands ($DEMO_LINES)";
+else fail "README.md: top demo has $DEMO_LINES commands (expected ≤2)"; fi
+
+# 7. benchmark.md has v6.3.0 release note
+check_present "benchmark.md: has v6.3.0 release note" 'v6\.3\.0 release note' docs-vp/guide/benchmark.md
+
+# 8. retrieval-benchmark.md has v6.3.0 release note
+check_present "retrieval-benchmark.md: has v6.3.0 release note" 'v6\.3\.0 release note' docs-vp/guide/retrieval-benchmark.md
+
+# 9. task-benchmark.md has v6.3.0 release note
+check_present "task-benchmark.md: has v6.3.0 release note" 'v6\.3\.0 release note' docs-vp/guide/task-benchmark.md
+
+# 10. mcp.md has v6.3.0 native tool callout
+check_present "mcp.md: has v6.3.0 callout" 'v6\.3\.0' docs-vp/guide/mcp.md
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -95,7 +95,9 @@ test('replace: embeddings / vector DB (❌) present', () => {
 });
 
 test('replace: correct file selection (✅) present', () => {
-  assert.ok(src.includes('Correct file selection') || src.includes('correct file selection'),
+  assert.ok(
+    src.includes('Correct file selection') || src.includes('correct file selection') ||
+    src.includes('Right file in context'),
     'missing correct file selection item');
 });
 


### PR DESCRIPTION
## Summary
- Eliminates the visible version mismatch between the live site and GitHub Releases (closes #115)
- Docs-only release — no source code changes to sig extraction, retrieval, or MCP logic

## Changes
- `docs-vp/index.md`: hero badge split into separate Release (v6.4.0) and Benchmark (sigmap-v6.0-main) labels
- `docs-vp/guide/generalization.md`: upgraded v5.9-main → v6.0-main snapshot reference throughout
- `README.md`: removed "every time" overclaim from comparison table; trimmed top demo from 4 → 2 commands
- `docs-vp/guide/benchmark.md`, `retrieval-benchmark.md`, `task-benchmark.md`: added v6.3.0 release note callout blocks
- `docs-vp/guide/mcp.md`: added v6.3 native tool registration callout
- `test/content/v640-trust-sync.sh`: new bash content-consistency script with 11 checks
- `test/integration/features/readme-structure.test.js`: updated assertion for revised copy
- `package.json`, `packages/*/package.json`, `gen-context.js`, `src/mcp/server.js`: bumped to v6.4.0
- `CHANGELOG.md`, `docs-vp/guide/roadmap.md`: v6.4.0 release entry added

## Test plan
- [x] All integration tests pass (`node test/integration/all.js`) — 54 passed, 0 failed
- [x] Content-consistency test passes (`bash test/content/v640-trust-sync.sh`) — 11 passed, 0 failed
- [x] Manual smoke test: `node gen-context.js --health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)