### PR TITLE
ci(sync): authenticate develop sync with SYNC_PAT to bypass ruleset

### DIFF
--- a/.github/workflows/sync-develop-main.yml
+++ b/.github/workflows/sync-develop-main.yml
@@ -17,7 +17,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT so the push to `develop` is authenticated as a ruleset
+          # bypass actor. The default GITHUB_TOKEN (github-actions[bot]) is NOT
+          # in the develop ruleset bypass list, so its direct push is rejected
+          # ("Changes must be made through a pull request"). SYNC_PAT must belong
+          # to an account/role listed under Settings → Rules → develop → Bypass.
+          # Falls back to GITHUB_TOKEN if the secret is unset (will still be
+          # blocked by the ruleset, but the workflow stays valid).
+          token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary
The **Sync develop with main** workflow fails on every push to `main` ([example run](https://github.com/manojmallick/sigmap/actions/runs/26854991941)) — it pushes to `develop` using the default `GITHUB_TOKEN` (`github-actions[bot]`), which is **not** a bypass actor on the `develop` ruleset, so the push is rejected:
```
remote: error: GH013: Repository rule violations found for refs/heads/develop
 - Changes must be made through a pull request.
```

## Fix (Option 1 — keep direct-push design, authenticate as a bypass actor)
Switch the checkout `token:` to `secrets.SYNC_PAT` (falls back to `GITHUB_TOKEN` if unset, so the workflow stays valid). The PAT authenticates the push as its owner; when that owner is in the `develop` ruleset bypass list, the fast-forward push succeeds — exactly like the manual owner-credentialed sync we just did, which reported *"Bypassed rule violations for refs/heads/develop."*

## ⚙️ Required manual step before this takes effect
1. Create a PAT for an account in the `develop` ruleset bypass list (the repo owner already is):
   - **Fine-grained:** repo `manojmallick/sigmap` → Contents: **Read and write**, Workflows: **Read and write** (the latter is needed because syncing `develop` may include workflow-file changes).
   - **or Classic:** scopes `repo` + `workflow`.
2. Add it as a repository secret named **`SYNC_PAT`** (Settings → Secrets and variables → Actions).
3. Confirm the PAT's account/role appears under Settings → Rules → `develop` → **Bypass list**.

## Test plan
- [x] YAML valid; only the checkout token changed (+ `persist-credentials: true` for clarity)
- [ ] After merge + `SYNC_PAT` secret added: next push to `main` runs the workflow and the `develop` push succeeds (no GH013)

## Alternative considered
Option 2 (convert to a PR-based `main → develop` sync) keeps `develop` fully PR-gated but needs a PAT/App token for status checks to fire plus auto-merge — more moving parts for a trusted internal mirror. Option 1 chosen for least friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)