### PR TITLE
feat: add GDScript extractor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,56 +56,13 @@ Use this marker block for all appendable context files:
 | To query by topic | `sigmap --query "<topic>"` |
 
 Always run `sigmap ask` or `sigmap --query` before searching for files relevant to a task.
-## changes (last 5 commits — 47 minutes ago)
+## changes (last 5 commits — 3 days ago)
 ```
 src/eval/usefulness-scorer.js                 +scoreUsefulness  +computeUsefulnessStats
 src/workspace/detector.js                     +detectWorkspaces  +inferPackage  +_getMatchLength  +scopeToPackage
 ```
 
 ## packages
-
-### packages/cli/index.js
-```
-module.exports = { CLI_ENTRY, run }
-function run(argv, cwd) → void
-```
-
-### packages/adapters/index.js
-```
-module.exports = { getAdapter, listAdapters, adapt, outputsToAdapters }
-function getAdapter(name) → { name: string, format: F
-function listAdapters() → string[]
-function adapt(context, adapterName, opts = {}) → string
-function outputsToAdapters(outputs) → string[]
-```
-
-### packages/adapters/llm-full.js
-```
-module.exports = { name: 'llm-full', format, outputPath, write }
-function outputPath(cwd)
-function format(context, opts)
-function write(context, cwd, opts)
-```
-
-### packages/core/README.md
-```
-h1 sigmap-core
-h2 Installation
-h2 Quick start
-h2 API reference
-h3 `extract(src, language)` → `string[]`
-h3 `rank(query, sigIndex, opts?)` → `Result[]`
-h3 `buildSigIndex(cwd)` → `Map<string, string[]>`
-h3 `scan(sigs, filePath)` → `{ safe: string[], redacted: boolean }`
-h3 `score(cwd)` → `HealthResult`
-h2 Migration from v2.3 and earlier
-h2 v3.0 — Multi-Adapter Architecture (released)
-h2 Zero dependencies
-code-fence bash
-code-fence plain
-code-fence js
-code-fence ---
-```
 
 ### packages/core/index.js
 ```
@@ -119,66 +76,220 @@ function score(cwd) → { * score: number, * grad
 function adapt(context, adapterName, opts = {}) → string
 ```
 
-### packages/adapters/copilot.js
-```
-module.exports = { name, format, outputPath, write }
-function format(context, opts = {}) → string
-function _confidenceMeta(opts)
-function outputPath(cwd) → string
-function write(context, cwd, opts = {})
-```
-
-### packages/adapters/cursor.js
-```
-module.exports = { name, format, outputPath }
-function format(context, opts = {}) → string
-function _confidenceMeta(opts)
-function outputPath(cwd) → string
-```
-
-### packages/adapters/gemini.js
-```
-module.exports = { name, format, outputPath, write }
-function format(context, opts = {}) → string
-function outputPath(cwd) → string
-function write(context, cwd, opts = {})
-function _confidenceMeta(opts)
-```
-
-### packages/adapters/openai.js
-```
-module.exports = { name, format, outputPath }
-function format(context, opts = {}) → string
-function outputPath(cwd) → string
-function _confidenceMeta(opts)
-```
-
-### packages/adapters/windsurf.js
-```
-module.exports = { name, format, outputPath }
-function format(context, opts = {}) → string
-function _confidenceMeta(opts)
-function outputPath(cwd) → string
-```
-
-### packages/adapters/claude.js
-```
-module.exports = { name, format, outputPath, write }
-function format(context, opts = {}) → string
-function _confidenceMeta(opts)
-function outputPath(cwd) → string
-function write(context, cwd, opts = {})
-```
-
-### packages/adapters/codex.js
-```
-module.exports = { name, format, outputPath, write }
-function format(context, opts = {}) → string
-function outputPath(cwd) → string
-function write(context, cwd, opts = {})
-```
-
 ## src
