### PR TITLE
refactor: extract JVM path pattern as constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.6.4] — 2026-04-29
+
+### Changed
+
+- **JVM path pattern refactor** — Extracted JVM path regex pattern into a reusable constant `JVM_PATH_PATTERN` in source-root-scorer.js for improved testability and reusability. No behavior changes.
+
+---
+
 ## [6.6.3] — 2026-04-29
 
 ### Fixed

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -450,7 +450,7 @@ sigmap bench --submit --json
 ────────────────────────────────────────────────────────
  SigMap Community Benchmark Submission
 ────────────────────────────────────────────────────────
- SigMap version : 6.6.3
+ SigMap version : 6.6.4
  Benchmark ID   : sigmap-v6.5-main
  Submitted      : 2026-04-27
 ────────────────────────────────────────────────────────
@@ -471,7 +471,7 @@ JSON output (`--json`) returns a machine-readable object:
 
 ```json
 {
-  "sigmapVersion": "6.6.3",
+  "sigmapVersion": "6.6.4",
   "benchmarkId": "sigmap-v6.5-main",
   "canonicalHitAt5": 81.1,
   "canonicalReduction": 96.9,

--- a/gen-context.js
+++ b/gen-context.js
@@ -5387,7 +5387,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.6.3',
+  version: '6.6.4',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -7855,7 +7855,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.6.3';
+const VERSION = '6.6.4';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/discovery/source-root-scorer.js
+++ b/src/discovery/source-root-scorer.js
@@ -22,6 +22,8 @@ const PENALTY_DIRS = new Set([
   'benchmarks','scripts',
 ]);
 
+const JVM_PATH_PATTERN = /^(src\/main\/(java|kotlin|scala)|app\/src\/main\/(java|kotlin|scala))$/;
+
 const ROOT_ENTRYPOINTS = {
   go:         ['main.go'],
   python:     ['app.py','main.py','wsgi.py','asgi.py'],
@@ -48,7 +50,7 @@ function scoreCandidate(dirName, fullPath, context) {
   let score = 0;
 
   // JVM paths (Java, Kotlin, Scala) get highest priority: +5.0
-  if (/^(src\/main\/(java|kotlin|scala)|app\/src\/main\/(java|kotlin|scala))$/.test(dirName)) score += 5.0;
+  if (JVM_PATH_PATTERN.test(dirName)) score += 5.0;
 
   // Framework match: +3.0 if this dir is in the framework's srcDirs
   if (frameworkSrcDirs.has(dirName)) score += 3.0;
@@ -98,4 +100,4 @@ function _countSourceFiles(dir, depth) {
   return count;
 }
 
-module.exports = { scoreCandidate, getRecentlyChangedDirs, ROOT_ENTRYPOINTS };
+module.exports = { scoreCandidate, getRecentlyChangedDirs, ROOT_ENTRYPOINTS, JVM_PATH_PATTERN };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.6.3',
+  version: '6.6.4',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/v650-source-root-resolver.test.js
+++ b/test/integration/v650-source-root-resolver.test.js
@@ -8,7 +8,7 @@ const os = require('os');
 const { resolveSourceRoots } = require('../../src/discovery/source-root-resolver');
 const { detectLanguages }     = require('../../src/discovery/language-detector');
 const { detectFrameworks }    = require('../../src/discovery/framework-detector');
-const { scoreCandidate }      = require('../../src/discovery/source-root-scorer');
+const { scoreCandidate, JVM_PATH_PATTERN }      = require('../../src/discovery/source-root-scorer');
 const { loadIgnorePatterns, matchesIgnorePattern } = require('../../src/discovery/sigmapignore');
 
 function makeRepo(files) {
@@ -445,6 +445,29 @@ test('scoreCandidate gives +5.0 bonus to app/src/main/scala', () => {
   const ctx = { frameworks: [], languages: [], recentDirs: new Set(), frameworkSrcDirs: new Set(), entrypoints: [], frameworkPenalties: [] };
   const score = scoreCandidate('app/src/main/scala', path.join(cwd, 'app/src/main/scala'), ctx);
   assert(score >= 5.0, `app/src/main/scala should get +5.0 bonus, got ${score}`);
+});
+
+test('JVM_PATH_PATTERN is exported from source-root-scorer', () => {
+  assert(JVM_PATH_PATTERN instanceof RegExp, 'JVM_PATH_PATTERN should be a RegExp');
+});
+
+test('JVM_PATH_PATTERN matches src/main/ JVM paths', () => {
+  assert(JVM_PATH_PATTERN.test('src/main/java'), 'should match src/main/java');
+  assert(JVM_PATH_PATTERN.test('src/main/kotlin'), 'should match src/main/kotlin');
+  assert(JVM_PATH_PATTERN.test('src/main/scala'), 'should match src/main/scala');
+});
+
+test('JVM_PATH_PATTERN matches app/src/main/ JVM paths', () => {
+  assert(JVM_PATH_PATTERN.test('app/src/main/java'), 'should match app/src/main/java');
+  assert(JVM_PATH_PATTERN.test('app/src/main/kotlin'), 'should match app/src/main/kotlin');
+  assert(JVM_PATH_PATTERN.test('app/src/main/scala'), 'should match app/src/main/scala');
+});
+
+test('JVM_PATH_PATTERN rejects non-JVM paths', () => {
+  assert(!JVM_PATH_PATTERN.test('src/main/python'), 'should not match src/main/python');
+  assert(!JVM_PATH_PATTERN.test('src/test/java'), 'should not match src/test/java');
+  assert(!JVM_PATH_PATTERN.test('app/main/java'), 'should not match app/main/java');
+  assert(!JVM_PATH_PATTERN.test('src'), 'should not match bare src');
 });
 
 console.log('\nAll tests passed!');


### PR DESCRIPTION
## Summary
- Extracted JVM path regex pattern into a reusable constant `JVM_PATH_PATTERN` in source-root-scorer.js
- Improves code maintainability and testability
- No behavior changes — all existing tests pass

Closes #131

## Changes
- **src/discovery/source-root-scorer.js**: Extract pattern constant and export it
- **test/integration/v650-source-root-resolver.test.js**: Add 4 tests validating the pattern
- **Version bump**: 6.6.3 → 6.6.4 (patch release)

## Test plan
- [x] All 58 integration tests pass (`node test/integration/all.js`)
- [x] Manual smoke test: `node gen-context.js --health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)