### PR TITLE
docs: update CONTRIBUTORS.md with v6.10.11 and attribution guide

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,10 +16,27 @@ SigMap is built by a great community of contributors. Thank you to everyone who 
 - [Matt Van Horn](https://github.com/mvanhorn) — Testing, reliability improvements
 - [kumamaki](https://github.com/kumamaki) — Bug fixes, improvements
 
+## Special Acknowledgments
+
+Contributors whose work may not appear in the GitHub graph due to email configuration:
+- **Denis Solonenko** — GDScript language extractor and support (#146)
+
+To fix this: link your commit email to your GitHub account at https://github.com/settings/emails
+
 ## Supporters
 
 - **SigMap Bot** — Release automation, version management
 - Community members — Bug reports, feedback, discussions
+
+## Contribution Attribution
+
+When you contribute to SigMap, your GitHub account will appear in the [contributors graph](https://github.com/manojmallick/sigmap/graphs/contributors) if:
+- Your commit author email is linked to your GitHub account profile
+- You make commits using that email address
+
+To ensure proper attribution:
+1. Link your email to your GitHub account: https://github.com/settings/emails
+2. Configure git locally: `git config user.email your-github-email@example.com`
 
 ## How to Contribute
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,13 +16,6 @@ SigMap is built by a great community of contributors. Thank you to everyone who 
 - [Matt Van Horn](https://github.com/mvanhorn) — Testing, reliability improvements
 - [kumamaki](https://github.com/kumamaki) — Bug fixes, improvements
 
-## Special Acknowledgments
-
-Contributors whose work may not appear in the GitHub graph due to email configuration:
-- **Denis Solonenko** — GDScript language extractor and support (#146)
-
-To fix this: link your commit email to your GitHub account at https://github.com/settings/emails
-
 ## Supporters
 
 - **SigMap Bot** — Release automation, version management


### PR DESCRIPTION
## Summary
Update CONTRIBUTORS.md to reflect v6.10.11 release and add contribution attribution guide.

## Changes
- Updated recent contributors section to v6.10.11
- Added "Contribution Attribution" section explaining GitHub contributor graph requirements
- Step-by-step guide for linking commit email to GitHub account

## Why This Matters
- Documents v6.10.11 contributions (MCP cache, binary builds, npm workflow, test improvements)
- Helps contributors understand how to ensure proper GitHub attribution
- Clarifies that Denis Solonenko is already credited in Feature Contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)