+
+### src/discovery/sigmapignore.js
+```
+module.exports = { loadIgnorePatterns, matchesIgnorePattern }
+function loadIgnorePatterns(cwd)
+function matchesIgnorePattern(dirName, patterns)
+```
+
+### src/discovery/source-root-registry.js
+```
+module.exports = { REGISTRY }
+```
+
+### src/discovery/source-root-resolver.js
+```
+module.exports = { resolveSourceRoots }
+function resolveSourceRoots(cwd, opts = {})
+function _detectMonorepo(cwd)
+function _enumerateCandidates(cwd, isMonorepo, ignorePatterns, excludeList)
+function _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks)
+function _dedupeNested(scored)
+function _computeConfidence(frameworks, languages, scoredCount)
+```
+
+### src/discovery/source-root-scorer.js
+```
+module.exports = { scoreCandidate, getRecentlyChangedDirs, ROOT_ENTRYPOINTS, JVM_PATH_PATTERN }
+function getRecentlyChangedDirs(cwd)
+function scoreCandidate(dirName, fullPath, context)
+function _countSourceFiles(dir, depth)
+```
+
+### src/eval/runner.js
+```
+module.exports = { run, rank, loadTasks, buildSigIndex, formatTable, formatMetrics, tokenize }
+function buildSigIndex(cwd) → Map<string, string[]>
+function tokenize(text) → string[]
+function scoreFile(sigs, queryTokens) → number
+function rank(query, index, topK = 10) → { file: string, score: nu
+function estimateTokens(sigs) → number
+function loadTasks(tasksFile) → Array<{id:string, query:s
+function run(tasksFile, cwd, opts = {}) → { * tasks: Array<{id, que
+function formatTable(taskResults) → string
+function formatMetrics(metrics) → string
+```
+
+### src/eval/scorer.js
+```
+module.exports = { hitAtK, reciprocalRank, precisionAtK, aggregate, firstRank }
+function firstRank(ranked, expected) → number
+function normalizePath(p) → string
+function hitAtK(ranked, expected, k = 5) → 0|1
+function reciprocalRank(ranked, expected) → number
+function precisionAtK(ranked, expected, k = 5) → number
+function aggregate(results, k = 5) → { * hitAt5: number, // fr
+function round(x)
+```
+
+### src/extractors/coverage.js
+```
+module.exports = { buildTestIndex, isTested }
+function walkFiles(dir)
+function buildTestIndex(cwd, testDirs)
+function isTested(funcName, testIndex)
+```
+
+### src/extractors/cpp.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+function normalizeType(type)
+```
+
+### src/extractors/csharp.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+function normalizeType(type)
+```
+
+### src/extractors/css.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/dart.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+```
+
+### src/extractors/deps.js
+```
+module.exports = { extractPythonDeps, extractTSDeps, buildReverseDepMap }
+function extractPythonDeps(src) → string[]
+function extractTSDeps(src) → string[]
+function buildReverseDepMap(forwardMap) → Map<string, string[]>
+```
+
+### src/extractors/dockerfile.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/generic.js
+```
+module.exports = { extract }
+function extract(src)
+```
+
+### src/extractors/go.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractInterfaceMethods(block)
+function normalizeParams(params)
+```
+
+### src/extractors/graphql.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/html.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/java.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+function normalizeType(type)
+```
+
+### src/extractors/javascript.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractClassMembers(block, returnHints)
+function buildReturnHints(src)
+function normalizeType(type)
+function formatReturnHint(type)
+function normalizeParams(params)
+```
+
+### src/extractors/kotlin.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+```
+
+### src/extractors/markdown.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/patterns.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/php.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractMembers(block)
+function normalizeParams(params)
+function normalizeType(type)
+```
+
+### src/extractors/prdiff.js
+```
+module.exports = { diffSignatures, extractName }
+function diffSignatures(baseSigs, currentSigs) → {added:string[], removed:
+function extractName(sig)
+```
+
+### src/extractors/properties.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/protobuf.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
 
 ### src/extractors/python.js
 ```
@@ -191,6 +302,12 @@ function extractClassConstants(stripped, startIndex)
 function extractReturnType(sigLine)
 function normalizeParams(params)
 function extractDocHint(src, fnName, fnSigLine)
+```
+
+### src/extractors/python_dataclass.js
+```
+module.exports = { extract }
+function extract(src) → string[]
 ```
 
 ### src/extractors/ruby.js
@@ -221,6 +338,20 @@ function normalizeParams(params)
 function normalizeType(type)
 ```
 
+### src/extractors/shell.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/sql.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function _cleanName(raw)
+function _normalizeParams(raw)
+```
+
 ### src/extractors/svelte.js
 ```
 module.exports = { extract }
@@ -239,10 +370,38 @@ function normalizeParams(params)
 function extractArrowType(str)
 ```
 
+### src/extractors/terraform.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
 ### src/extractors/todos.js
 ```
 module.exports = { extractTodos }
 function extractTodos(src) → {line:number, tag:string,
+```
+
+### src/extractors/toml.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+```
+
+### src/extractors/typescript.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractBlock(src, startIndex)
+function extractInterfaceMembers(block)
+function extractClassMembers(block)
+function normalizeParams(params)
+```
+
+### src/extractors/typescript_react.js
+```
+module.exports = { extract }
+function extract(src) → string[]
 ```
 
 ### src/extractors/vue.js
@@ -253,123 +412,7 @@ function normalizeParams(params)
 function normalizeType(type)
 ```
 
-### src/eval/scorer.js
-```
-module.exports = { hitAtK, reciprocalRank, precisionAtK, aggregate, firstRank }
-function firstRank(ranked, expected) → number
-function normalizePath(p) → string
-function hitAtK(ranked, expected, k = 5) → 0|1
-function reciprocalRank(ranked, expected) → number
-function precisionAtK(ranked, expected, k = 5) → number
-function aggregate(results, k = 5) → { * hitAt5: number, // fr
-function round(x)
-```
-
-### src/eval/runner.js
-```
-module.exports = { run, rank, loadTasks, buildSigIndex, formatTable, formatMetrics, tokenize }
-function buildSigIndex(cwd) → Map<string, string[]>
-function tokenize(text) → string[]
-function scoreFile(sigs, queryTokens) → number
-function rank(query, index, topK = 10) → { file: string, score: nu
-function estimateTokens(sigs) → number
-function loadTasks(tasksFile) → Array<{id:string, query:s
-function run(tasksFile, cwd, opts = {}) → { * tasks: Array<{id, que
-function formatTable(taskResults) → string
-function formatMetrics(metrics) → string
-```
-
-### src/retrieval/tokenizer.js
-```
-module.exports = { tokenize, STOP_WORDS }
-function tokenize(text, opts) → string[]
-```
-
-### src/graph/builder.js
-```
-module.exports = { build, buildFromCwd, extractFileDeps }
-function resolveJsPath(dir, importStr, fileSet) → string|null
-function extractFileDeps(filePath, content, fileSet) → string[]
-function build(files, cwd) → { forward: Map<string,str
-function buildFromCwd(cwd, opts) → { forward: Map<string,str
-```
-
-### src/graph/impact.js
-```
-module.exports = { getImpact, analyzeImpact, formatImpact, formatImpactJSON }
-function bfs(startFile, reverseGraph, maxDepth) → { direct: Set<string>, tr
-function isTestFile(f)
-function isRouteFile(f)
-function getImpact(changedFile, graph, opts) → { * changed: string, * di
-function analyzeImpact(changedFiles, cwd, opts) → { file: string, impact: o
-function formatImpact(result) → string
-function formatImpactJSON(result) → object
-```
-
-### src/mcp/tools.js
-```
-module.exports = { TOOLS }
-```
-
-### src/health/scorer.js
-```
-module.exports = { score }
-function score(cwd) → { * score: number, * grad
-```
-
-### src/extractors/coverage.js
-```
-module.exports = { buildTestIndex, isTested }
-function walkFiles(dir)
-function buildTestIndex(cwd, testDirs)
-function isTested(funcName, testIndex)
-```
-
-### src/extractors/css.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/sql.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-function _cleanName(raw)
-function _normalizeParams(raw)
-```
-
-### src/extractors/graphql.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/protobuf.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/terraform.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/markdown.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/properties.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/toml.js
+### src/extractors/vue_sfc.js
 ```
 module.exports = { extract }
 function extract(src) → string[]
@@ -381,92 +424,10 @@ module.exports = { extract }
 function extract(src) → string[]
 ```
 
-### src/extractors/patterns.js
+### src/extractors/yaml.js
 ```
 module.exports = { extract }
 function extract(src) → string[]
-```
-
-### src/extractors/python_dataclass.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/typescript_react.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/vue_sfc.js
-```
-module.exports = { extract }
-function extract(src) → string[]
-```
-
-### src/extractors/generic.js
-```
-module.exports = { extract }
-function extract(src)
-```
-
-### src/format/llm-txt.js
-```
-module.exports = { format, outputPath }
-function outputPath(cwd)
-function format(context, cwd, version)
-```
-
-### src/format/llms-txt.js
-```
-module.exports = { format, outputPath }
-function outputPath(cwd)
-function getShortCommit(cwd)
-function detectVersion(cwd)
-function format(context, cwd, writtenFiles, sigmapVersion)
-```
-
-### src/eval/analyzer.js
-```
-module.exports = { analyzeFiles, formatAnalysisTable, formatAnalysisJSON }
-function isDockerfile(name)
-function getExtractorName(filePath)
-function tokenCount(sigs)
-function hasCoverage(filePath, cwd)
-function loadExtractor(name, cwd)
-function analyzeFiles(files, cwd, opts) → object[]
-function formatAnalysisTable(stats, showSlow) → string
-function formatAnalysisJSON(stats) → object
-```
-
-### src/format/dashboard.js
-```
-module.exports = { generateDashboardHtml, renderHistoryCharts, computeExtractorCoverage, percentile, overBudgetStreak }
-function toNumber(v)
-function percentile(values, p)
-function overBudgetStreak(entries)
-function loadConfig(cwd)
-function shouldExclude(rel, excludeSet)
-function detectLanguage(filePath)
-function walkFiles(dir, maxDepth, depth, out, excludeSet)
-function computeExtractorCoverage(cwd)
-function readBenchmarkTrend(cwd)
-function lineChartSvg(values, title, ySuffix)
-function barChartSvg(perLanguage)
-function sparkline(values)
-function buildDashboardData(cwd, health)
-function generateDashboardHtml(cwd, health)
-function renderHistoryCharts(cwd, health)
-```
-
-### src/judge/judge-engine.js
-```
-module.exports = { groundedness, judge }
-function tokenize(text)
-function groundedness(response, context)
-function extractContextFiles(context, cwd)
-function judge(response, context, opts = {})
 ```
 
 ### src/format/benchmark-report.js
@@ -496,53 +457,83 @@ function generateBenchmarkReportHtml(reports, opts = {})
 function writeBenchmarkReport(cwd, opts = {})
 ```
 
-### src/analysis/coverage-score.js
+### src/format/cache.js
 ```
-module.exports = { coverageScore, CODE_EXTS }
-function coverageScore(cwd, fileEntries, config)
-function _walk(dir, excludeSet, out)
-```
-
-### src/cache/sig-cache.js
-```
-module.exports = { loadCache, saveCache, getChangedFiles, updateCacheEntries }
-function cachePath(cwd)
-function loadCache(cwd, currentVersion) → Map<string, { mtime: numb
-function saveCache(cwd, currentVersion, cache)
-function getChangedFiles(files, cache) → { changed: string[], unch
-function updateCacheEntries(cache, extracted)
+module.exports = { formatCache, formatCachePayload }
+function formatCache(content) → string
+function formatCachePayload(content, model) → string
 ```
 
-### src/mcp/handlers.js
+### src/format/dashboard.js
 ```
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact }
-function readContext(args, cwd)
-function searchSignatures(args, cwd)
-function getMap(args, cwd)
-function createCheckpoint(args, cwd)
-function getRouting(args, cwd)
-function explainFile(args, cwd)
-function listModules(args, cwd)
-function queryContext(args, cwd)
-function getImpact(args, cwd)
-```
-
-### src/tracking/logger.js
-```
-module.exports = { logRun, readLog, summarize }
-function logRun(entry, cwd)
-function readLog(cwd) → object[]
-function summarize(entries) → object
+module.exports = { generateDashboardHtml, renderHistoryCharts, computeExtractorCoverage, percentile, overBudgetStreak }
+function toNumber(v)
+function percentile(values, p)
+function overBudgetStreak(entries)
+function loadConfig(cwd)
+function shouldExclude(rel, excludeSet)
+function detectLanguage(filePath)
+function walkFiles(dir, maxDepth, depth, out, excludeSet)
+function computeExtractorCoverage(cwd)
+function readBenchmarkTrend(cwd)
+function lineChartSvg(values, title, ySuffix)
+function barChartSvg(perLanguage)
+function sparkline(values)
+function buildDashboardData(cwd, health)
+function generateDashboardHtml(cwd, health)
+function renderHistoryCharts(cwd, health)
 ```
 
-### src/extractors/typescript.js
+### src/format/llm-txt.js
 ```
-module.exports = { extract }
-function extract(src) → string[]
-function extractBlock(src, startIndex)
-function extractInterfaceMembers(block)
-function extractClassMembers(block)
-function normalizeParams(params)
+module.exports = { format, outputPath }
+function outputPath(cwd)
+function format(context, cwd, version)
+```
+
+### src/format/llms-txt.js
+```
+module.exports = { format, outputPath }
+function outputPath(cwd)
+function getShortCommit(cwd)
+function detectVersion(cwd)
+function format(context, cwd, writtenFiles, sigmapVersion)
+```
+
+### src/graph/builder.js
+```
+module.exports = { build, buildFromCwd, extractFileDeps }
+function resolveJsPath(dir, importStr, fileSet) → string|null
+function extractFileDeps(filePath, content, fileSet) → string[]
+function build(files, cwd) → { forward: Map<string,str
+function buildFromCwd(cwd, opts) → { forward: Map<string,str
+```
+
+### src/graph/impact.js
+```
+module.exports = { getImpact, analyzeImpact, formatImpact, formatImpactJSON }
+function bfs(startFile, reverseGraph, maxDepth) → { direct: Set<string>, tr
+function isTestFile(f)
+function isRouteFile(f)
+function getImpact(changedFile, graph, opts) → { * changed: string, * di
+function analyzeImpact(changedFiles, cwd, opts) → { file: string, impact: o
+function formatImpact(result) → string
+function formatImpactJSON(result) → object
+```
+
+### src/health/scorer.js
+```
+module.exports = { score }
+function score(cwd) → { * score: number, * grad
+```
+
+### src/judge/judge-engine.js
+```
+module.exports = { groundedness, judge }
+function tokenize(text)
+function groundedness(response, context)
+function extractContextFiles(context, cwd)
+function judge(response, context, opts = {})
 ```
 
 ### src/learning/weights.js
@@ -562,43 +553,51 @@ function exportWeights(cwd, outputPath)
 function importWeights(cwd, importPath, replace)
 ```
 
-### src/config/loader.js
+### src/map/class-hierarchy.js
 ```
-module.exports = { loadConfig, loadBaseConfig }
-function loadBaseConfig(extendsVal, cwd)
-function detectAutoSrcDirs(cwd, excludeList) → string[]
-function _legacyDetectAutoSrcDirs(cwd, excludeList) → string[]
-function loadConfig(cwd) → object
-function deepClone(obj)
+module.exports = { analyze }
+function analyze(files, cwd)
 ```
 
-### src/discovery/framework-detector.js
+### src/map/import-graph.js
 ```
-module.exports = { detectFrameworks }
-function detectFrameworks(cwd)
-function _readDeps(cwd)
-function _readFile(p)
-function _existsAnywhere(cwd, filename, maxDepth)
-function _walkFind(dir, name, depth)
-```
-
-### src/discovery/language-detector.js
-```
-module.exports = { detectLanguages }
-function detectLanguages(cwd)
-function _walkDepth(dir, depth, extCount)
+module.exports = { analyze }
+function extractImports(filePath, content, fileSet)
+function resolveJsPath(dir, importStr, fileSet)
+function detectCycles(graph)
+function analyze(files, cwd)
 ```
 
-### src/discovery/sigmapignore.js
+### src/map/route-table.js
 ```
-module.exports = { loadIgnorePatterns, matchesIgnorePattern }
-function loadIgnorePatterns(cwd)
-function matchesIgnorePattern(dirName, patterns)
+module.exports = { analyze }
+function shouldSkipFile(rel)
+function analyze(files, cwd)
 ```
 
-### src/discovery/source-root-registry.js
+### src/mcp/handlers.js
 ```
-module.exports = { REGISTRY }
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact }
+function readContext(args, cwd)
+function searchSignatures(args, cwd)
+function getMap(args, cwd)
+function createCheckpoint(args, cwd)
+function getRouting(args, cwd)
+function explainFile(args, cwd)
+function listModules(args, cwd)
+function queryContext(args, cwd)
+function getImpact(args, cwd)
+```
+
+### src/mcp/tools.js
+```
+module.exports = { TOOLS }
+```
+
+### src/plan/planner.js
+```
+module.exports = { createPlan }
+function createPlan(goal, cwd, config)
 ```
 
 ### src/retrieval/ranker.js
@@ -616,10 +615,34 @@ function formatRankJSON(results, query) → object
 function detectIntent(query)
 ```
 
-### src/plan/planner.js
+### src/retrieval/tokenizer.js
 ```
-module.exports = { createPlan }
-function createPlan(goal, cwd, config)
+module.exports = { tokenize, STOP_WORDS }
+function tokenize(text, opts) → string[]
+```
+
+### src/routing/classifier.js
+```
+module.exports = { classify, classifyAll }
+function classify(filePath, sigs) → 'fast'|'balanced'|'powerf
+function classifyAll(fileEntries, cwd) → { fast: string[], balance
+```
+
+### src/routing/hints.js
+```
+module.exports = { TIERS, formatRoutingSection }
+function formatRoutingSection(groups) → string
+```
+
+### src/security/patterns.js
+```
+module.exports = { PATTERNS }
+```
+
+### src/security/scanner.js
+```
+module.exports = { scan }
+function scan(signatures, filePath) → { safe: string[], redacte
 ```
 
 ### src/session/memory.js
@@ -632,28 +655,40 @@ function mergeSessionContext(scores, session, currentIntent)
 function clearSession(cwd)
 ```
 
-### src/config/defaults.js
+### src/tracking/logger.js
 ```
-module.exports = { DEFAULTS }
-```
-
-### src/discovery/source-root-scorer.js
-```
-module.exports = { scoreCandidate, getRecentlyChangedDirs, ROOT_ENTRYPOINTS, JVM_PATH_PATTERN }
-function getRecentlyChangedDirs(cwd)
-function scoreCandidate(dirName, fullPath, context)
-function _countSourceFiles(dir, depth)
+module.exports = { logRun, readLog, summarize }
+function logRun(entry, cwd)
+function readLog(cwd) → object[]
+function summarize(entries) → object
 ```
 
-### src/discovery/source-root-resolver.js
+### src/eval/analyzer.js
 ```
-module.exports = { resolveSourceRoots }
-function resolveSourceRoots(cwd, opts = {})
-function _detectMonorepo(cwd)
-function _enumerateCandidates(cwd, isMonorepo, ignorePatterns, excludeList)
-function _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks)
-function _dedupeNested(scored)
-function _computeConfidence(frameworks, languages, scoredCount)
+module.exports = { analyzeFiles, formatAnalysisTable, formatAnalysisJSON }
+function isDockerfile(name)
+function getExtractorName(filePath)
+function tokenCount(sigs)
+function hasCoverage(filePath, cwd)
+function loadExtractor(name, cwd)
+function analyzeFiles(files, cwd, opts) → object[]
+function formatAnalysisTable(stats, showSlow) → string
+function formatAnalysisJSON(stats) → object
+```
+
+### src/discovery/language-detector.js
+```
+module.exports = { detectLanguages }
+function detectLanguages(cwd)
+function _walkDepth(dir, depth, extCount)
+```
+
+### src/extractors/gdscript.js
+```
+module.exports = { extract }
+function extract(src) → string[]
+function extractInnerMembers(stripped, startIndex)
+function normalizeParams(params)
 ```
 
 ### src/eval/usefulness-scorer.js

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -29,6 +29,7 @@ const EXT_MAP = {
   '.swift': 'swift',
   '.dart': 'dart',
   '.scala': 'scala',   '.sc': 'scala',
+  '.gd': 'gdscript',
   '.vue': 'vue',
   '.svelte': 'svelte',
   '.html': 'html',     '.htm': 'html',

--- a/src/discovery/language-detector.js
+++ b/src/discovery/language-detector.js
@@ -19,6 +19,7 @@ const EXT_TO_LANG = {
   '.java': 'java', '.kt': 'kotlin', '.cs': 'csharp', '.cpp': 'cpp',
   '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.swift': 'swift',
   '.dart': 'dart', '.scala': 'scala', '.php': 'php',
+  '.gd': 'gdscript',
 };
 
 function detectLanguages(cwd) {

--- a/src/eval/analyzer.js
+++ b/src/eval/analyzer.js
@@ -29,6 +29,7 @@ const EXT_MAP = {
   '.swift': 'swift',
   '.dart': 'dart',
   '.scala': 'scala',   '.sc': 'scala',
+  '.gd': 'gdscript',
   '.vue': 'vue',
   '.svelte': 'svelte',
   '.html': 'html',     '.htm': 'html',

--- a/src/extractors/gdscript.js
+++ b/src/extractors/gdscript.js
@@ -14,6 +14,7 @@ function extract(src) {
 
   let className = null;
   let baseName = null;
+  const addedClasses = new Set();
 
   const cm = stripped.match(/^class_name\s+(\w+)(?:\s+extends\s+([\w.]+))?/m);
   if (cm) {
@@ -27,6 +28,7 @@ function extract(src) {
 
   if (className) {
     sigs.push(baseName ? `class ${className}(${baseName})` : `class ${className}`);
+    addedClasses.add(className);
   } else if (baseName) {
     sigs.push(`extends ${baseName}`);
   }
@@ -48,8 +50,12 @@ function extract(src) {
   let constCount = 0;
   for (const m of stripped.matchAll(/^const\s+(\w+)(?:\s*:\s*[^=\n]+)?\s*:?=\s*([^\n]+)$/gm)) {
     let val = m[2].trim();
-    if (/^preload\s*\(/.test(val)) continue;
-    if (val.length > 40) val = val.slice(0, 37) + '...';
+    const preloadMatch = val.match(/^preload\s*\(([^)]+)\)/);
+    if (preloadMatch) {
+      val = `preload(${preloadMatch[1]})`;
+    } else if (val.length > 40) {
+      val = val.slice(0, 37) + '...';
+    }
     sigs.push(`${indent}const ${m[1]} = ${val}`);
     if (++constCount >= 5) break;
   }
@@ -57,24 +63,28 @@ function extract(src) {
   for (const m of stripped.matchAll(/^((?:@\w+(?:\([^)]*\))?\s+)*)var\s+(\w+)(?:\s*:\s*([^=\n]+?))?(?:\s*:?=\s*[^\n]+)?$/gm)) {
     const decorators = m[1] || '';
     const name = m[2];
-    const isExport = /@export/.test(decorators);
-    const isOnready = /@onready/.test(decorators);
-    if (!isExport && !isOnready && name.startsWith('_')) continue;
+    const hasDecorator = /@\w+/.test(decorators);
+    if (!hasDecorator && name.startsWith('_')) continue;
+    
+    let prefix = decorators.replace(/\([^)]*\)/g, '').trim().split(/\s+/).join(' ');
+    if (prefix) prefix += ' ';
+    
     const type = (m[3] || '').trim();
     const typeStr = type ? `: ${type}` : '';
-    const prefix = isExport ? '@export ' : (isOnready ? '@onready ' : '');
     sigs.push(`${indent}${prefix}var ${name}${typeStr}`);
   }
 
   for (const m of stripped.matchAll(/^(static\s+)?func\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*([^:\n]+))?\s*:/gm)) {
     const params = normalizeParams(m[3]);
     const ret = (m[4] || '').trim();
-    const retStr = ret ? ` → ${ret.slice(0, 25)}` : '';
+    const retStr = ret ? ` → ${ret.slice(0, 30)}` : '';
     const staticKw = m[1] ? 'static ' : '';
     sigs.push(`${indent}${staticKw}func ${m[2]}(${params})${retStr}`);
   }
 
   for (const m of stripped.matchAll(/^class\s+(\w+)(?:\s+extends\s+(\w+))?\s*:/gm)) {
+    if (addedClasses.has(m[1])) continue;
+    addedClasses.add(m[1]);
     sigs.push(m[2] ? `class ${m[1]}(${m[2]})` : `class ${m[1]}`);
     const startIdx = m.index + m[0].length;
     for (const meth of extractInnerMembers(stripped, startIdx)) {
@@ -95,7 +105,7 @@ function extractInnerMembers(stripped, startIndex) {
     if (fm) {
       const params = normalizeParams(fm[3]);
       const ret = (fm[4] || '').trim();
-      const retStr = ret ? ` → ${ret.slice(0, 25)}` : '';
+      const retStr = ret ? ` → ${ret.slice(0, 30)}` : '';
       const staticKw = fm[1] ? 'static ' : '';
       members.push(`${staticKw}func ${fm[2]}(${params})${retStr}`);
     }

--- a/src/extractors/gdscript.js
+++ b/src/extractors/gdscript.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * Extract signatures from Godot GDScript source code.
+ * @param {string} src - Raw file content
+ * @returns {string[]} Array of signature strings
+ */
+
+function extract(src) {
+  if (!src || typeof src !== 'string') return [];
+  const sigs = [];
+
+  const stripped = src.replace(/#.*$/gm, '');
+
+  let className = null;
+  let baseName = null;
+
+  const cm = stripped.match(/^class_name\s+(\w+)(?:\s+extends\s+([\w.]+))?/m);
+  if (cm) {
+    className = cm[1];
+    if (cm[2]) baseName = cm[2];
+  }
+  if (!baseName) {
+    const em = stripped.match(/^extends\s+([\w."/]+)/m);
+    if (em) baseName = em[1];
+  }
+
+  if (className) {
+    sigs.push(baseName ? `class ${className}(${baseName})` : `class ${className}`);
+  } else if (baseName) {
+    sigs.push(`extends ${baseName}`);
+  }
+
+  const indent = (className || baseName) ? '  ' : '';
+
+  for (const m of stripped.matchAll(/^signal\s+(\w+)(?:\s*\(([^)]*)\))?/gm)) {
+    sigs.push(`${indent}signal ${m[1]}(${normalizeParams(m[2] || '')})`);
+  }
+
+  for (const m of stripped.matchAll(/^enum\s+(\w+)\s*\{([^}]*)\}/gm)) {
+    const members = m[2]
+      .split(',')
+      .map((s) => s.trim().split(/\s*=/)[0].trim())
+      .filter(Boolean);
+    sigs.push(`${indent}enum ${m[1]} { ${members.slice(0, 6).join(', ')} }`);
+  }
+
+  let constCount = 0;
+  for (const m of stripped.matchAll(/^const\s+(\w+)(?:\s*:\s*[^=\n]+)?\s*:?=\s*([^\n]+)$/gm)) {
+    let val = m[2].trim();
+    if (/^preload\s*\(/.test(val)) continue;
+    if (val.length > 40) val = val.slice(0, 37) + '...';
+    sigs.push(`${indent}const ${m[1]} = ${val}`);
+    if (++constCount >= 5) break;
+  }
+
+  for (const m of stripped.matchAll(/^((?:@\w+(?:\([^)]*\))?\s+)*)var\s+(\w+)(?:\s*:\s*([^=\n]+?))?(?:\s*:?=\s*[^\n]+)?$/gm)) {
+    const decorators = m[1] || '';
+    const name = m[2];
+    const isExport = /@export/.test(decorators);
+    const isOnready = /@onready/.test(decorators);
+    if (!isExport && !isOnready && name.startsWith('_')) continue;
+    const type = (m[3] || '').trim();
+    const typeStr = type ? `: ${type}` : '';
+    const prefix = isExport ? '@export ' : (isOnready ? '@onready ' : '');
+    sigs.push(`${indent}${prefix}var ${name}${typeStr}`);
+  }
+
+  for (const m of stripped.matchAll(/^(static\s+)?func\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*([^:\n]+))?\s*:/gm)) {
+    const params = normalizeParams(m[3]);
+    const ret = (m[4] || '').trim();
+    const retStr = ret ? ` → ${ret.slice(0, 25)}` : '';
+    const staticKw = m[1] ? 'static ' : '';
+    sigs.push(`${indent}${staticKw}func ${m[2]}(${params})${retStr}`);
+  }
+
+  for (const m of stripped.matchAll(/^class\s+(\w+)(?:\s+extends\s+(\w+))?\s*:/gm)) {
+    sigs.push(m[2] ? `class ${m[1]}(${m[2]})` : `class ${m[1]}`);
+    const startIdx = m.index + m[0].length;
+    for (const meth of extractInnerMembers(stripped, startIdx)) {
+      sigs.push(`  ${meth}`);
+    }
+  }
+
+  return sigs.slice(0, 25);
+}
+
+function extractInnerMembers(stripped, startIndex) {
+  const members = [];
+  const lines = stripped.slice(startIndex).split('\n');
+  for (const line of lines) {
+    if (line.trim() === '') continue;
+    if (!/^\s+/.test(line)) break;
+    const fm = line.match(/^\s+(static\s+)?func\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*([^:\n]+))?\s*:/);
+    if (fm) {
+      const params = normalizeParams(fm[3]);
+      const ret = (fm[4] || '').trim();
+      const retStr = ret ? ` → ${ret.slice(0, 25)}` : '';
+      const staticKw = fm[1] ? 'static ' : '';
+      members.push(`${staticKw}func ${fm[2]}(${params})${retStr}`);
+    }
+  }
+  return members.slice(0, 6);
+}
+
+function normalizeParams(params) {
+  if (!params) return '';
+  return params.trim()
+    .split(',')
+    .map((p) => {
+      const part = p.trim();
+      if (!part) return '';
+      const eqIdx = part.indexOf('=');
+      const noDefault = eqIdx !== -1 ? part.slice(0, eqIdx).trim() : part;
+      return noDefault.split(':')[0].trim();
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+module.exports = { extract };

--- a/test/expected/gdscript.txt
+++ b/test/expected/gdscript.txt
@@ -1,0 +1,19 @@
+class Player(CharacterBody2D)
+  signal health_changed(new_value)
+  signal died()
+  enum State { IDLE, RUN, JUMP, FALL }
+  const MAX_SPEED = 300.0
+  const ACCEL = 50.0
+  @export var speed: float
+  @export var max_health: int
+  @onready var sprite: Sprite2D
+  var current_health: int
+  func _ready() → void
+  func _physics_process(delta) → void
+  func take_damage(amount) → bool
+  func heal(amount) → void
+  static func from_dict(data) → Player
+  func _private_helper()
+class Inventory
+  func add(item) → void
+  func remove(item) → bool

--- a/test/expected/gdscript.txt
+++ b/test/expected/gdscript.txt
@@ -4,9 +4,10 @@ class Player(CharacterBody2D)
   enum State { IDLE, RUN, JUMP, FALL }
   const MAX_SPEED = 300.0
   const ACCEL = 50.0
+  const ENEMY_SCENE = preload("res://enemy.tscn")
   @export var speed: float
-  @export var max_health: int
-  @onready var sprite: Sprite2D
+  @export_range var max_health: int
+  @export @onready var sprite: Sprite2D
   var current_health: int
   func _ready() → void
   func _physics_process(delta) → void
@@ -14,6 +15,7 @@ class Player(CharacterBody2D)
   func heal(amount) → void
   static func from_dict(data) → Player
   func _private_helper()
+  func get_very_long_return_type_name_to_test_truncation() → VeryLongReturnTypeNameToTestTr
 class Inventory
   func add(item) → void
   func remove(item) → bool

--- a/test/fixtures/gdscript.gd
+++ b/test/fixtures/gdscript.gd
@@ -7,12 +7,13 @@ signal died
 
 const MAX_SPEED := 300.0
 const ACCEL = 50.0
+const ENEMY_SCENE = preload("res://enemy.tscn")
 
 enum State { IDLE, RUN, JUMP, FALL }
 
 @export var speed: float = 200.0
 @export_range(0, 100) var max_health: int = 100
-@onready var sprite: Sprite2D = $Sprite2D
+@export @onready var sprite: Sprite2D = $Sprite2D
 var current_health: int
 var _internal_state: int = 0
 
@@ -42,6 +43,12 @@ static func from_dict(data: Dictionary) -> Player:
 func _private_helper():
 	return _internal_state
 
+func get_very_long_return_type_name_to_test_truncation() -> VeryLongReturnTypeNameToTestTruncation:
+	pass
+
+# This inner class should be skipped because it matches the class_name
+class Player:
+	pass
 
 class Inventory:
 	var items: Array

--- a/test/fixtures/gdscript.gd
+++ b/test/fixtures/gdscript.gd
@@ -1,0 +1,53 @@
+# Player controller fixture for SigMap GDScript extractor.
+class_name Player
+extends CharacterBody2D
+
+signal health_changed(new_value: int)
+signal died
+
+const MAX_SPEED := 300.0
+const ACCEL = 50.0
+
+enum State { IDLE, RUN, JUMP, FALL }
+
+@export var speed: float = 200.0
+@export_range(0, 100) var max_health: int = 100
+@onready var sprite: Sprite2D = $Sprite2D
+var current_health: int
+var _internal_state: int = 0
+
+
+func _ready() -> void:
+	current_health = max_health
+
+
+func _physics_process(delta: float) -> void:
+	velocity.x = speed * delta
+
+
+func take_damage(amount: int) -> bool:
+	current_health -= amount
+	health_changed.emit(current_health)
+	return current_health <= 0
+
+
+func heal(amount: int) -> void:
+	current_health += amount
+
+
+static func from_dict(data: Dictionary) -> Player:
+	return Player.new()
+
+
+func _private_helper():
+	return _internal_state
+
+
+class Inventory:
+	var items: Array
+
+	func add(item) -> void:
+		items.append(item)
+
+	func remove(item) -> bool:
+		return items.erase(item)

--- a/test/run.js
+++ b/test/run.js
@@ -44,6 +44,7 @@ const LANG_EXT = {
   yaml: 'yml',
   shell: 'sh',
   dockerfile: 'Dockerfile',
+  gdscript: 'gd',
 };
 
 let passed = 0;


### PR DESCRIPTION
## Summary
- Add `src/extractors/gdscript.js` to extract function signatures and inner members from Godot `.gd` files
- Wire `.gd` into the core extractor map, language detector, eval analyzer, and test runner
- Add fixture (`test/fixtures/gdscript.gd`) and expected output (`test/expected/gdscript.txt`)

## Test plan
- [x] `node test/run.js` passes, including the new gdscript fixture
- [x] Run sigmap against a Godot project and confirm `.gd` signatures appear in the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)