### PR TITLE
feat(extractors): add R language support (RScript extractor)

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -29,6 +29,7 @@ const EXT_MAP = {
   '.swift': 'swift',
   '.dart': 'dart',
   '.scala': 'scala',   '.sc': 'scala',
+  '.r': 'r',           '.R': 'r',
   '.vue': 'vue',
   '.svelte': 'svelte',
   '.html': 'html',     '.htm': 'html',

--- a/src/discovery/language-detector.js
+++ b/src/discovery/language-detector.js
@@ -19,6 +19,7 @@ const EXT_TO_LANG = {
   '.java': 'java', '.kt': 'kotlin', '.cs': 'csharp', '.cpp': 'cpp',
   '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.swift': 'swift',
   '.dart': 'dart', '.scala': 'scala', '.php': 'php',
+  '.r': 'r', '.R': 'r',
 };
 
 function detectLanguages(cwd) {

--- a/src/discovery/source-root-registry.js
+++ b/src/discovery/source-root-registry.js
@@ -161,6 +161,15 @@ const REGISTRY = {
     srcDirs:  ['src/main/scala','src'],
     penalties: ['target'],
   },
+
+  r: {
+    manifestFiles: ['DESCRIPTION','renv.lock'],
+    frameworks: {
+      shiny: { detectionFiles: ['app.R','ui.R','server.R'], srcDirs: ['R','inst','tests'], entrypoints: ['app.R','server.R'] },
+    },
+    srcDirs:  ['R','src','inst'],
+    penalties: ['renv','packrat','.Rcheck'],
+  },
 };
 
 module.exports = { REGISTRY };

--- a/src/eval/analyzer.js
+++ b/src/eval/analyzer.js
@@ -29,6 +29,7 @@ const EXT_MAP = {
   '.swift': 'swift',
   '.dart': 'dart',
   '.scala': 'scala',   '.sc': 'scala',
+  '.r': 'r',           '.R': 'r',
   '.vue': 'vue',
   '.svelte': 'svelte',
   '.html': 'html',     '.htm': 'html',

--- a/src/extractors/r.js
+++ b/src/extractors/r.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * Extract signatures from R source code.
+ * @param {string} src - Raw file content
+ * @returns {string[]} Array of signature strings
+ */
+function extract(src) {
+  if (!src || typeof src !== 'string') return [];
+  const sigs = [];
+
+  // Strip line comments. R uses # comments. Roxygen2 (#') comments are
+  // stripped along with regular ones; Phase 2 may parse them.
+  const stripped = src.replace(/#.*$/gm, '');
+
+  // Function definitions:
+  //   name <- function(args) { ... }
+  //   name = function(args) { ... }
+  //   name <<- function(args) { ... }
+  // Args may span multiple lines and contain default values, so we need to
+  // match a balanced parenthesis group rather than a single line.
+  const funcRe = /^(?:[ \t]*)([\w.]+)\s*(?:<<-|<-|=)\s*function\s*\(/gm;
+  let m;
+  while ((m = funcRe.exec(stripped)) !== null) {
+    const name = m[1];
+    if (name.startsWith('.')) continue; // private convention
+    const argsStart = funcRe.lastIndex;
+    const args = readBalancedParens(stripped, argsStart - 1);
+    if (args === null) continue;
+    sigs.push(`${name} <- function(${normalizeParams(args)})`);
+  }
+
+  // S4 setMethod / setGeneric:
+  //   setGeneric("name", function(args) standardGeneric("name"))
+  //   setMethod("name", "ClassName", function(args) { ... })
+  for (const sm of stripped.matchAll(/^[ \t]*setGeneric\s*\(\s*["']([\w.]+)["']/gm)) {
+    sigs.push(`setGeneric("${sm[1]}")`);
+  }
+  for (const sm of stripped.matchAll(/^[ \t]*setMethod\s*\(\s*["']([\w.]+)["']\s*,\s*["']([\w.]+)["']/gm)) {
+    sigs.push(`setMethod("${sm[1]}", "${sm[2]}")`);
+  }
+
+  // S4 class definitions:
+  //   setClass("Name", representation(...), ...)
+  for (const sm of stripped.matchAll(/^[ \t]*setClass\s*\(\s*["']([\w.]+)["']/gm)) {
+    sigs.push(`setClass("${sm[1]}")`);
+  }
+
+  return sigs.slice(0, 30);
+}
+
+/**
+ * Read a parenthesis-balanced substring starting at the position of the
+ * opening '(' character, returning the inner content (without the outer
+ * parens). Returns null if no matching close paren is found within `cap`
+ * characters, which guards against runaway scans on malformed input.
+ */
+function readBalancedParens(src, openIdx, cap = 4096) {
+  if (src[openIdx] !== '(') return null;
+  let depth = 1;
+  let i = openIdx + 1;
+  const end = Math.min(src.length, openIdx + cap);
+  let inString = null; // null | '"' | "'"
+  while (i < end) {
+    const ch = src[i];
+    if (inString) {
+      if (ch === '\\') { i += 2; continue; }
+      if (ch === inString) inString = null;
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { inString = ch; i++; continue; }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return src.slice(openIdx + 1, i);
+    }
+    i++;
+  }
+  return null;
+}
+
+/**
+ * Compress whitespace inside a parameter list, collapse multi-line default
+ * expressions onto a single line, and trim. The goal is one-line readable
+ * signatures, not a faithful AST.
+ *
+ * String literals are protected so that commas/equals inside default values
+ * like sep = "," don't get respaced.
+ */
+function normalizeParams(raw) {
+  const tokens = [];
+  let buf = '';
+  let inString = null;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inString) {
+      buf += ch;
+      if (ch === '\\' && i + 1 < raw.length) { buf += raw[i + 1]; i++; continue; }
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { inString = ch; buf += ch; continue; }
+    buf += ch;
+  }
+  // Now buf === raw with strings preserved character-for-character.
+  // Walk again: collapse non-string runs of whitespace, normalize ', ' and ' = '.
+  let out = '';
+  inString = null;
+  for (let i = 0; i < buf.length; i++) {
+    const ch = buf[i];
+    if (inString) {
+      out += ch;
+      if (ch === '\\' && i + 1 < buf.length) { out += buf[i + 1]; i++; continue; }
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { inString = ch; out += ch; continue; }
+    if (/\s/.test(ch)) {
+      if (out.length && !/\s$/.test(out)) out += ' ';
+      continue;
+    }
+    if (ch === ',') {
+      out = out.replace(/\s+$/, '') + ', ';
+      continue;
+    }
+    if (ch === '=') {
+      out = out.replace(/\s+$/, '') + ' = ';
+      continue;
+    }
+    out += ch;
+  }
+  return out.trim();
+}
+
+module.exports = { extract };

--- a/test/expected/r.txt
+++ b/test/expected/r.txt
@@ -1,0 +1,7 @@
+moving_average <- function(x, n = 5)
+greet <- function(name = "world", greeting = "hello")
+load_data <- function(path, sep = ",", na.strings = c("NA", "", "n/a"), stringsAsFactors = FALSE)
+server <- function(input, output, session)
+setGeneric("distance_to_origin")
+setMethod("distance_to_origin", "Point")
+setClass("Point")

--- a/test/fixtures/r.r
+++ b/test/fixtures/r.r
@@ -1,0 +1,44 @@
+# Sample R source representative of a Shiny dashboard / data analysis
+# project. Mixes top-level function definitions, default args, the `=` form,
+# S3/S4 patterns, and a roxygen2-style block.
+
+#' Compute a moving average over a numeric vector.
+#'
+#' @param x   numeric vector
+#' @param n   integer window size, defaults to 5
+#' @return    numeric vector of the same length as x
+moving_average <- function(x, n = 5) {
+  stats::filter(x, rep(1 / n, n), sides = 2)
+}
+
+# Equals form is also valid in R
+greet = function(name = "world", greeting = "hello") {
+  paste0(greeting, ", ", name)
+}
+
+# Multi-line argument list with a default expression
+load_data <- function(
+  path,
+  sep = ",",
+  na.strings = c("NA", "", "n/a"),
+  stringsAsFactors = FALSE
+) {
+  read.csv(path, sep = sep, na.strings = na.strings, stringsAsFactors = stringsAsFactors)
+}
+
+# Shiny server function shape
+server <- function(input, output, session) {
+  output$plot <- renderPlot({ plot(input$x) })
+}
+
+# Private function (leading dot) — should be skipped
+.internal_helper <- function(x) x * 2
+
+# S4 patterns
+setClass("Point", representation(x = "numeric", y = "numeric"))
+
+setGeneric("distance_to_origin", function(p) standardGeneric("distance_to_origin"))
+
+setMethod("distance_to_origin", "Point", function(p) {
+  sqrt(p@x^2 + p@y^2)
+})

--- a/test/run.js
+++ b/test/run.js
@@ -37,6 +37,7 @@ const LANG_EXT = {
   swift: 'swift',
   dart: 'dart',
   scala: 'scala',
+  r: 'r',
   vue: 'vue',
   svelte: 'svelte',
   html: 'html',


### PR DESCRIPTION
Closes #164.

Phase 1 per the issue scope. The four EXT_MAPs and the test runner all gain `r`, plus a new extractor and fixture.

## Approach

`src/extractors/r.js` walks the source after stripping `#` comments. It emits one line per:
- top-level function definition — `name <- function(args)`, `name = function(args)`, `name <<- function(args)`. Multi-line argument lists are collapsed via balanced-paren reading rather than a single-line regex, so `load_data(path, sep = ",", na.strings = c("NA", "", "n/a"), ...)` survives intact.
- S4 patterns — `setGeneric("foo")`, `setMethod("foo", "ClassName")`, `setClass("Name")`.
- Names starting with `.` are dropped, mirroring the convention other extractors use for `_`-prefixed Python / Ruby methods.

Default values are preserved verbatim. String literals are tokenised so that the comma in `sep = ","` doesn't get respaced by the `, ` rule that other extractors apply naively.

## Integration points

- `src/discovery/language-detector.js` — `.r` and `.R` map to `r` so `detectLanguages()` ranks R against other languages.
- `src/discovery/source-root-registry.js` — adds an `r` entry: `DESCRIPTION` / `renv.lock` manifests, `R/` + `inst/` + `src/` srcDirs, and a `shiny` framework keyed off `app.R` / `ui.R` / `server.R`.
- `src/eval/analyzer.js` — `.r` and `.R` registered in EXT_MAP so per-file diagnostics resolve the right extractor.
- `packages/core/index.js` — same EXT_MAP entry so the core package's API surface picks R up.
- `test/run.js` — `r: 'r'` so the existing zero-dep runner discovers `test/fixtures/r.r` against `test/expected/r.txt`.

`gen-context.js` is the bundled distribution per its header (`generated by scripts/bundle.js`); I left it for the maintainer to rebuild on the next release.

## Test fixture

`test/fixtures/r.r` is representative of a Shiny / data-analysis project:

- `moving_average <- function(x, n = 5)` — basic default
- `greet = function(...)` — `=` form
- `load_data <- function(path, sep = ",", na.strings = c("NA", "", "n/a"), ...)` — multi-line, comma-in-string default, `c(...)` call default
- `server <- function(input, output, session)` — Shiny server shape
- `.internal_helper <- function(x)` — leading-dot, must be skipped
- `setClass("Point", ...)` / `setGeneric` / `setMethod` — S4

`test/expected/r.txt` was generated with `node test/run.js r --update`. Output: 7 signatures, the `.internal_helper` correctly omitted.

## Test status

```
node test/run.js              → 22 passed, 0 failed (was 21 + r)
node test/integration/strategy.test.js     → 8 passed, 0 failed
node test/integration/secret-scan.test.js  → 12 passed, 0 failed
node test/integration/token-budget.test.js → 5 passed, 0 failed
node test/integration/auto-budget.test.js  → 12 passed, 0 failed
node test/v351-features.test.js            → 39 passed, 0 failed
node test/v360-features.test.js            → 35 passed, 2 failed (pre-existing,
                                              same on master without my changes;
                                              version=3.6.0/output=6.10.0 + missing
                                              decorations.js)
```

## Out of scope (Phase 2 from the issue)

- Roxygen2 (`#'`) comment parsing — currently stripped along with regular `#` comments
- S3 method dispatch (e.g. `print.MyClass <- function(x, ...)`)
- Package namespace detection (`@import`, `NAMESPACE`)
- `.Rmd` (R Markdown) chunk extraction

Happy to follow up with Phase 2 if Phase 1 lands the way you'd like.

## Open AC

- "Verified working on community test project (Shiny dashboard)" — I don't have access to `Altruistic_Still2370`'s project, so the fixture is the closest stand-in I could produce. If the community tester can run `node gen-context.js` against their Shiny dashboard, that confirms the AC.