### PR TITLE
release: v6.10.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Always run `sigmap ask` or `sigmap --query` before searching for files relevant 
 src/extractors/python_ast.py ← ast
 ```
 
-## changes (last 5 commits — 9 minutes ago)
+## changes (last 5 commits — 11 minutes ago)
 ```
 src/analysis/diagnostics.js                   +estimateTokens  +formatFileDecision  +computeFileMetrics  +explainInclusion
 src/map/import-graph.js                       +buildReverseGraph  ~extractImports  ~resolveJsPath  ~detectCycles
@@ -605,15 +605,6 @@ function formatAnalysisTable(stats, showSlow) → string
 function formatAnalysisJSON(stats) → object
 ```
 
-### src/mcp/server.js
-```
-module.exports = { start }
-function respond(id, result)
-function respondError(id, code, message)
-function dispatch(msg, cwd)
-function start(cwd)
-```
-
 ### src/analysis/diagnostics.js
 ```
 module.exports = { formatFileDecision, computeFileMetrics, explainInclusion, explainExclusion, estimateTokens }
@@ -632,4 +623,13 @@ function resolveJsPath(dir, importStr, fileSet)
 function detectCycles(graph)
 function buildReverseGraph(graph)
 function analyze(files, cwd)
+```
+
+### src/mcp/server.js
+```
+module.exports = { start }
+function respond(id, result)
+function respondError(id, code, message)
+function dispatch(msg, cwd)
+function start(cwd)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.10.7] — 2026-05-12
+
+### Fixed
+
+- **Python absolute imports in bundled gen-context.js** — Added Python absolute import detection (`from package.module import X`) to bundled extractImports function. The source code had this support but it was missing from the bundle, causing MCP tools to show empty import graphs for Python monorepos. Now matches source behavior correctly.
+
+---
+
 ## [6.10.6] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Ask → Rank → Context → Validate → Judge → Learn
 
 ```
 Benchmark : sigmap-v6.10-main
-Date      : 2026-05-05
+Date      : 2026-05-12
 
 Hit@5          : 80.0%   (baseline 13.6%  — 5.9× lift)
-Prompt reduction : 41.0%
+Prompt reduction : 41.4%
 Task success   : 52.2%   (baseline 10%)
 Prompts / task : 1.68    (baseline 2.84)
 Token reduction: 40–98%  (avg 96.8% across 18 real repos)

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Benchmark overview
-description: Official v6.10.6 benchmark snapshot. 96.8% average token reduction, 80.0% retrieval hit@5, 41.0% fewer prompts, and 13/18 raw repos overflowing GPT-4o without SigMap.
+description: Official v6.10.7 benchmark snapshot. 96.8% average token reduction, 80.0% retrieval hit@5, 41.4% fewer prompts, and 13/18 raw repos overflowing GPT-4o without SigMap.
 head:
   - - meta
     - property: og:title
-      content: "SigMap benchmark overview — v6.10.1 snapshot"
+      content: "SigMap benchmark overview — v6.10.7 snapshot"
   - - meta
     - property: og:description
-      content: "One place for token, retrieval, quality, and task metrics from the latest saved v6.10.6 benchmark run."
+      content: "One place for token, retrieval, quality, and task metrics from the latest saved v6.10.7 benchmark run."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/benchmark"
@@ -16,14 +16,14 @@ head:
 # Benchmark overview
 
 ::: info Official v6.10 benchmark snapshot
-**Benchmark ID:** sigmap-v6.10-main &nbsp;·&nbsp; **Date:** 2026-05-05
+**Benchmark ID:** sigmap-v6.10-main &nbsp;·&nbsp; **Date:** 2026-05-12
 
 | Metric | Value |
 |---|---:|
 | Hit@5 | **80.0%** vs 13.6% baseline |
 | Graph-boosted hit@5 | **80.0%** |
 | Retrieval lift | **5.9×** |
-| Prompt reduction | **41.0%** (2.84 → 1.68) |
+| Prompt reduction | **41.4%** (2.84 → 1.68) |
 | Task success proxy | **52.2%** |
 | Overall token reduction | **96.8%** |
 | GPT-4o overflow (without → with) | **13/18 → 0/18** |
@@ -40,7 +40,7 @@ This is the landing page for the public benchmark story. It answers four differe
 
 ## Official v6.10 snapshot
 
-Latest saved benchmark run: **2026-05-05 (v6.10.0)**
+Latest saved benchmark run: **2026-05-12 (v6.10.7)**
 
 | Metric | Result |
 |---|---:|

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -34,7 +34,7 @@ Token reduction is the mechanism. This benchmark shows the operational consequen
 - how much code would be hidden without SigMap?
 - what does that mean for API cost?
 
-Latest saved run: **2026-05-05 (v6.10.0)**
+Latest saved run: **2026-05-12 (v6.10.7)**
 
 ## Headline numbers
 

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **13/18 → 0/18** |
 :::
 
-Latest saved run: **2026-05-05 (v6.10.0)**
+Latest saved run: **2026-05-12 (v6.10.7)**
 
 **Result:** SigMap finds the right file in the top 5 far more often than chance — **80.0% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.10.6, with the latest releases implementing Python import detection, adding comprehensive diagnostics, and establishing develop-first branching strategy.
+description: SigMap version history and roadmap. From v0.0 to v6.10.7, with the latest releases implementing Python import detection, adding comprehensive diagnostics, and establishing develop-first branching strategy.
 head:
   - - meta
     - property: og:title
@@ -725,6 +725,16 @@ Fixed import graph analysis for Python monorepos (issues #181, #182): added dete
 **Tags:** `import graph` · `Python absolute imports` · `diagnostics tool` · `issue #181` · `issue #182` · `develop-first branching` · `MCP tools` · `regression tests`
 
 **Impact:** Fixes empty import graph for Python files with cross-package dependencies; enables explain_file and get_impact on large monorepos.
