### PR TITLE
fix(mcp): export extractImports from bundled import-graph module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.10.4] — 2026-05-11
+
+### Fixed
+
+- **Bundled MCP tools extractImports export** — Fixed `extractImports` function not being exported from the import-graph factory in bundled gen-context.js, which caused `explain_file` (imports/callers) and `get_impact` MCP tools to fail with "extractImports is not a function" when running via `--mcp` server. Added comprehensive tests to prevent regression.
+
+---
+
 ## [6.10.3] — 2026-05-11
 
 ### Fixed

--- a/gen-context.js
+++ b/gen-context.js
@@ -5607,7 +5607,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.10.3',
+  version: '6.10.4',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -8234,7 +8234,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.10.3';
+const VERSION = '6.10.4';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -4610,9 +4610,9 @@ __factories["./src/map/import-graph"] = function(module, exports) {
   
     return lines.join('\n');
   }
-  
-  module.exports = { analyze };
-  
+
+  module.exports = { analyze, extractImports };
+
 };
 
 // ── ./src/map/route-table ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.10.3',
+  version: '6.10.4',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -324,6 +324,67 @@ test('create_checkpoint reports missing context when no file', () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────
+// explain_file (imports/callers) and get_impact — extractImports export test
+// ─────────────────────────────────────────────────────────────
+
+function seedProjectWithImports(dir) {
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+  fs.writeFileSync(path.join(dir, 'src', 'utils.js'), 'function log(msg) { console.log(msg); }');
+  fs.writeFileSync(path.join(dir, 'src', 'config.js'), 'module.exports = { debug: true };');
+  fs.writeFileSync(
+    path.join(dir, 'src', 'app.js'),
+    "const utils = require('./utils');\nconst config = require('./config');\nfunction start() { utils.log('started'); }"
+  );
+  fs.writeFileSync(path.join(dir, 'src', 'main.js'), "const app = require('./app');\napp.start();");
+
+  // Generate context
+  execSync(`node "${GEN_CONTEXT}"`, { cwd: dir, stdio: 'pipe' });
+}
+
+test('explain_file with imports parameter works without extractImports error', () => {
+  withTempProject((dir) => {
+    seedProjectWithImports(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 30, params: { name: 'explain_file', arguments: { path: 'src/app.js' } } },
+      dir
+    );
+    assert.ok(res.result, 'Should have result');
+    const text = res.result.content[0].text;
+    assert.ok(!text.includes('extractImports is not a function'), 'Should NOT have extractImports error');
+    assert.ok(text.includes('## Imports'), 'Should include Imports section');
+  });
+});
+
+test('explain_file with callers parameter works without extractImports error', () => {
+  withTempProject((dir) => {
+    seedProjectWithImports(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 31, params: { name: 'explain_file', arguments: { path: 'src/utils.js' } } },
+      dir
+    );
+    assert.ok(res.result, 'Should have result');
+    const text = res.result.content[0].text;
+    assert.ok(!text.includes('extractImports is not a function'), 'Should NOT have extractImports error');
+    assert.ok(text.includes('## Callers'), 'Should include Callers section');
+  });
+});
+
+test('get_impact tool works without extractImports error', () => {
+  withTempProject((dir) => {
+    seedProjectWithImports(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 32, params: { name: 'get_impact', arguments: { file: 'src/utils.js' } } },
+      dir
+    );
+    assert.ok(res.result, 'Should have result');
+    const text = res.result.content[0].text;
+    assert.ok(!text.includes('extractImports is not a function'), 'Should NOT have extractImports error');
+    assert.ok(text.includes('## Impact'), 'Should include Impact section');
+  });
+});
+
 console.log('');
 console.log(`mcp-server: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.10.3",
+  "version": "6.10.4",
   "benchmark_date": "2026-05-05",
   "benchmark_id": "sigmap-v6.10-main",
   "languages": 29,


### PR DESCRIPTION
## Summary
- Fixed bundled gen-context.js not exporting `extractImports` from import-graph factory (line 4614)
- This was causing three MCP tools to fail: `explain_file` (imports/callers) and `get_impact`
- Closes #174

## Changes
- **gen-context.js**: Updated module.exports to include extractImports
- **test/integration/mcp/server.test.js**: Added 3 comprehensive tests for the affected tools

## Test plan
- [x] All integration tests pass (`node test/integration/all.js`) — 60/60 tests passing
- [x] Manual smoke test: `echo '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"explain_file","arguments":{"path":"src/mcp/handlers.js"}}}' | node gen-context.js --mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)