### PR TITLE
feat: native Python AST extractor for accurate signature extraction

### DIFF
--- a/src/extractors/python.js
+++ b/src/extractors/python.js
@@ -1,11 +1,42 @@
 'use strict';
 
+const path = require('path');
+
+/**
+ * Try to extract signatures using the native Python AST extractor.
+ * Returns null if Python3 is unavailable or the script returns empty results.
+ * @param {string} filePath - Absolute path to the Python file
+ * @returns {string[]|null}
+ */
+function tryNativeExtract(filePath) {
+  try {
+    const { execFileSync } = require('child_process');
+    const scriptPath = path.join(__dirname, 'python_ast.py');
+    const result = execFileSync('python3', [scriptPath, filePath], {
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    const sigs = JSON.parse(result.trim());
+    if (Array.isArray(sigs) && sigs.length > 0) return sigs;
+  } catch (_) {}
+  return null;
+}
+
 /**
  * Extract signatures from Python source code.
+ * When a real file path is provided, tries the native Python AST extractor first
+ * (more accurate for multiline signatures, stacked decorators, and type annotations).
+ * Falls back to the regex approach if Python3 is unavailable or returns no results.
  * @param {string} src - Raw file content
+ * @param {string} [filePath] - Optional absolute path to the source file
  * @returns {string[]} Array of signature strings
  */
-function extract(src) {
+function extract(src, filePath) {
+  // Prefer native AST extractor when a real file path is available
+  if (filePath && typeof filePath === 'string') {
+    const native = tryNativeExtract(filePath);
+    if (native) return native;
+  }
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
 
@@ -200,4 +231,4 @@ function extractDocHint(src, fnName, fnSigLine) {
   return sentence.slice(0, 60);
 }
 
-module.exports = { extract };
+module.exports = { extract, tryNativeExtract };

--- a/src/extractors/python_ast.py
+++ b/src/extractors/python_ast.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+python_ast.py — Native Python AST-based signature extractor for SigMap.
+
+More accurate than the JS regex approach:
+- Handles multiline signatures correctly
+- Decorator stacking resolved properly
+- Type annotations extracted from AST nodes
+- No false positives from regex on string contents
+
+Usage (called by SigMap's python.js extractor as fallback):
+    python3 python_ast.py <filepath>
+
+Output: JSON array of signature strings (one per line → stdout)
+"""
+
+import ast
+import json
+import sys
+
+MAX_SIGS = 30
+
+
+def annotation_to_str(node):
+    """Convert an AST annotation node to a string representation."""
+    if node is None:
+        return None
+    try:
+        return ast.unparse(node)
+    except Exception:
+        # Fallback for older Python versions without ast.unparse
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            return f"{annotation_to_str(node.value)}.{node.attr}"
+        if isinstance(node, ast.Subscript):
+            val = annotation_to_str(node.value)
+            slc = annotation_to_str(node.slice)
+            return f"{val}[{slc}]"
+        if isinstance(node, ast.Index):
+            return annotation_to_str(node.value)
+        if isinstance(node, ast.Tuple):
+            parts = ", ".join(annotation_to_str(e) for e in node.elts)
+            return parts
+        if isinstance(node, ast.Constant):
+            return repr(node.value)
+        return "..."
+
+
+def format_args(args_node):
+    """Format a function arguments node into a compact signature string."""
+    parts = []
+    all_args = args_node.args or []
+    defaults = args_node.defaults or []
+    # Align defaults to the right of args
+    default_offset = len(all_args) - len(defaults)
+
+    for i, arg in enumerate(all_args):
+        name = arg.arg
+        ann = annotation_to_str(arg.annotation) if arg.annotation else None
+        default_idx = i - default_offset
+        has_default = default_idx >= 0
+        token = name
+        if ann:
+            token = f"{name}: {ann}"
+        if has_default:
+            token = f"{token}=..."
+        parts.append(token)
+
+    # *args
+    vararg = args_node.vararg
+    if vararg:
+        ann = annotation_to_str(vararg.annotation) if vararg.annotation else None
+        token = f"*{vararg.arg}"
+        if ann:
+            token = f"*{vararg.arg}: {ann}"
+        parts.append(token)
+
+    # keyword-only args
+    kwonly = args_node.kwonlyargs or []
+    kw_defaults = args_node.kw_defaults or []
+    for i, arg in enumerate(kwonly):
+        name = arg.arg
+        ann = annotation_to_str(arg.annotation) if arg.annotation else None
+        has_default = i < len(kw_defaults) and kw_defaults[i] is not None
+        token = name
+        if ann:
+            token = f"{name}: {ann}"
+        if has_default:
+            token = f"{token}=..."
+        parts.append(token)
+
+    # **kwargs
+    kwarg = args_node.kwarg
+    if kwarg:
+        ann = annotation_to_str(kwarg.annotation) if kwarg.annotation else None
+        token = f"**{kwarg.arg}"
+        if ann:
+            token = f"**{kwarg.arg}: {ann}"
+        parts.append(token)
+
+    return ", ".join(parts)
+
+
+def get_decorator_names(node):
+    """Return a list of decorator name strings for a function/class node."""
+    names = []
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name):
+            names.append(dec.id)
+        elif isinstance(dec, ast.Attribute):
+            names.append(dec.attr)
+        elif isinstance(dec, ast.Call):
+            func = dec.func
+            if isinstance(func, ast.Name):
+                names.append(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.append(func.attr)
+    return names
+
+
+def is_dataclass(node):
+    return "dataclass" in get_decorator_names(node)
+
+
+def is_basemodel(bases):
+    """Check if class bases include BaseModel or BaseSettings."""
+    for base in bases:
+        name = annotation_to_str(base) or ""
+        if "BaseModel" in name or "BaseSettings" in name:
+            return True
+    return False
+
+
+def get_docstring_hint(node):
+    """Extract first sentence of docstring, if present."""
+    try:
+        doc = ast.get_docstring(node)
+        if doc:
+            first_line = doc.strip().splitlines()[0]
+            return first_line[:60] if len(first_line) > 60 else first_line
+    except Exception:
+        pass
+    return None
+
+
+def extract_dataclass_fields(class_node):
+    """Return a collapsed fields string for a @dataclass class."""
+    fields = []
+    for stmt in class_node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            name = stmt.target.target.id if hasattr(stmt.target, 'target') else stmt.target.id
+            ann_str = annotation_to_str(stmt.annotation) if stmt.annotation else ""
+            # Optional if annotation contains Optional or has a default
+            is_optional = (
+                "Optional" in ann_str
+                or "None" in ann_str
+                or stmt.value is not None
+            )
+            suffix = "?" if is_optional else ""
+            fields.append(f"{name}{suffix}")
+    return ", ".join(fields)
+
+
+def extract_basemodel_fields(class_node):
+    """Return a compact {required*, optional?} string for a BaseModel subclass."""
+    req = []
+    opt = []
+    for stmt in class_node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            name = stmt.target.id
+            ann_str = annotation_to_str(stmt.annotation) if stmt.annotation else ""
+            has_default = stmt.value is not None
+            is_optional = "Optional" in ann_str or "None" in ann_str or has_default
+            if is_optional:
+                opt.append(f"{name}?")
+            else:
+                req.append(f"{name}*")
+    all_fields = req + opt
+    if not all_fields:
+        return None
+    return "{" + ", ".join(all_fields) + "}"
+
+
+def extract_class_constants(class_node):
+    """Yield ALL_CAPS constant assignments from class body."""
+    for stmt in class_node.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id.isupper():
+                    try:
+                        val = ast.unparse(stmt.value)
+                    except Exception:
+                        val = "..."
+                    yield f"{target.id}={val}"
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            name = stmt.target.id
+            if name.isupper():
+                val = "..."
+                if stmt.value:
+                    try:
+                        val = ast.unparse(stmt.value)
+                    except Exception:
+                        pass
+                yield f"{name}={val}"
+
+
+def extract_method_sig(func_node):
+    """Format a method signature string (already indented by caller)."""
+    is_async = isinstance(func_node, ast.AsyncFunctionDef)
+    prefix = "async " if is_async else ""
+    params = format_args(func_node.args)
+    ret = annotation_to_str(func_node.returns) if func_node.returns else None
+    ret_str = f" → {ret}" if ret else ""
+    return f"{prefix}def {func_node.name}({params}){ret_str}"
+
+
+def extract_function_sig(func_node, src_lines=None):
+    """Format a top-level function signature string."""
+    is_async = isinstance(func_node, ast.AsyncFunctionDef)
+    prefix = "async " if is_async else ""
+    params = format_args(func_node.args)
+    ret = annotation_to_str(func_node.returns) if func_node.returns else None
+    ret_str = f" → {ret}" if ret else ""
+    hint = get_docstring_hint(func_node)
+    hint_str = f"  # {hint}" if hint else ""
+    return f"{prefix}def {func_node.name}({params}){ret_str}{hint_str}"
+
+
+def extract_fastapi_routes(tree, src_lines):
+    """Extract FastAPI route signatures from decorated functions."""
+    routes = []
+    http_methods = {"get", "post", "put", "patch", "delete", "head"}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            if not isinstance(dec, ast.Call):
+                continue
+            func = dec.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            method = func.attr.lower()
+            if method not in http_methods:
+                continue
+            if dec.args:
+                path_node = dec.args[0]
+                if isinstance(path_node, ast.Constant):
+                    path = path_node.value
+                    routes.append(f"{method.upper()} {path}  →  {node.name}()")
+    return routes
+
+
+def extract(filepath):
+    with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+        src = f.read()
+
+    tree = ast.parse(src, filename=filepath)
+    src_lines = src.splitlines()
+    sigs = []
+
+    # Walk top-level statements only
+    for node in tree.body:
+        if len(sigs) >= MAX_SIGS:
+            break
+
+        # Classes
+        if isinstance(node, ast.ClassDef):
+            bases_str = ", ".join(annotation_to_str(b) for b in node.bases if b)
+            dec_names = get_decorator_names(node)
+
+            if is_dataclass(node):
+                fields = extract_dataclass_fields(node)
+                sigs.append(f"@dataclass {node.name}({fields})")
+            elif is_basemodel(node.bases):
+                bm_fields = extract_basemodel_fields(node)
+                base_label = next(
+                    (annotation_to_str(b) for b in node.bases
+                     if "BaseModel" in (annotation_to_str(b) or "") or "BaseSettings" in (annotation_to_str(b) or "")),
+                    "BaseModel"
+                )
+                if bm_fields:
+                    sigs.append(f"class {node.name}({base_label}) {bm_fields}")
+                else:
+                    sigs.append(f"class {node.name}({base_label})")
+            else:
+                base_part = f"({bases_str})" if bases_str else ""
+                sigs.append(f"class {node.name}{base_part}")
+
+            # Class constants
+            for const in extract_class_constants(node):
+                if len(sigs) >= MAX_SIGS:
+                    break
+                sigs.append(f"  {const}")
+
+            # Methods (skip private except __init__, skip all other dunder)
+            for stmt in node.body:
+                if len(sigs) >= MAX_SIGS:
+                    break
+                if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                name = stmt.name
+                if name.startswith("_") and name != "__init__":
+                    continue
+                sigs.append(f"  {extract_method_sig(stmt)}")
+
+        # Top-level functions
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.startswith("_"):
+                continue
+            sigs.append(extract_function_sig(node, src_lines))
+
+    # FastAPI routes (walk full tree for decorated functions)
+    routes = extract_fastapi_routes(tree, src_lines)
+    for route in routes:
+        if len(sigs) >= MAX_SIGS:
+            break
+        if route not in sigs:
+            sigs.append(route)
+
+    return sigs[:MAX_SIGS]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("[]")
+        return
+
+    filepath = sys.argv[1]
+    try:
+        sigs = extract(filepath)
+        print(json.dumps(sigs))
+    except Exception:
+        print("[]")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/extractors/python_ast.py
+++ b/src/extractors/python_ast.py
@@ -19,6 +19,7 @@ import json
 import sys
 
 MAX_SIGS = 30
+MAX_DOC_HINT_LEN = 60
 
 
 def annotation_to_str(node):
@@ -132,13 +133,26 @@ def is_basemodel(bases):
     return False
 
 
+def is_optional_annotation(annotation):
+    """Check if an annotation represents an Optional type."""
+    if annotation is None:
+        return False
+    ann_str = annotation_to_str(annotation) or ""
+    return (
+        "Optional[" in ann_str
+        or ("Union[" in ann_str and "None" in ann_str)
+        or "| None" in ann_str
+        or "None |" in ann_str
+    )
+
+
 def get_docstring_hint(node):
     """Extract first sentence of docstring, if present."""
     try:
         doc = ast.get_docstring(node)
         if doc:
             first_line = doc.strip().splitlines()[0]
-            return first_line[:60] if len(first_line) > 60 else first_line
+            return first_line[:MAX_DOC_HINT_LEN] if len(first_line) > MAX_DOC_HINT_LEN else first_line
     except Exception:
         pass
     return None
@@ -149,14 +163,9 @@ def extract_dataclass_fields(class_node):
     fields = []
     for stmt in class_node.body:
         if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-            name = stmt.target.target.id if hasattr(stmt.target, 'target') else stmt.target.id
-            ann_str = annotation_to_str(stmt.annotation) if stmt.annotation else ""
-            # Optional if annotation contains Optional or has a default
-            is_optional = (
-                "Optional" in ann_str
-                or "None" in ann_str
-                or stmt.value is not None
-            )
+            name = stmt.target.id
+            has_default = stmt.value is not None
+            is_optional = is_optional_annotation(stmt.annotation) or has_default
             suffix = "?" if is_optional else ""
             fields.append(f"{name}{suffix}")
     return ", ".join(fields)
@@ -169,9 +178,8 @@ def extract_basemodel_fields(class_node):
     for stmt in class_node.body:
         if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
             name = stmt.target.id
-            ann_str = annotation_to_str(stmt.annotation) if stmt.annotation else ""
             has_default = stmt.value is not None
-            is_optional = "Optional" in ann_str or "None" in ann_str or has_default
+            is_optional = is_optional_annotation(stmt.annotation) or has_default
             if is_optional:
                 opt.append(f"{name}?")
             else:
@@ -228,10 +236,10 @@ def extract_function_sig(func_node, src_lines=None):
 
 
 def extract_fastapi_routes(tree, src_lines):
-    """Extract FastAPI route signatures from decorated functions."""
+    """Extract FastAPI route signatures from top-level decorated functions only."""
     routes = []
     http_methods = {"get", "post", "put", "patch", "delete", "head"}
-    for node in ast.walk(tree):
+    for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         for dec in node.decorator_list:
@@ -310,13 +318,15 @@ def extract(filepath):
                 continue
             sigs.append(extract_function_sig(node, src_lines))
 
-    # FastAPI routes (walk full tree for decorated functions)
+    # FastAPI routes (extract top-level decorated functions)
     routes = extract_fastapi_routes(tree, src_lines)
+    seen_sigs = set(sigs)
     for route in routes:
         if len(sigs) >= MAX_SIGS:
             break
-        if route not in sigs:
+        if route not in seen_sigs:
             sigs.append(route)
+            seen_sigs.add(route)
 
     return sigs[:MAX_SIGS]
 

--- a/tests/test_python_ast_extractor.py
+++ b/tests/test_python_ast_extractor.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+test_python_ast_extractor.py — Tests for python_ast.py native extractor.
+
+Covers: dataclasses, BaseModel fields, multiline signatures, private functions,
+syntax errors, signature cap, and nested function behavior.
+"""
+
+import ast
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class TestPythonASTExtractor(unittest.TestCase):
+    """Test the python_ast.py signature extractor."""
+
+    def run_extractor(self, code):
+        """Write code to temp file, run extractor, parse output."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+            f.write(code)
+            filepath = f.name
+
+        try:
+            # Get the extractor path
+            extractor = os.path.join(os.path.dirname(__file__), '..', 'src', 'extractors', 'python_ast.py')
+            result = subprocess.run(
+                [sys.executable, extractor, filepath],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return json.loads(result.stdout.strip())
+            return []
+        finally:
+            os.unlink(filepath)
+
+    def test_dataclass_with_optional_fields(self):
+        """Dataclass with Optional, | None, and default values."""
+        code = '''
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class User:
+    id: int
+    name: str | None
+    email: Optional[str]
+    age: int = 0
+'''
+        sigs = self.run_extractor(code)
+        self.assertTrue(any('@dataclass' in s for s in sigs), "Should have @dataclass signature")
+        dc_sig = next(s for s in sigs if '@dataclass' in s)
+        self.assertIn('id', dc_sig)
+        self.assertIn('name?', dc_sig, "name should be marked optional")
+        self.assertIn('email?', dc_sig, "email should be marked optional")
+        self.assertIn('age?', dc_sig, "age has default so should be optional")
+
+    def test_basemodel_fields(self):
+        """Pydantic BaseModel with required and optional fields."""
+        code = '''
+from pydantic import BaseModel
+from typing import Optional
+
+class UserModel(BaseModel):
+    id: int
+    name: str | None
+    email: Optional[str] = None
+    active: bool = True
+'''
+        sigs = self.run_extractor(code)
+        self.assertTrue(any('UserModel' in s and 'BaseModel' in s for s in sigs),
+                       "Should have UserModel(BaseModel) signature")
+        bm_sig = next(s for s in sigs if 'UserModel' in s)
+        self.assertIn('{', bm_sig, "Should have field list in braces")
+        self.assertIn('id*', bm_sig, "id is required")
+        self.assertIn('name?', bm_sig, "name is optional")
+        self.assertIn('email?', bm_sig, "email is optional")
+
+    def test_multiline_function_signature(self):
+        """Function with parameters spanning multiple lines."""
+        code = '''
+def process_data(
+    filepath: str,
+    delimiter: str = ",",
+    skip_rows: int = 0,
+    encoding: str = "utf-8"
+) -> dict:
+    """Process a CSV file."""
+    return {}
+'''
+        sigs = self.run_extractor(code)
+        func_sig = next((s for s in sigs if 'process_data' in s), None)
+        self.assertIsNotNone(func_sig, "Should extract multiline signature")
+        self.assertIn('filepath', func_sig)
+        self.assertIn('delimiter', func_sig)
+        self.assertIn('skip_rows', func_sig)
+        self.assertIn('encoding', func_sig)
+        self.assertIn('→ dict', func_sig, "Should include return annotation")
+
+    def test_private_functions_excluded(self):
+        """Private functions (_foo) should be excluded, except methods."""
+        code = '''
+def public_func():
+    pass
+
+def _private_func():
+    pass
+
+def __dunder_func():
+    pass
+
+class MyClass:
+    def __init__(self):
+        pass
+
+    def public_method(self):
+        pass
+
+    def _private_method(self):
+        pass
+'''
+        sigs = self.run_extractor(code)
+        sigs_str = ' '.join(sigs)
+        self.assertIn('public_func', sigs_str)
+        self.assertNotIn('_private_func', sigs_str, "_private_func should be excluded")
+        self.assertNotIn('__dunder_func', sigs_str, "__dunder_func should be excluded")
+        self.assertIn('__init__', sigs_str, "__init__ should be included (exception)")
+        self.assertNotIn('_private_method', sigs_str, "_private_method should be excluded")
+
+    def test_syntax_error_file(self):
+        """File with syntax errors should return empty list."""
+        code = 'def bad syntax here'
+        sigs = self.run_extractor(code)
+        self.assertEqual(sigs, [], "Syntax error should return empty list")
+
+    def test_signature_cap_at_max_sigs(self):
+        """When signatures exceed MAX_SIGS (30), should cap at 30."""
+        # Generate 40+ function definitions
+        funcs = '\n'.join(f'def func_{i}():\n    pass' for i in range(45))
+        code = funcs
+        sigs = self.run_extractor(code)
+        self.assertEqual(len(sigs), 30, "Should cap at MAX_SIGS=30")
+        # Verify first funcs are captured
+        self.assertTrue(any('func_0' in s for s in sigs))
+
+    def test_nested_fastapi_routes_excluded(self):
+        """Nested function with FastAPI decorator should NOT be extracted."""
+        code = '''
+from fastapi import FastAPI
+
+app = FastAPI()
+
+def outer():
+    @app.get("/nested")
+    def nested_route():
+        return {}
+    return nested_route
+
+@app.get("/top-level")
+def top_level():
+    return {}
+'''
+        sigs = self.run_extractor(code)
+        sigs_str = ' '.join(sigs)
+        self.assertIn('GET /top-level', sigs_str, "Top-level route should be extracted")
+        self.assertNotIn('/nested', sigs_str, "Nested route should NOT be extracted")
+
+    def test_async_function_signature(self):
+        """Async functions should have 'async' prefix."""
+        code = '''
+async def fetch_data(url: str) -> dict:
+    return {}
+
+async def _private_async():
+    pass
+'''
+        sigs = self.run_extractor(code)
+        async_sig = next((s for s in sigs if 'fetch_data' in s), None)
+        self.assertIsNotNone(async_sig)
+        self.assertTrue(async_sig.startswith('async '), "Should have async prefix")
+
+    def test_docstring_hint_truncation(self):
+        """Docstring hints should be truncated at MAX_DOC_HINT_LEN (60)."""
+        code = '''
+def my_function():
+    """This is a very long docstring that definitely exceeds the maximum length limit."""
+    pass
+'''
+        sigs = self.run_extractor(code)
+        func_sig = next((s for s in sigs if 'my_function' in s), None)
+        self.assertIsNotNone(func_sig)
+        if '#' in func_sig:
+            hint = func_sig.split('#')[1].strip()
+            self.assertLessEqual(len(hint), 60, "Docstring hint should be capped at 60 chars")
+
+    def test_class_with_bases(self):
+        """Classes with inheritance should show base classes."""
+        code = '''
+class Animal:
+    pass
+
+class Dog(Animal):
+    def bark(self):
+        pass
+'''
+        sigs = self.run_extractor(code)
+        dog_sig = next((s for s in sigs if 'class Dog' in s), None)
+        self.assertIsNotNone(dog_sig)
+        self.assertIn('Animal', dog_sig, "Should show base class")
+
+    def test_fastapi_multiple_methods(self):
+        """FastAPI routes with different HTTP methods."""
+        code = '''
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/items")
+def list_items():
+    return []
+
+@app.post("/items")
+def create_item(data: dict):
+    return data
+
+@app.put("/items/{id}")
+def update_item(id: int):
+    return {}
+'''
+        sigs = self.run_extractor(code)
+        sigs_str = ' '.join(sigs)
+        self.assertIn('GET /items', sigs_str)
+        self.assertIn('POST /items', sigs_str)
+        self.assertIn('PUT /items/{id}', sigs_str)
+
+    def test_empty_class(self):
+        """Empty class should still be captured."""
+        code = '''
+class Empty:
+    pass
+'''
+        sigs = self.run_extractor(code)
+        self.assertTrue(any('Empty' in s for s in sigs))
+
+    def test_complex_type_annotations(self):
+        """Complex type annotations should be handled."""
+        code = '''
+from typing import List, Dict, Union
+
+def transform(
+    data: List[Dict[str, Union[int, str]]],
+    config: Dict = None
+) -> List[str]:
+    return []
+'''
+        sigs = self.run_extractor(code)
+        func_sig = next((s for s in sigs if 'transform' in s), None)
+        self.assertIsNotNone(func_sig)
+        self.assertIn('transform', func_sig)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `src/extractors/python_ast.py` — a native Python fallback for the Python extractor that uses `ast.parse()` instead of regex.

**Why:** The JS regex extractor works well for most cases but has known failure modes:
- Multiline function signatures (parameters spanning multiple lines) are missed
- Stacked decorators can confuse the class detection regex
- Type annotations with complex generics are truncated incorrectly
- String literals containing `def ` or `class ` can produce false positives

**How:** `python.js` now calls `python3 python_ast.py <filepath>` first. If Python3 is available and returns non-empty results, that output is used. Otherwise falls back to the existing regex logic unchanged.

**Zero breaking changes:** The fallback preserves existing behavior for users without Python3, and the output format is identical.

## Test plan
- [ ] `python3 src/extractors/python_ast.py <file.py>` outputs valid JSON
- [ ] Complex dataclass with Optional fields → collapsed `@dataclass Foo(field1, field2?)` form
- [ ] Pydantic BaseModel subclass → `class Foo(BaseModel) {required*, optional?}` form
- [ ] Multiline function signature → correctly extracted
- [ ] Private function `_foo` → excluded
- [ ] Syntax error file → `[]` with exit 0
- [ ] File with 40+ signatures → capped at 30