### PR TITLE
ci(sync): add workflow_dispatch to develop-sync

### DIFF
--- a/.github/workflows/sync-develop-main.yml
+++ b/.github/workflows/sync-develop-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a manual `workflow_dispatch` trigger to the Sync develop with main workflow so it can be run on demand (e.g. to verify the new SYNC_PAT bypass) instead of only on push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)