### PR TITLE
docs: add GitHub stars badge to header navigation

### DIFF
--- a/docs-vp/.vitepress/config.mts
+++ b/docs-vp/.vitepress/config.mts
@@ -22,7 +22,7 @@ export default defineConfig({
     nav: [
       { text: 'Docs', link: '/guide/quick-start', activeMatch: '/guide/' },
       {
-        text: 'GitHub',
+        text: 'GitHub ⭐',
         link: 'https://github.com/manojmallick/sigmap',
       },
     ],


### PR DESCRIPTION
## Summary
- Added GitHub stars badge (⭐) to header navigation
- Updated header to show "GitHub ⭐" instead of just "GitHub"

## Test plan
- [ ] Verify header displays "GitHub ⭐" on live docs
- [ ] All integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)