### PR TITLE
fix: resolve ReferenceError in --query when no context file (#150)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -11182,6 +11182,7 @@ function main() {
       // Priority: --output flag > --adapter flag > buildSigIndex probe order
       //   (customOutput from config is handled inside buildSigIndex itself)
       let queryOpts;
+      const adpIdx = args.indexOf('--adapter');
 
       // 1. --output <file> pins to an explicit path
       if (config.customOutput) {
@@ -11189,17 +11190,14 @@ function main() {
       }
 
       // 2. --adapter <name> pins to that adapter's output path (if --output not given)
-      if (!queryOpts) {
-        const adpIdx = args.indexOf('--adapter');
-        if (adpIdx >= 0) {
-          const adapterName = (args[adpIdx + 1] || '').trim().toLowerCase();
-          const VALID_ADAPTERS = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex'];
-          if (VALID_ADAPTERS.includes(adapterName)) {
-            try {
-              const adapterMod = __require('./packages/adapters/' + adapterName);
-              queryOpts = { contextPath: adapterMod.outputPath(cwd) };
-            } catch (_) {}
-          }
+      if (!queryOpts && adpIdx >= 0) {
+        const adapterName = (args[adpIdx + 1] || '').trim().toLowerCase();
+        const VALID_ADAPTERS = ['copilot', 'claude', 'cursor', 'windsurf', 'openai', 'gemini', 'codex'];
+        if (VALID_ADAPTERS.includes(adapterName)) {
+          try {
+            const adapterMod = __require('./packages/adapters/' + adapterName);
+            queryOpts = { contextPath: adapterMod.outputPath(cwd) };
+          } catch (_) {}
         }
       }
 


### PR DESCRIPTION
## Summary
- Fixes ReferenceError when using `--query` without a context file
- Moves variable declaration to proper scope
- Combines related conditions for clarity

## Changes
- **gen-context.js**: Moved `const adpIdx` declaration before conditional block so it's accessible in all code paths where it's referenced

## Test plan
- [x] All 21 unit tests pass
- [x] All 60 integration tests pass
- [x] Manual test: `node gen-context.js --query "auth"` (without context file) works without error

Fixes #150