### PR TITLE
feat: register MCP server in .mcp.json (#209)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -10455,9 +10455,11 @@ function registerMcp(cwd, scriptPath) {
     args: [path.resolve(scriptPath), '--mcp'],
   };
 
-  // JSON mcpServers targets: Claude, Cursor, Windsurf project, Windsurf global,
-  // VS Code (GitHub Copilot 1.99+), OpenCode project, OpenCode global, Gemini CLI
+  // JSON mcpServers targets: portable .mcp.json (priority), Claude, Cursor,
+  // Windsurf project, Windsurf global, VS Code (GitHub Copilot 1.99+),
+  // OpenCode project, OpenCode global, Gemini CLI
   const jsonTargets = [
+    path.join(cwd, '.mcp.json'),
     path.join(cwd, '.claude', 'settings.json'),
     path.join(cwd, '.cursor', 'mcp.json'),
     path.join(cwd, '.windsurf', 'mcp.json'),
@@ -10496,6 +10498,8 @@ function registerMcp(cwd, scriptPath) {
 
   // Print manual snippets for all targets
   console.warn('[sigmap] MCP / context server config snippets:');
+  console.warn('  .mcp.json (portable, recommended):');
+  console.warn(JSON.stringify({ mcpServers: { sigmap: serverEntry } }, null, 2));
   console.warn('  Claude / Cursor / Windsurf / VS Code / OpenCode / Gemini CLI:');
   console.warn(JSON.stringify({ mcpServers: { sigmap: serverEntry } }, null, 2));
   console.warn('  Zed (~/.config/zed/settings.json):');

--- a/test/integration/mcp/register.test.js
+++ b/test/integration/mcp/register.test.js
@@ -158,6 +158,55 @@ test('skips Zed registration when ~/.config/zed/settings.json does not exist', (
   }
 });
 
+// ── Portable .mcp.json (project root) ────────────────────────────────────────
+test('writes mcpServers.sigmap to .mcp.json when it exists (highest priority)', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({}));
+
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.ok(result.mcpServers, '.mcp.json should have mcpServers');
+    assert.ok(result.mcpServers.sigmap, 'mcpServers.sigmap should be set');
+    assert.strictEqual(result.mcpServers.sigmap.command, 'node');
+    assert.ok(Array.isArray(result.mcpServers.sigmap.args));
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('does not duplicate .mcp.json entry on repeat --setup', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { sigmap: { command: 'node', args: ['existing'] } } }));
+
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.deepStrictEqual(result.mcpServers.sigmap.args, ['existing'], 'existing .mcp.json entry must not be overwritten');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('falls back to .claude/settings.json when .mcp.json does not exist', () => {
+  const dir = makeTmpDir();
+  try {
+    const claudeDir = path.join(dir, '.claude');
+    fs.mkdirSync(claudeDir);
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({}));
+
+    // .mcp.json does not exist, so it should register to .claude/settings.json
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    assert.ok(result.mcpServers?.sigmap, '.claude/settings.json mcpServers.sigmap must be set when .mcp.json does not exist');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
 // ── Summary ─────────────────────────────────────────────────────────────────
 console.log(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- Register MCP servers in `.mcp.json` as highest-priority target
- Falls back to `.claude/settings.json` if `.mcp.json` doesn't exist
- Makes MCP registration portable for other agentic harnesses

## Changes
- `gen-context.js`: Added `.mcp.json` to MCP registration targets
- `test/integration/mcp/register.test.js`: Added 3 comprehensive tests

## Test plan
- [x] All 60 integration tests pass
- [x] MCP registration tests specifically verify `.mcp.json` behavior
- [x] Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)