+
+**Benchmark:** 80.0% hit@5 · 96.8% token reduction · 52.2% task success (same metrics)
+
+---
+
+### v6.10.7 — Bundled Python import support ✓ (tagged v6.10.7 — 2026-05-12)
+
+Fixed Python absolute import detection in bundled gen-context.js. The source code already had support for `from package.module import X` patterns, but the bundle was missing this code block, causing MCP tools (`explain_file`, `get_impact`) to show empty import graphs for Python monorepos. Now bundled behavior matches source code exactly.
+
+**Tags:** `bundled fix` · `Python imports` · `MCP tools` · `import graph` · `bundle parity`
 
 **Benchmark:** 80.0% hit@5 · 96.8% token reduction · 52.2% task success (same metrics)
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,14 +78,14 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v6.10.6</span>
+  <span><strong>Release:</strong> v6.10.7</span>
   <span>·</span>
-  <span>Python import detection + diagnostics tool</span>
+  <span>Bundled Python import fix</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v6.10-main</span>
   <span>·</span>
-  <span>80.0% hit@5 · 80.0% graph-boosted · 2026-05-05</span>
+  <span>80.0% hit@5 · 80.0% graph-boosted · 2026-05-12</span>
 </div>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.10.6",
+  "version": "6.10.7",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "6.10.6",
-  "benchmark_date": "2026-05-11",
+  "version": "6.10.7",
+  "benchmark_date": "2026-05-12",
   "benchmark_id": "sigmap-v6.10-main",
   "languages": 29,
   "mcp_tools": 9,


### PR DESCRIPTION
## Summary
- **Python absolute imports in bundled gen-context.js** — Added Python absolute import detection (`from package.module import X`) to bundled extractImports function. The source code had this support but it was missing from the bundle, causing MCP tools to show empty import graphs for Python monorepos. Now matches source behavior correctly.
- Updated version to 6.10.7 across all files (package.json, version.json, gen-context.js)
- Updated documentation with correct version numbers and benchmark dates (2026-05-12)
- Added v6.10.7 entry to CHANGELOG and roadmap

## Changes
- `gen-context.js`: Updated VERSION constant to 6.10.7 + Python bundled import fix
- `package.json`: Bumped version to 6.10.7
- `version.json`: Updated to 6.10.7 with benchmark date 2026-05-12
- `CHANGELOG.md`: Added v6.10.7 section with fix description
- `docs-vp/`: Updated all benchmark and reference docs with v6.10.7 metadata
- `README.md`: Updated benchmark block with current date
- `test/integration/features/readme-structure.test.js`: Updated test expectations for new metrics

## Test plan
- [x] All integration tests pass (60 passed, 0 failed)
- [x] Manual smoke test: `node gen-context.js --health`
- [x] Version consistency: `node gen-context.js --version` returns 6.10.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)