### PR TITLE
release: v6.10.12 — MCP .mcp.json support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.10.12] — 2026-05-27
+
+### Added
+
+- **Portable `.mcp.json` support** — MCP server registration now detects and prioritizes `.mcp.json` at the project root, making MCP configuration portable across multiple agentic harnesses (Claude, Cursor, Windsurf, etc.). Falls back to `.claude/settings.json` if `.mcp.json` doesn't exist (closes #209).
+
+---
+
 ## [6.10.11] — 2026-05-22
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,7 +35,11 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
-### Recent Contributors (v6.10.11)
+### Recent Contributors (v6.10.12)
+- Portable `.mcp.json` support for agentic harnesses (Claude, Cursor, Windsurf, etc.)
+- MCP registration with intelligent fallback to `.claude/settings.json`
+
+### v6.10.11
 - MCP cache improvements for hot/cold context indexing
 - Binary build reliability with r-manifest module bundling
 - npm publish workflow with automation token support

--- a/gen-context.js
+++ b/gen-context.js
@@ -5901,7 +5901,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
   
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.10.11',
+  version: '6.10.12',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -8655,7 +8655,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.10.11';
+const VERSION = '6.10.12';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -10455,9 +10455,11 @@ function registerMcp(cwd, scriptPath) {
     args: [path.resolve(scriptPath), '--mcp'],
   };
 
-  // JSON mcpServers targets: Claude, Cursor, Windsurf project, Windsurf global,
-  // VS Code (GitHub Copilot 1.99+), OpenCode project, OpenCode global, Gemini CLI
+  // JSON mcpServers targets: portable .mcp.json (priority), Claude, Cursor,
+  // Windsurf project, Windsurf global, VS Code (GitHub Copilot 1.99+),
+  // OpenCode project, OpenCode global, Gemini CLI
   const jsonTargets = [
+    path.join(cwd, '.mcp.json'),
     path.join(cwd, '.claude', 'settings.json'),
     path.join(cwd, '.cursor', 'mcp.json'),
     path.join(cwd, '.windsurf', 'mcp.json'),
@@ -10496,6 +10498,8 @@ function registerMcp(cwd, scriptPath) {
 
   // Print manual snippets for all targets
   console.warn('[sigmap] MCP / context server config snippets:');
+  console.warn('  .mcp.json (portable, recommended):');
+  console.warn(JSON.stringify({ mcpServers: { sigmap: serverEntry } }, null, 2));
   console.warn('  Claude / Cursor / Windsurf / VS Code / OpenCode / Gemini CLI:');
   console.warn(JSON.stringify({ mcpServers: { sigmap: serverEntry } }, null, 2));
   console.warn('  Zed (~/.config/zed/settings.json):');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.10.11",
+  "version": "6.10.12",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.10.11",
+  "version": "6.10.12",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.10.11",
+  "version": "6.10.12",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.10.11',
+  version: '6.10.12',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/mcp/register.test.js
+++ b/test/integration/mcp/register.test.js
@@ -158,6 +158,55 @@ test('skips Zed registration when ~/.config/zed/settings.json does not exist', (
   }
 });
 
+// ── Portable .mcp.json (project root) ────────────────────────────────────────
+test('writes mcpServers.sigmap to .mcp.json when it exists (highest priority)', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({}));
+
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.ok(result.mcpServers, '.mcp.json should have mcpServers');
+    assert.ok(result.mcpServers.sigmap, 'mcpServers.sigmap should be set');
+    assert.strictEqual(result.mcpServers.sigmap.command, 'node');
+    assert.ok(Array.isArray(result.mcpServers.sigmap.args));
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('does not duplicate .mcp.json entry on repeat --setup', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { sigmap: { command: 'node', args: ['existing'] } } }));
+
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.deepStrictEqual(result.mcpServers.sigmap.args, ['existing'], 'existing .mcp.json entry must not be overwritten');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('falls back to .claude/settings.json when .mcp.json does not exist', () => {
+  const dir = makeTmpDir();
+  try {
+    const claudeDir = path.join(dir, '.claude');
+    fs.mkdirSync(claudeDir);
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({}));
+
+    // .mcp.json does not exist, so it should register to .claude/settings.json
+    execSync(`node "${GEN_CONTEXT}" --setup`, { cwd: dir, encoding: 'utf8', timeout: 15000 });
+
+    const result = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    assert.ok(result.mcpServers?.sigmap, '.claude/settings.json mcpServers.sigmap must be set when .mcp.json does not exist');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
 // ── Summary ─────────────────────────────────────────────────────────────────
 console.log(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.10.11",
+  "version": "6.10.12",
   "benchmark_date": "2026-05-22",
   "benchmark_id": "sigmap-v6.10-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Register MCP servers in `.mcp.json` as highest-priority target
- Falls back to `.claude/settings.json` for backward compatibility
- Makes MCP registration portable across agentic harnesses

## Changes
- `feat: register MCP server in .mcp.json (#209)` — Added `.mcp.json` support with 3 comprehensive tests
- `docs: update CONTRIBUTORS.md and CHANGELOG for v6.10.12`
- Updated all version references: package.json, version.json, gen-context.js, MCP server

## Test plan
- [x] All 60 integration tests pass
- [x] MCP registration tests verify `.mcp.json` behavior and fallback
- [x] Backward compatibility maintained with `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)