### PR TITLE
feat: enhance monorepo support for JVM project structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.6.5] — 2026-04-30
+
+### Added
+
+- **Monorepo JVM project detection** — Enhanced source root resolver to detect `src/main/{java,kotlin,scala}` and `app/src/main/{java,kotlin,scala}` in monorepo workspace packages (packages/*, apps/*, services/*, modules/*). Added `src/test/{java,kotlin}` and `app/src/main/scala` to DEEP_PATHS for consistent detection across monorepo and non-monorepo structures.
+
+---
+
 ## [6.6.4] — 2026-04-29
 
 ### Changed

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -450,7 +450,7 @@ sigmap bench --submit --json
 ────────────────────────────────────────────────────────
  SigMap Community Benchmark Submission
 ────────────────────────────────────────────────────────
- SigMap version : 6.6.4
+ SigMap version : 6.6.5
  Benchmark ID   : sigmap-v6.5-main
  Submitted      : 2026-04-27
 ────────────────────────────────────────────────────────
@@ -471,7 +471,7 @@ JSON output (`--json`) returns a machine-readable object:
 
 ```json
 {
-  "sigmapVersion": "6.6.4",
+  "sigmapVersion": "6.6.5",
   "benchmarkId": "sigmap-v6.5-main",
   "canonicalHitAt5": 81.1,
   "canonicalReduction": 96.9,

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,13 +1,13 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.6.3, with the latest features adding comprehensive srcDirs validation, JVM project structure detection, session memory, plan command, 2-hop graph boost, hub suppression, incremental signature cache, and cache health statistics.
+description: SigMap version history and roadmap. From v0.0 to v6.6.5, with the latest features adding monorepo JVM detection, comprehensive srcDirs validation, JVM project structure detection, session memory, plan command, 2-hop graph boost, hub suppression, incremental signature cache, and cache health statistics.
 head:
   - - meta
     - property: og:title
       content: "SigMap Roadmap — version history and upcoming features"
   - - meta
     - property: og:description
-      content: "49 versions shipped. See what changed in each release and what is coming next."
+      content: "51 versions shipped. See what changed in each release and what is coming next."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/roadmap"
@@ -604,19 +604,19 @@ Added out-of-the-box support for Java, Kotlin, and Scala projects through intell
 
 ---
 
-### v6.6.2–v6.6.3 — srcDirs validation & test coverage ✓ (latest patch: v6.6.3 — 2026-04-29)
+### v6.6.2–v6.6.5 — srcDirs validation, JVM pattern refactor & monorepo support ✓ (latest: v6.6.5 — 2026-04-30)
 
-Comprehensive validation of srcDirs configuration with 10 integration tests ensuring all source directory paths (including JVM structures) are correctly defined, bundled, and accessible. Tests verify: array structure, common directories (src, app, lib), framework conventions (Next.js pages, components), JVM paths (src/main/java, Kotlin, Scala, test directories), reasonable count (25–50 entries), load via loadConfig(), no duplicates, valid relative paths, proper JVM formatting, and safe exclusions (no node_modules, .git, dist).
+Comprehensive validation of srcDirs configuration with comprehensive JVM project support. v6.6.2 added 10 integration tests ensuring all source directory paths (including JVM structures) are correctly defined. v6.6.3 fixed Scala detection in app/src/main/ pattern. v6.6.4 extracted JVM path pattern as a reusable constant for improved testability. v6.6.5 enhanced monorepo support to detect `src/main/{java,kotlin,scala}` and `app/src/main/{java,kotlin,scala}` in workspace packages (packages/*, apps/*, services/*, modules/*), ensuring JVM projects in monorepo structures are properly discovered.
 
-**Tags:** `srcDirs validation` · `integration tests` · `JVM paths` · `configuration consistency` · `test coverage`
+**Tags:** `srcDirs validation` · `JVM path detection` · `monorepo support` · `integration tests` · `configuration consistency`
 
-**Impact:** All 58 integration tests passing. srcDirs configuration now machine-verified on every CI run. Catch misconfiguration of source directories before runtime.
+**Impact:** All 58 integration tests passing. srcDirs configuration machine-verified on every CI run. JVM project detection now works seamlessly across monorepo and non-monorepo structures. Catch misconfiguration of source directories before runtime.
 
 ---
 
 ## Current milestone — v6.7+
 
-v6.0–v6.6.1 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, and JVM project structure auto-detection. Next: performance optimizations for large repos and extended language/framework coverage.
+v6.0–v6.6.5 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, JVM project structure auto-detection, and enhanced monorepo JVM support for workspace packages. Next: performance optimizations for large repos and extended language/framework coverage.
 
 ---
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -5387,7 +5387,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.6.4',
+  version: '6.6.5',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -7855,7 +7855,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.6.4';
+const VERSION = '6.6.5';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.6.4",
+  "version": "6.6.5",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.6.4",
+  "version": "6.6.5",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.6.4",
+  "version": "6.6.5",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/discovery/source-root-resolver.js
+++ b/src/discovery/source-root-resolver.js
@@ -110,6 +110,18 @@ function _enumerateCandidates(cwd, isMonorepo, ignorePatterns, excludeList) {
           }
           // Also consider the package root itself
           candidates.push({ name: `${top}/${pkg.name}`, full: path.join(topFull, pkg.name) });
+
+          // JVM project structures in monorepo packages (Java, Kotlin, Scala)
+          for (const jvmLang of ['java', 'kotlin', 'scala']) {
+            const srcMainJvm = path.join(topFull, pkg.name, 'src', 'main', jvmLang);
+            if (fs.existsSync(srcMainJvm)) {
+              candidates.push({ name: `${top}/${pkg.name}/src/main/${jvmLang}`, full: srcMainJvm });
+            }
+            const appSrcMainJvm = path.join(topFull, pkg.name, 'app', 'src', 'main', jvmLang);
+            if (fs.existsSync(appSrcMainJvm)) {
+              candidates.push({ name: `${top}/${pkg.name}/app/src/main/${jvmLang}`, full: appSrcMainJvm });
+            }
+          }
         }
       } catch (_) {}
     }
@@ -118,7 +130,8 @@ function _enumerateCandidates(cwd, isMonorepo, ignorePatterns, excludeList) {
   // Deep paths known by language/framework (e.g. src/main/java, src-tauri/src)
   const DEEP_PATHS = [
     'src/main/java','src/main/kotlin','src/main/scala',
-    'src-tauri/src','Sources/App','app/src/main/java','app/src/main/kotlin',
+    'src-tauri/src','Sources/App','app/src/main/java','app/src/main/kotlin','app/src/main/scala',
+    'src/test/java','src/test/kotlin',
   ];
   for (const dp of DEEP_PATHS) {
     const full = path.join(cwd, dp);

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.6.4',
+  version: '6.6.5',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/v650-source-root-resolver.test.js
+++ b/test/integration/v650-source-root-resolver.test.js
@@ -470,4 +470,45 @@ test('JVM_PATH_PATTERN rejects non-JVM paths', () => {
   assert(!JVM_PATH_PATTERN.test('src'), 'should not match bare src');
 });
 
+test('resolveSourceRoots detects JVM paths in monorepo packages', () => {
+  const cwd = makeRepo({
+    'pnpm-workspace.yaml': 'packages:\n  - packages/*',
+    'packages/api/package.json': '{"name": "api"}',
+    'packages/api/src/main/java/App.java': 'class App {}',
+    'packages/api/src/main/kotlin/Config.kt': 'object Config',
+    'packages/api/src/main/java/utils/Helper.java': 'class Helper {}',
+    'packages/api/src/main/java/models/Model.java': 'class Model {}',
+  });
+  const result = resolveSourceRoots(cwd);
+  assert(result.isMonorepo === true, 'should detect pnpm monorepo');
+  assert(result.roots.length > 0, 'should find at least one root');
+  // JVM paths in monorepo should be in explanation or roots
+  const hasJvmPath = result.explanation.some(e => e.dir.includes('packages/api') && (e.dir.includes('java') || e.dir.includes('kotlin')));
+  assert(hasJvmPath, 'should detect JVM paths in monorepo explanation');
+});
+
+test('resolveSourceRoots detects app/src/main JVM paths in monorepo', () => {
+  const cwd = makeRepo({
+    'pnpm-workspace.yaml': 'packages:\n  - apps/*',
+    'apps/backend/package.json': '{"name": "backend"}',
+    'apps/backend/app/src/main/scala/Main.scala': 'object Main',
+    'apps/backend/app/src/main/scala/core/Engine.scala': 'class Engine',
+  });
+  const result = resolveSourceRoots(cwd);
+  assert(result.isMonorepo === true, 'should detect monorepo');
+  // JVM paths should be scored and appear in explanation
+  const hasScalaPath = result.explanation.some(e => e.dir.includes('apps/backend') && e.dir.includes('scala'));
+  assert(hasScalaPath, 'should detect Scala paths in monorepo explanation');
+});
+
+test('resolveSourceRoots includes test JVM paths in DEEP_PATHS', () => {
+  const cwd = makeRepo({
+    'src/test/java/AppTest.java': '',
+    'src/test/kotlin/ConfigTest.kt': '',
+  });
+  const result = resolveSourceRoots(cwd);
+  assert(result.roots.some(r => r === 'src/test/java'), 'should find src/test/java');
+  assert(result.roots.some(r => r === 'src/test/kotlin'), 'should find src/test/kotlin');
+});
+
 console.log('\nAll tests passed!');


### PR DESCRIPTION
## Summary
- Enhanced source root resolver to detect JVM projects in monorepo workspace packages
- Added detection for `src/main/{java,kotlin,scala}` and `app/src/main/{java,kotlin,scala}` in packages/*, apps/*, services/*, modules/* directories
- Updated DEEP_PATHS to include `src/test/{java,kotlin}` and `app/src/main/scala` for consistent detection

Closes #133

## Changes
- **src/discovery/source-root-resolver.js**: Added JVM path detection in monorepo packages
- **test/integration/v650-source-root-resolver.test.js**: Added 3 tests for monorepo JVM detection
- **Version bump**: 6.6.4 → 6.6.5 (patch release)

## Test plan
- [x] All 58 integration tests pass (`node test/integration/all.js`)
- [x] Manual smoke test: `node gen-context.js --health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)