### PR TITLE
fix(mcp): merge hot-cold cache and context-cold into MCP index

### DIFF
--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -5,6 +5,16 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const CONTEXT_FILE = path.join('.github', 'copilot-instructions.md');
+const CONTEXT_COLD_FILE = path.join('.github', 'context-cold.md');
+
+function _readContextFiles(cwd) {
+  const paths = [path.join(cwd, CONTEXT_FILE), path.join(cwd, CONTEXT_COLD_FILE)];
+  const chunks = [];
+  for (const p of paths) {
+    if (fs.existsSync(p)) chunks.push(fs.readFileSync(p, 'utf8'));
+  }
+  return chunks.join('\n');
+}
 
 // Section header keywords in PROJECT_MAP.md
 const MAP_SECTIONS = {
@@ -20,12 +30,10 @@ const MAP_SECTIONS = {
  * contain the given module substring.
  */
 function readContext(args, cwd) {
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (!fs.existsSync(contextPath)) {
+  const content = _readContextFiles(cwd);
+  if (!content) {
     return 'No context file found. Run: node gen-context.js';
   }
-
-  const content = fs.readFileSync(contextPath, 'utf8');
 
   if (!args || !args.module) return content;
 
@@ -62,41 +70,28 @@ function readContext(args, cwd) {
 function searchSignatures(args, cwd) {
   if (!args || !args.query) return 'Missing required argument: query';
 
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (!fs.existsSync(contextPath)) {
-    return 'No context file found. Run: node gen-context.js';
-  }
-
-  const content = fs.readFileSync(contextPath, 'utf8');
   const query = args.query.toLowerCase();
-  const lines = content.split('\n');
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) {
+      return 'No context file found. Run: node gen-context.js';
+    }
 
-  const result = [];
-  let currentFile = '';
-  let fileHeaderAdded = false;
+    const result = [];
+    for (const [file, sigs] of index.entries()) {
+      const hits = sigs.filter((s) => s.toLowerCase().includes(query));
+      if (hits.length === 0) continue;
+      if (result.length > 0) result.push('');
+      result.push(`### ${file}`);
+      result.push(...hits);
+    }
 
-  for (const line of lines) {
-    if (line.startsWith('### ')) {
-      currentFile = line.slice(4).trim();
-      fileHeaderAdded = false;
-      continue;
-    }
-    // Skip markdown fences and top-level headers
-    if (line.startsWith('```') || line.startsWith('## ') || line.startsWith('# ') || line.startsWith('<!--')) {
-      continue;
-    }
-    if (line.toLowerCase().includes(query)) {
-      if (currentFile && !fileHeaderAdded) {
-        if (result.length > 0) result.push('');
-        result.push(`### ${currentFile}`);
-        fileHeaderAdded = true;
-      }
-      result.push(line);
-    }
+    if (result.length === 0) return `No signatures found matching: ${args.query}`;
+    return result.join('\n');
+  } catch (err) {
+    return `_search_signatures failed: ${err.message}_`;
   }
-
-  if (result.length === 0) return `No signatures found matching: ${args.query}`;
-  return result.join('\n');
 }
 
 /**
@@ -280,39 +275,29 @@ function explainFile(args, cwd) {
 
   const lines = ['# explain_file: ' + targetRel, ''];
 
-  // ── Signatures (from context file) ─────────────────────────────────────
+  // ── Signatures (hot + cold + cache via buildSigIndex) ───────────────────
   lines.push('## Signatures');
   let indexedFiles = [];
 
-  if (fs.existsSync(contextPath)) {
-    const ctxContent = fs.readFileSync(contextPath, 'utf8');
-    const ctxLines = ctxContent.split('\n');
-    let capturing = false;
-    const sigLines = [];
-
-    for (const line of ctxLines) {
-      if (line.startsWith('### ')) {
-        if (capturing) break; // already collected our block
-        const rel = line.slice(4).trim().replace(/\\/g, '/');
-        capturing = rel === targetRel || rel.endsWith('/' + targetRel) || targetRel.endsWith('/' + rel);
-        if (capturing) continue;
-      } else if (capturing) {
-        sigLines.push(line);
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    let sigs = index.get(targetRel);
+    if (!sigs) {
+      for (const [file, fileSigs] of index.entries()) {
+        if (file === targetRel || file.endsWith('/' + targetRel) || targetRel.endsWith('/' + file)) {
+          sigs = fileSigs;
+          break;
+        }
       }
     }
-
-    const sigs = sigLines.filter((l) => l !== '```' && l.trim() !== '');
-    if (sigs.length > 0) {
+    if (sigs && sigs.length > 0) {
       lines.push(...sigs);
     } else {
       lines.push('_No signatures indexed for this file. Run: node gen-context.js_');
     }
-
-    indexedFiles = ctxContent
-      .split('\n')
-      .filter((l) => l.startsWith('### '))
-      .map((l) => path.resolve(cwd, l.slice(4).trim()));
-  } else {
+    indexedFiles = [...index.keys()].map((rel) => path.resolve(cwd, rel));
+  } catch (_) {
     lines.push('_No context file found. Run: node gen-context.js_');
   }
 
@@ -377,37 +362,21 @@ function explainFile(args, cwd) {
  * descending. Helps agents decide which module to query with read_context.
  */
 function listModules(args, cwd) {
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (!fs.existsSync(contextPath)) {
-    return 'No context file found. Run: node gen-context.js';
-  }
-
-  const content = fs.readFileSync(contextPath, 'utf8');
-  const ctxLines = content.split('\n');
-
-  const groups = {}; // key: top-level dir, value: { fileCount, tokenCount }
-  let currentGroup = null;
-  let blockBuf = [];
-
-  function flushBlock() {
-    if (currentGroup === null || blockBuf.length === 0) return;
-    if (!groups[currentGroup]) groups[currentGroup] = { fileCount: 0, tokenCount: 0 };
-    groups[currentGroup].fileCount++;
-    groups[currentGroup].tokenCount += Math.ceil(blockBuf.join('\n').length / 4);
-    blockBuf = [];
-  }
-
-  for (const line of ctxLines) {
-    if (line.startsWith('### ')) {
-      flushBlock();
-      const rel = line.slice(4).trim().replace(/\\/g, '/');
-      const parts = rel.split('/');
-      currentGroup = parts.length > 1 ? parts[0] : '.';
-    } else if (currentGroup !== null) {
-      blockBuf.push(line);
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) {
+      return 'No context file found. Run: node gen-context.js';
     }
-  }
-  flushBlock();
+
+    const groups = {};
+    for (const [rel, sigs] of index.entries()) {
+      const parts = rel.replace(/\\/g, '/').split('/');
+      const mod = parts.length > 1 ? parts[0] : '.';
+      if (!groups[mod]) groups[mod] = { fileCount: 0, tokenCount: 0 };
+      groups[mod].fileCount++;
+      groups[mod].tokenCount += Math.ceil(sigs.join('\n').length / 4);
+    }
 
   const sorted = Object.entries(groups)
     .map(([mod, data]) => ({ module: mod, fileCount: data.fileCount, tokenCount: data.tokenCount }))
@@ -428,6 +397,9 @@ function listModules(args, cwd) {
     '',
     '_Use `read_context({ module: "name" })` to get signatures for a specific module._',
   ].join('\n');
+  } catch (err) {
+    return `_list_modules failed: ${err.message}_`;
+  }
 }
 
 /**
@@ -438,11 +410,6 @@ function listModules(args, cwd) {
  */
 function queryContext(args, cwd) {
   if (!args || !args.query) return 'Missing required argument: query';
-
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (!fs.existsSync(contextPath)) {
-    return 'No context file found. Run: node gen-context.js';
-  }
 
   try {
     const { rank, buildSigIndex, formatRankTable } = require('../retrieval/ranker');

--- a/src/retrieval/ranker.js
+++ b/src/retrieval/ranker.js
@@ -361,6 +361,58 @@ function _parseContextFile(contextPath) {
   return index;
 }
 
+/** Merge source index into target; prefer non-empty sig lists. */
+function _mergeSigIndex(target, source) {
+  for (const [file, sigs] of source.entries()) {
+    if (!sigs || sigs.length === 0) continue;
+    if (!target.has(file) || target.get(file).length < sigs.length) {
+      target.set(file, sigs);
+    }
+  }
+  return target;
+}
+
+/**
+ * Load signatures from .sigmap-cache.json (absolute paths → repo-relative keys).
+ * @param {string} cwd
+ * @returns {Map<string, string[]>}
+ */
+function _buildSigIndexFromCache(cwd) {
+  const fs = require('fs');
+  const path = require('path');
+  const index = new Map();
+  try {
+    const { loadCache } = require('../cache/sig-cache');
+    const pkgPath = path.join(cwd, 'package.json');
+    let version = '0.0.0';
+    if (fs.existsSync(pkgPath)) {
+      version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || version;
+    }
+    const cache = loadCache(cwd, version);
+    for (const [absPath, entry] of cache.entries()) {
+      if (!entry || !entry.sigs || entry.sigs.length === 0) continue;
+      const rel = path.relative(cwd, absPath).replace(/\\/g, '/');
+      if (!rel || rel.startsWith('..')) continue;
+      index.set(rel, entry.sigs);
+    }
+  } catch (_) {}
+  return index;
+}
+
+/**
+ * Hot-cold and per-module strategies store most signatures outside the primary
+ * copilot-instructions.md file. MCP tools must merge all sources.
+ * @param {string} cwd
+ * @returns {Map<string, string[]>}
+ */
+function _enrichSigIndexFromStrategy(cwd, index) {
+  const path = require('path');
+  const coldPath = path.join(cwd, '.github', 'context-cold.md');
+  _mergeSigIndex(index, _parseContextFile(coldPath));
+  _mergeSigIndex(index, _buildSigIndexFromCache(cwd));
+  return index;
+}
+
 /**
  * Build a signature index from the generated context file.
  * Returns Map<filePath, string[]> where filePath is the relative path
@@ -382,7 +434,8 @@ function buildSigIndex(cwd, opts) {
 
   // 1. Caller supplied an explicit path — use it directly.
   if (opts && opts.contextPath) {
-    return _parseContextFile(opts.contextPath);
+    const index = _parseContextFile(opts.contextPath);
+    return _enrichSigIndexFromStrategy(cwd, index);
   }
 
   // 2. Check gen-context.config.json for a persisted customOutput path.
@@ -393,7 +446,7 @@ function buildSigIndex(cwd, opts) {
       if (cfg.customOutput) {
         const customPath = path.resolve(cwd, cfg.customOutput);
         const index = _parseContextFile(customPath);
-        if (index.size > 0) return index;
+        if (index.size > 0) return _enrichSigIndexFromStrategy(cwd, index);
       }
     }
   } catch (_) {}
@@ -402,10 +455,12 @@ function buildSigIndex(cwd, opts) {
   for (const parts of ADAPTER_OUTPUT_PATHS) {
     const contextPath = path.join(cwd, ...parts);
     const index = _parseContextFile(contextPath);
-    if (index.size > 0) return index;
+    if (index.size > 0) return _enrichSigIndexFromStrategy(cwd, index);
   }
 
-  return new Map();
+  // 4. Primary file empty/missing (hot-cold) — still serve cold + cache.
+  const fallback = new Map();
+  return _enrichSigIndexFromStrategy(cwd, fallback);
 }
 
 /**

--- a/test/integration/strategy.test.js
+++ b/test/integration/strategy.test.js
@@ -213,6 +213,32 @@ test('hot-cold: falls back to full-equivalent when outside git repo', () => {
   assert.ok(fs.existsSync(primary), 'Primary output must still be written without git');
 });
 
+test('hot-cold: MCP buildSigIndex includes cold file and cache (issue #201)', () => {
+  const dir = makeTmpRepo('hot-cold-mcp');
+
+  writeFile(dir, 'src/cold.js', 'function coldOnlyFn() {}');
+  commit(dir, 'cold');
+
+  writeFile(dir, 'src/hot.js', 'function hotOnlyFn() {}');
+  commit(dir, 'hot');
+
+  writeConfig(dir, { strategy: 'hot-cold', hotCommits: 1, srcDirs: ['src'], sigCache: true });
+  runGenContext(dir);
+
+  const { buildSigIndex } = require('../../src/retrieval/ranker');
+  const { listModules, searchSignatures } = require('../../src/mcp/handlers');
+
+  const index = buildSigIndex(dir);
+  assert.ok(index.has('src/cold.js'), 'index must include cold-file signatures');
+  assert.ok(index.get('src/cold.js').some((s) => s.includes('coldOnlyFn')), 'cold sig text present');
+
+  const listed = listModules({}, dir);
+  assert.ok(!listed.includes('No modules found'), 'list_modules must see cold files');
+
+  const found = searchSignatures({ query: 'coldOnlyFn' }, dir);
+  assert.ok(found.includes('coldOnlyFn'), 'search_signatures must find cold symbols');
+});
+
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #201 — under `strategy: hot-cold`, MCP tools only read the sparse hot block in `copilot-instructions.md`, so `list_modules`, `search_signatures`, `query_context`, and `explain_file` return near-empty results even when `context-cold.md` and `.sigmap-cache.json` are populated.

## Changes

- `buildSigIndex()` merges signatures from:
  1. Primary adapter output (existing behavior)
  2. `.github/context-cold.md`
  3. `.sigmap-cache.json` (absolute paths → repo-relative keys)
- MCP handlers use the unified index / merged context text
- Integration test: `hot-cold: MCP buildSigIndex includes cold file and cache (issue #201)`

## Test plan

- [x] `node test/integration/strategy.test.js` (9/9 pass)


Made with [Cursor](https://cursor.com)