### PR TITLE
fix(build): bundle line-anchor module so binary build passes

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -1174,6 +1174,30 @@ __factories["./src/extractors/php"] = function(module, exports) {
   
 };
 
+// ── ./src/extractors/line-anchor ──
+__factories["./src/extractors/line-anchor"] = function(module, exports) {
+
+  function lineAt(src, idx) {
+    let line = 1;
+    const end = Math.min(idx, src.length);
+    for (let i = 0; i < end; i++) {
+      if (src.charCodeAt(i) === 10) line++;
+    }
+    return line;
+  }
+
+  function anchor(start, end) {
+    return `  :${start}-${end}`;
+  }
+
+  function withAnchor(sig, start, end) {
+    return `${sig}${anchor(start, end)}`;
+  }
+
+  module.exports = { lineAt, anchor, withAnchor };
+
+};
+
 // ── ./src/extractors/python ──
 __factories["./src/extractors/python"] = function(module, exports) {
   


### PR DESCRIPTION
## Summary
- The **Release Binaries** workflow (triggered by the `v6.11.0` tag) failed: the binary pre-flight requires every `src/*.js` module to have a `__factories` entry in the bundled `gen-context.js`, and the new `src/extractors/line-anchor.js` (added in #213, required by the typescript & python extractors) was missing.
- Fix: add the `line-anchor` factory to `gen-context.js`.

## Why npm/local was unaffected
`gen-context.js` loads extractors via `requireSourceOrBundled()` — **disk-first** (`src/` is shipped in the npm package), falling back to the bundled `__factories` only when `src/` is absent (the standalone binary). So anchors already work via npm/local; only the binary build's static pre-flight broke.

## Changes
- `gen-context.js`: add `__factories["./src/extractors/line-anchor"]` (verbatim, dependency-free copy of `src/extractors/line-anchor.js`, already covered by `test/integration/extractors/line-anchors.test.js`).

## Test plan
- [x] `node --check gen-context.js`
- [x] `npm run build:binary` → `✓ bundle pre-flight: all src/ modules present` (local build only fails later at macOS `postject`, an env quirk CI runners don't hit)
- [x] `node test/integration/all.js` → 61 passed, 0 failed
- [x] `node gen-context.js --version` → 6.11.0

## Note (follow-up, not in this PR)
The bundled `typescript`/`python` factories still lag `src/` (they predate even the #97 guard-clause fix and the v6.11.0 anchors), so the *standalone binary* won't emit anchors until those factories are re-synced. The npm package — the primary distribution — is unaffected. Re-syncing the bundle (or restoring an automated bundler) is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)