### PR TITLE
feat: add JVM project structure srcDirs + v6.6.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.6.1] — 2026-04-27
+
+### Added
+
+- **JVM project structure support** — Added auto-detection of Java, Kotlin, and Scala project directories. `srcDirs` now includes `src/main/java`, `src/main/kotlin`, `src/main/scala`, `app/src/main/java`, `app/src/main/kotlin`, `src/test/java`, and `src/test/kotlin` for out-of-the-box support of JVM-based projects.
+
+---
+
 ## [6.6.0] — 2026-04-27
 
 ### Added

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.6.0, with the latest features adding session memory, plan command, 2-hop graph boost, hub suppression, incremental signature cache, and cache health statistics.
+description: SigMap version history and roadmap. From v0.0 to v6.6.1, with the latest features adding JVM project structure detection, session memory, plan command, 2-hop graph boost, hub suppression, incremental signature cache, and cache health statistics.
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Forty-eight versions shipped. MIT open source from day one.
+Forty-nine versions shipped. MIT open source from day one.
 
 **Stats:** 96.9% overall token reduction · 722 tests passing · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -594,9 +594,19 @@ Cross-session context carry-forward with topic-switch guard and change-impact an
 
 ---
 
+### v6.6.1 — JVM project structure detection ✓ (tagged v6.6.1 — 2026-04-27)
+
+Added out-of-the-box support for Java, Kotlin, and Scala projects through intelligent detection of JVM convention directories. `srcDirs` configuration now includes Maven/Gradle standard paths (`src/main/java`, `src/main/kotlin`, `src/main/scala`, `app/src/main/java`, `app/src/main/kotlin`) and common test locations (`src/test/java`, `src/test/kotlin`). Patch release with no benchmark changes.
+
+**Tags:** `JVM support` · `Java detection` · `Kotlin detection` · `Scala detection` · `srcDirs` · `auto-detection`
+
+**Impact:** Eliminates manual configuration for JVM-based projects. Developers can now run `sigmap` immediately on Spring Boot, Micronaut, Quarkus, and Kotlin codebases.
+
+---
+
 ## Current milestone — v6.7+
 
-v6.0–v6.6.0 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, and cross-session context memory with impact planning. Next: performance optimizations for large repos and extended language/framework coverage.
+v6.0–v6.6.1 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, and JVM project structure auto-detection. Next: performance optimizations for large repos and extended language/framework coverage.
 
 ---
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -5387,7 +5387,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.6.0',
+  version: '6.6.1',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -7855,7 +7855,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.6.0';
+const VERSION = '6.6.1';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -26,6 +26,10 @@ const DEFAULTS = {
     'pages', 'components', 'hooks', 'routes', 'controllers',
     'models', 'views', 'resources', 'config', 'db',
     'projects', 'apps', 'libs', 'instance', 'blueprints',
+    // JVM project structures (Java, Kotlin, Scala)
+    'src/main/java', 'src/main/kotlin', 'src/main/scala',
+    'app/src/main/java', 'app/src/main/kotlin',
+    'src/test/java', 'src/test/kotlin',
   ],
 
   // Directory/file names to exclude entirely

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.6.0',
+  version: '6.6.1',
   description: 'SigMap MCP server — code signatures on demand',
 };
 


### PR DESCRIPTION
## Summary

- Add JVM project structure srcDirs (Java, Kotlin, Scala) for out-of-the-box project support
- Release v6.6.1 patch version with configuration enhancement

## Changes

- : Added 7 JVM convention directories (src/main/java, src/main/kotlin, src/main/scala, app/src/main/java, app/src/main/kotlin, src/test/java, src/test/kotlin)
- : Bumped version to 6.6.1
- : Synced version to 6.6.1
- : Synced version to 6.6.1
- : Updated VERSION constant to 6.6.1
- : Added v6.6.1 release notes
- : Version synced

## Test plan

- [x] All integration tests pass (57 passed, 0 failures)
- [x] Manual smoke test: `node gen-context.js --health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)