### PR TITLE
fix: support bracket character classes and trailing slashes in .contextignore patterns (#149)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -8104,8 +8104,12 @@ function matchesIgnore(relPath, patterns) {
       .replace(/\*\*/g, '___DOUBLE___')
       .replace(/\*/g, '[^/]*')
       .replace(/___DOUBLE___/g, '.*');
-    const regex = new RegExp(`(^|/)${regexStr}($|/)`);
-    if (regex.test(relPath)) return true;
+    try {
+      const regex = new RegExp(`(^|/)${regexStr}($|/)`);
+      if (regex.test(relPath)) return true;
+    } catch (_) {
+      // Malformed bracket syntax or invalid regex — skip this pattern
+    }
   }
   return false;
 }

--- a/gen-context.js
+++ b/gen-context.js
@@ -8094,9 +8094,13 @@ function loadIgnorePatterns(cwd) {
 function matchesIgnore(relPath, patterns) {
   for (const pat of patterns) {
     const normalized = pat.replace(/\\/g, '/');
-    // Simple glob: support * and ** and trailing /
-    const regexStr = normalized
-      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    // Strip trailing slash (gitignore style — directory patterns)
+    const patternToUse = normalized.endsWith('/')
+      ? normalized.slice(0, -1)
+      : normalized;
+    // Escape regex special chars but NOT brackets (keep them for character classes)
+    const regexStr = patternToUse
+      .replace(/[.+^${}()|\\]/g, '\\$&')
       .replace(/\*\*/g, '___DOUBLE___')
       .replace(/\*/g, '[^/]*')
       .replace(/___DOUBLE___/g, '.*');


### PR DESCRIPTION
## Summary
- Fixes bracket character classes (`[Bb]`) being treated as literals instead of regex patterns
- Fixes trailing slash (`/`) directory patterns not matching nested paths
- Patterns like `[Bb]in/`, `[Oo]bj/`, `dist/` now work correctly

## Changes
- **gen-context.js**: Updated `matchesIgnore()` function to:
  - Not escape bracket characters so they work as regex character classes
  - Strip trailing slashes before building regex (gitignore convention)

## Test plan
- [x] All 21 unit tests pass
- [x] All 60 integration tests pass
- [x] Verified bracket classes: `[Bb]in/` matches `bin/`, `Bin/`, nested paths
- [x] Verified trailing slashes: `bin/`, `node_modules/` correctly match nested directories

Fixes #149