### PR TITLE
feat: Willow adapter for Postgres-backed knowledge store

### DIFF
--- a/packages/adapters/index.js
+++ b/packages/adapters/index.js
@@ -11,14 +11,16 @@
 
 const path = require('path');
 
-const ADAPTER_NAMES = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex'];
+// Third-party adapters: 'willow' writes atoms to a Willow MCP knowledge store
+// instead of a flat file (see willow.js for configuration).
+const ADAPTER_NAMES = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex', 'willow'];
 
 // Lazy-load adapters so unused ones don't pay any require() cost
 const _cache = {};
 
 /**
  * Load and return an adapter module by name.
- * @param {string} name - Adapter name (copilot|claude|cursor|windsurf|openai|gemini|codex)
+ * @param {string} name - Adapter name (copilot|claude|cursor|windsurf|openai|gemini|codex|willow)
  * @returns {{ name: string, format: Function, outputPath: Function }|null}
  */
 function getAdapter(name) {

--- a/packages/adapters/willow.js
+++ b/packages/adapters/willow.js
@@ -4,21 +4,28 @@
  * Willow adapter — writes SigMap context to Willow MCP knowledge store.
  *
  * Instead of writing a flat .willow-context.md file, this adapter sends
- * signature atoms to a Willow MCP server (https://github.com/sean-campbell/willow-1.9)
+ * signature atoms to a Willow MCP server (https://github.com/rudi193-cmd/willow-1.9)
  * via HTTP POST. Each indexed file becomes a searchable knowledge atom.
  *
  * Contract:
  *   format(context, opts?) → string   (markdown for display/debug)
  *   outputPath(cwd)        → string   (placeholder — no file written)
- *   write(context, cwd, opts?) → void (POSTs to Willow MCP)
+ *   write(context, cwd, opts?) → Promise<void> (POSTs to Willow MCP, must await)
  *
  * Configuration (env vars or opts):
  *   WILLOW_MCP_URL   — MCP server base URL (default: http://localhost:8000)
  *   WILLOW_AGENT     — agent namespace (default: sigmap)
+ *   WILLOW_TIMEOUT   — fetch timeout in ms (default: 30000)
+ *   WILLOW_MAX_ATOM_SIZE — max atom size in bytes (default: 100000)
+ *   WILLOW_RETRIES   — max retry attempts for transient failures (default: 3)
  */
 
+const crypto = require('crypto');
 const name = 'willow';
 const DEFAULT_MCP_URL = 'http://localhost:8000';
+const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_MAX_ATOM_SIZE = 100000;
+const DEFAULT_RETRIES = 3;
 
 /**
  * Format SigMap context as markdown for display or debug.
@@ -38,18 +45,111 @@ function format(context, opts = {}) {
  * @returns {string}
  */
 function outputPath(cwd) {
-  // No file written — context lives in Willow KB
   return '.willow-context.md';
+}
+
+/**
+ * Generate a cryptographically strong ID for an atom.
+ * Uses SHA256 hash of the filepath to ensure uniqueness and prevent collisions.
+ * @param {string} filepath - File path to hash
+ * @returns {string} - sigmap-{32-char-hex}
+ */
+function generateAtomId(filepath) {
+  const hash = crypto
+    .createHash('sha256')
+    .update(filepath)
+    .digest('hex');
+  return `sigmap-${hash}`;
+}
+
+/**
+ * Fetch with timeout support.
+ * @param {string} url - URL to fetch
+ * @param {object} opts - Fetch options
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @returns {Promise<Response>}
+ */
+async function fetchWithTimeout(url, opts, timeoutMs) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...opts, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * POST an atom to Willow with exponential backoff retry.
+ * @param {object} atom - Atom to ingest
+ * @param {string} mcpUrl - MCP server URL
+ * @param {number} timeoutMs - Fetch timeout
+ * @param {number} maxRetries - Max retry attempts
+ * @returns {Promise<boolean>} - True if succeeded, false if all retries exhausted
+ */
+async function postAtomWithRetry(atom, mcpUrl, timeoutMs, maxRetries) {
+  let lastErr;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const resp = await fetchWithTimeout(
+        `${mcpUrl}/tools/call`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'willow_knowledge_ingest',
+            arguments: {
+              app_id: atom.agent,
+              title: atom.title,
+              summary: atom.summary,
+              domain: atom.domain,
+              source_type: atom.source_type,
+              category: 'code',
+              record_id: atom.id,
+            },
+          }),
+        },
+        timeoutMs,
+      );
+
+      if (resp.ok) {
+        return true;
+      }
+
+      if (resp.status >= 500) {
+        lastErr = new Error(`HTTP ${resp.status}`);
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 100 * Math.pow(2, attempt)));
+          continue;
+        }
+      } else {
+        process.stderr.write(`[willow-adapter] ${atom.id}: HTTP ${resp.status} (not retryable)\n`);
+        return false;
+      }
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100 * Math.pow(2, attempt)));
+        continue;
+      }
+    }
+  }
+
+  process.stderr.write(
+    `[willow-adapter] ${atom.id}: failed after ${maxRetries} attempts: ${lastErr?.message || 'unknown'}\n`,
+  );
+  return false;
 }
 
 /**
  * POST each file section from SigMap context to the Willow MCP knowledge store.
  * Each `## filepath` section becomes one searchable knowledge atom.
- * Failures are per-atom and logged to stderr; the function never throws.
+ * Failures are per-atom and logged to stderr; function never throws.
+ * IMPORTANT: This is async — caller MUST await write() before process exit.
  *
  * @param {string} context - Raw SigMap context string
  * @param {string} cwd - Working directory (used as project label)
- * @param {object} [opts] - Optional overrides: { mcpUrl, agent }
+ * @param {object} [opts] - Optional overrides: { mcpUrl, agent, timeoutMs, maxAtomSize, maxRetries }
  * @returns {Promise<void>}
  */
 async function write(context, cwd, opts = {}) {
@@ -57,19 +157,32 @@ async function write(context, cwd, opts = {}) {
 
   const mcpUrl = opts.mcpUrl || process.env.WILLOW_MCP_URL || DEFAULT_MCP_URL;
   const agent = opts.agent || process.env.WILLOW_AGENT || 'sigmap';
+  const timeoutMs = opts.timeoutMs || parseInt(process.env.WILLOW_TIMEOUT, 10) || DEFAULT_TIMEOUT_MS;
+  const maxAtomSize = opts.maxAtomSize || parseInt(process.env.WILLOW_MAX_ATOM_SIZE, 10) || DEFAULT_MAX_ATOM_SIZE;
+  const maxRetries = opts.maxRetries || parseInt(process.env.WILLOW_RETRIES, 10) || DEFAULT_RETRIES;
 
-  // Parse context blocks: each file section becomes one atom
   const sections = context.split(/\n(?=##\s)/);
   const atoms = sections
     .map((section) => {
       const titleMatch = section.match(/^##\s+(.+)/);
       if (!titleMatch) return null;
+
+      const title = titleMatch[1].trim();
+      const contentSize = section.length;
+
+      if (contentSize > maxAtomSize) {
+        process.stderr.write(`[willow-adapter] ${title}: oversized (${contentSize} > ${maxAtomSize} bytes)\n`);
+        return null;
+      }
+
       return {
-        id: `sigmap-${Buffer.from(titleMatch[1]).toString('hex').slice(0, 16)}`,
-        title: titleMatch[1].trim(),
+        id: generateAtomId(title),
+        title,
+        summary: `${title} (${contentSize} bytes)`,
         content: section.trim(),
         domain: 'code',
         source_type: 'sigmap',
+        agent,
         project: cwd ? require('path').basename(cwd) : 'unknown',
       };
     })
@@ -77,32 +190,11 @@ async function write(context, cwd, opts = {}) {
 
   if (!atoms.length) return;
 
-  // POST each atom to Willow knowledge ingest endpoint
-  for (const atom of atoms) {
-    try {
-      const resp = await fetch(`${mcpUrl}/tools/call`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: 'willow_knowledge_ingest',
-          arguments: {
-            app_id: agent,
-            title: atom.title,
-            content: atom.content,
-            domain: atom.domain,
-            source_type: atom.source_type,
-            project: atom.project,
-            record_id: atom.id,
-          },
-        }),
-      });
-      if (!resp.ok) {
-        process.stderr.write(`[willow-adapter] ingest failed: ${resp.status}\n`);
-      }
-    } catch (err) {
-      process.stderr.write(`[willow-adapter] ${err.message}\n`);
-    }
-  }
+  await Promise.all(
+    atoms.map((atom) => postAtomWithRetry(atom, mcpUrl, timeoutMs, maxRetries).catch((err) => {
+      process.stderr.write(`[willow-adapter] ${atom.id}: unexpected error: ${err.message}\n`);
+    })),
+  );
 }
 
 module.exports = { name, format, outputPath, write };

--- a/packages/adapters/willow.js
+++ b/packages/adapters/willow.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Willow adapter — writes SigMap context to Willow MCP knowledge store.
+ *
+ * Instead of writing a flat .willow-context.md file, this adapter sends
+ * signature atoms to a Willow MCP server (https://github.com/sean-campbell/willow-1.9)
+ * via HTTP POST. Each indexed file becomes a searchable knowledge atom.
+ *
+ * Contract:
+ *   format(context, opts?) → string   (markdown for display/debug)
+ *   outputPath(cwd)        → string   (placeholder — no file written)
+ *   write(context, cwd, opts?) → void (POSTs to Willow MCP)
+ *
+ * Configuration (env vars or opts):
+ *   WILLOW_MCP_URL   — MCP server base URL (default: http://localhost:8000)
+ *   WILLOW_AGENT     — agent namespace (default: sigmap)
+ */
+
+const name = 'willow';
+const DEFAULT_MCP_URL = 'http://localhost:8000';
+
+/**
+ * Format SigMap context as markdown for display or debug.
+ * @param {string} context - Raw SigMap context string
+ * @param {object} [opts] - Unused; reserved for future options
+ * @returns {string}
+ */
+function format(context, opts = {}) {
+  if (!context || typeof context !== 'string') return '';
+  const ts = new Date().toISOString();
+  return `<!-- SigMap Willow context — ${ts} -->\n\n${context}`;
+}
+
+/**
+ * Return the placeholder output path (no file is written by this adapter).
+ * @param {string} cwd - Working directory
+ * @returns {string}
+ */
+function outputPath(cwd) {
+  // No file written — context lives in Willow KB
+  return '.willow-context.md';
+}
+
+/**
+ * POST each file section from SigMap context to the Willow MCP knowledge store.
+ * Each `## filepath` section becomes one searchable knowledge atom.
+ * Failures are per-atom and logged to stderr; the function never throws.
+ *
+ * @param {string} context - Raw SigMap context string
+ * @param {string} cwd - Working directory (used as project label)
+ * @param {object} [opts] - Optional overrides: { mcpUrl, agent }
+ * @returns {Promise<void>}
+ */
+async function write(context, cwd, opts = {}) {
+  if (!context) return;
+
+  const mcpUrl = opts.mcpUrl || process.env.WILLOW_MCP_URL || DEFAULT_MCP_URL;
+  const agent = opts.agent || process.env.WILLOW_AGENT || 'sigmap';
+
+  // Parse context blocks: each file section becomes one atom
+  const sections = context.split(/\n(?=##\s)/);
+  const atoms = sections
+    .map((section) => {
+      const titleMatch = section.match(/^##\s+(.+)/);
+      if (!titleMatch) return null;
+      return {
+        id: `sigmap-${Buffer.from(titleMatch[1]).toString('hex').slice(0, 16)}`,
+        title: titleMatch[1].trim(),
+        content: section.trim(),
+        domain: 'code',
+        source_type: 'sigmap',
+        project: cwd ? require('path').basename(cwd) : 'unknown',
+      };
+    })
+    .filter(Boolean);
+
+  if (!atoms.length) return;
+
+  // POST each atom to Willow knowledge ingest endpoint
+  for (const atom of atoms) {
+    try {
+      const resp = await fetch(`${mcpUrl}/tools/call`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'willow_knowledge_ingest',
+          arguments: {
+            app_id: agent,
+            title: atom.title,
+            content: atom.content,
+            domain: atom.domain,
+            source_type: atom.source_type,
+            project: atom.project,
+            record_id: atom.id,
+          },
+        }),
+      });
+      if (!resp.ok) {
+        process.stderr.write(`[willow-adapter] ingest failed: ${resp.status}\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`[willow-adapter] ${err.message}\n`);
+    }
+  }
+}
+
+module.exports = { name, format, outputPath, write };

--- a/test/integration/adapters.test.js
+++ b/test/integration/adapters.test.js
@@ -83,22 +83,22 @@ test('packages/adapters/index exports getAdapter, listAdapters, adapt, outputsTo
 });
 
 // ---------------------------------------------------------------------------
-// 2. listAdapters returns 7 names
+// 2. listAdapters returns 8 names
 // ---------------------------------------------------------------------------
-test('listAdapters() returns exactly 7 adapter names', () => {
+test('listAdapters() returns exactly 8 adapter names', () => {
   const list = adapters.listAdapters();
   assert.ok(Array.isArray(list), 'must be an array');
-  assert.strictEqual(list.length, 7, `expected 7 adapters, got ${list.length}: ${list.join(', ')}`);
-  const expected = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex'];
+  assert.strictEqual(list.length, 8, `expected 8 adapters, got ${list.length}: ${list.join(', ')}`);
+  const expected = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex', 'willow'];
   for (const name of expected) {
     assert.ok(list.includes(name), `missing adapter: ${name}`);
   }
 });
 
 // ---------------------------------------------------------------------------
-// 3-8. Each adapter has name, format, outputPath
+// 3-9. Each adapter has name, format, outputPath
 // ---------------------------------------------------------------------------
-for (const adapterName of ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini']) {
+for (const adapterName of ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'willow']) {
   test(`getAdapter('${adapterName}') returns {name, format, outputPath}`, () => {
     const a = adapters.getAdapter(adapterName);
     assert.ok(a !== null, `getAdapter('${adapterName}') returned null`);


### PR DESCRIPTION
## Summary

Adds `packages/adapters/willow.js` — writes SigMap signature atoms to a [Willow MCP](https://github.com/rudi193-cmd/willow-1.9) knowledge store instead of a flat file.

**What Willow is:** Willow is a local-first AI memory and task system for multi-agent fleets. It exposes a Postgres-backed KB via MCP. Each SigMap-indexed file becomes a searchable knowledge atom that all agents in the fleet can query.

**Why this matters for SigMap:** The flat-file adapter model assumes single-agent, single-session use. Willow removes that constraint — once a repo is indexed, every agent in the fleet benefits without re-indexing.

## Configuration

```bash
# Set MCP server URL (default: http://localhost:8000)
export WILLOW_MCP_URL=http://localhost:8000

# Set agent namespace (default: sigmap)  
export WILLOW_AGENT=hanuman

# Use the adapter
sigmap index --adapter willow
```

## How it works

Each `## filepath` section in the SigMap context output becomes one Willow knowledge atom. Atoms are upserted (safe to re-index). The `write()` function is async and fails silently per-atom so a single ingest failure doesn't stop the full index.

## Test plan
- [ ] `require('sigmap/adapters').getAdapter('willow')` returns the adapter
- [ ] `format(context)` returns markdown string with timestamp header
- [ ] `outputPath(cwd)` returns `.willow-context.md`
- [ ] `write(context, cwd)` POSTs to WILLOW_MCP_URL (mock the endpoint)
- [ ] `write()` with unreachable URL → stderr message, no throw