### PR TITLE
feat: line anchors for JavaScript + member-level anchors (TS & JS)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -916,61 +916,92 @@ __factories["./src/extractors/java"] = function(module, exports) {
 
 // ── ./src/extractors/javascript ──
 __factories["./src/extractors/javascript"] = function(module, exports) {
-  
+
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from JavaScript source code.
+   * Top-level declarations and class members carry a `:start-end` line anchor
+   * (see line-anchor.js); kept parallel to `sigs` and applied once at return.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    const anchors = [];
     const returnHints = buildReturnHints(src);
-  
+
+    // Block comments are blanked newline-by-newline (non-newline chars → spaces)
+    // so character offsets AND line numbers stay exact for anchors.
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
-  
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+    const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+    // End line for a function whose match ends at `matchEnd` (before its body brace).
+    const fnEndLine = (matchEnd, startLn) => {
+      const brace = stripped.indexOf('{', matchEnd);
+      return brace !== -1 ? lineAt(stripped, blockEndIdx(brace + 1)) : startLn;
+    };
+
     // Classes
     const classRegex = /^(export\s+(?:default\s+)?)?class\s+(\w+)(?:\s+extends\s+[\w.]+)?\s*\{/gm;
     for (const m of stripped.matchAll(classRegex)) {
       const prefix = m[1] ? m[1].trim() + ' ' : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`${prefix}class ${m[2]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const meth of extractClassMembers(block, returnHints)) sigs.push(`  ${meth}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+      const block = extractBlock(stripped, bodyStart);
+      for (const meth of extractClassMembers(block, returnHints)) {
+        sigs.push(`  ${meth.text}`);
+        anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+      }
     }
-  
+
     // Exported named functions
     for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
       const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
+
     // Exported arrow functions
     for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(([^)]*)\)\s*=>/gm)) {
       const asyncKw = m[0].includes('async') ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
+
     // module.exports = { ... }
     const moduleExports = stripped.match(/^module\.exports\s*=\s*\{([^}]+)\}/m);
     if (moduleExports) {
       const names = moduleExports[1].split(',').map((s) => s.trim()).filter(Boolean);
-      if (names.length > 0) sigs.push(`module.exports = { ${names.join(', ')} }`);
+      if (names.length > 0) {
+        const startLn = lineAt(stripped, moduleExports.index);
+        sigs.push(`module.exports = { ${names.join(', ')} }`);
+        anchors.push([startLn, lineAt(stripped, moduleExports.index + moduleExports[0].length)]);
+      }
     }
-  
+
     // Top-level named functions (non-exported)
     for (const m of stripped.matchAll(/^(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
       const asyncKw = m[0].startsWith('async') ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
-    return sigs.slice(0, 25);
+
+    return sigs
+      .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+      .slice(0, 25);
   }
-  
+
   function extractBlock(src, startIndex) {
     let depth = 1;
     let i = startIndex;
@@ -982,16 +1013,22 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
     }
     return src.slice(startIndex, i - 1);
   }
-  
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block` (end = the method's closing brace), so the caller can resolve
+  // per-method line anchors that span the method body.
   function extractClassMembers(block, returnHints) {
     const members = [];
     for (const m of block.matchAll(/^\s+(?:static\s+|async\s+|get\s+|set\s+)*(\w+)\s*\(([^)]*)\)\s*\{/gm)) {
       if (/^_/.test(m[1])) continue;
-      if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+      const bodyStart = m.index + m[0].length; // just past the opening brace
+      const end = bodyStart + extractBlock(block, bodyStart).length;
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
       const isAsync = m[0].includes('async ') ? 'async ' : '';
       const isStatic = m[0].includes('static ') ? 'static ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
-      members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
     }
     return members.slice(0, 8);
   }
@@ -1016,18 +1053,17 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
   }
 
   function formatReturnHint(type) {
-    return type ? ` \u2192 ${type}` : '';
+    return type ? ` → ${type}` : '';
   }
-  
+
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ');
   }
-  
-  module.exports = { extract };
-  
-};
 
+  module.exports = { extract };
+
+};
 // ── ./src/extractors/kotlin ──
 __factories["./src/extractors/kotlin"] = function(module, exports) {
   
@@ -1799,101 +1835,164 @@ __factories["./src/extractors/swift"] = function(module, exports) {
 
 // ── ./src/extractors/typescript ──
 __factories["./src/extractors/typescript"] = function(module, exports) {
-  
+
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from TypeScript source code.
+   * Top-level declarations carry a `:start-end` line anchor (see line-anchor.js);
+   * indented members do not.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
-  
-    // Strip single-line comments
+    // anchors[i] is [start, end] for a top-level sig, or null for an indented member.
+    // Kept parallel to `sigs` so existing push/mutation logic stays untouched;
+    // anchors are applied once at return.
+    const anchors = [];
+
+    // Strip comments to simplify matching. Block comments are blanked
+    // newline-by-newline (non-newline chars → spaces) so character offsets AND
+    // line numbers stay exact. Line comments preserve their trailing newline.
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
-  
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+    // Index of the closing brace for a block whose body starts at bodyStart.
+    const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+
     // Exported interfaces
     for (const m of stripped.matchAll(/^export\s+interface\s+(\w+)(?:<[^{]*>)?\s*(?:extends\s+[^{]+)?\{/gm)) {
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export interface ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
       // Collect members
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
+      const block = extractBlock(stripped, bodyStart);
       const members = extractInterfaceMembers(block);
-      for (const mem of members) sigs.push(`  ${mem}`);
+      for (const mem of members) {
+        sigs.push(`  ${mem.text}`);
+        anchors.push([lineAt(stripped, bodyStart + mem.start), lineAt(stripped, bodyStart + mem.end)]);
+      }
     }
-  
+
     // Exported type aliases
     for (const m of stripped.matchAll(/^export\s+type\s+(\w+)(?:<[^=]*>)?\s*=/gm)) {
       sigs.push(`export type ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, m.index + m[0].length)]);
     }
-  
+
     // Exported enums
     for (const m of stripped.matchAll(/^export\s+(?:const\s+)?enum\s+(\w+)\s*\{/gm)) {
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export enum ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
     }
-  
+
     // Classes (exported and internal)
     const classRegex = /^(export\s+)?(abstract\s+)?class\s+(\w+)(?:<[^{]*>)?(?:\s+extends\s+[\w<>, .]+)?(?:\s+implements\s+[\w<> ,]+)?\s*\{/gm;
     for (const m of stripped.matchAll(classRegex)) {
       const prefix = m[1] ? 'export ' : '';
       const abs = m[2] ? 'abstract ' : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`${prefix}${abs}class ${m[3]}`);
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+      const block = extractBlock(stripped, bodyStart);
       const methods = extractClassMembers(block);
-      for (const meth of methods) sigs.push(`  ${meth}`);
+      for (const meth of methods) {
+        sigs.push(`  ${meth.text}`);
+        anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+      }
     }
-  
+
     // Exported top-level functions (not methods)
     for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*[^{]+)?\s*\{/gm)) {
       const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
       const params = normalizeParams(m[2]);
       const retMatch = m[0].match(/\)\s*:\s*([^{]+)\s*\{/);
       const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 30) : '';
-      const retStr = retType ? ` \u2192 ${retType}` : '';
+      const retStr = retType ? ` → ${retType}` : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export ${asyncKw}function ${m[1]}(${params})${retStr}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+
+      // Hooks: capture compact return object shape for use* functions.
+      if (m[1].startsWith('use')) {
+        const body = stripped.slice(bodyStart, bodyStart + 800);
+        const ret = body.match(/return\s*\{([^}]{1,260})\}/);
+        if (ret) {
+          const keys = ret[1]
+            .split(',')
+            .map((s) => s.trim().split(':')[0].split('(')[0].trim())
+            .filter(Boolean)
+            .slice(0, 8);
+          if (keys.length) {
+            sigs[sigs.length - 1] += ` → { ${keys.join(', ')} }`;
+          }
+        }
+      }
     }
-  
+
     // Exported arrow functions / const functions
     for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?\(([^)]*)\)\s*(?::\s*[^=>{]+)?\s*=>/gm)) {
       const asyncKw = /=\s*async\s+/.test(m[0]) ? 'async ' : '';
       const params = normalizeParams(m[2]);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${params}) =>`);
-    }
+      const bodyStart = stripped.indexOf('{', m.index + m[0].length);
+      const endLn = bodyStart !== -1
+        ? lineAt(stripped, blockEndIdx(bodyStart + 1))
+        : lineAt(stripped, m.index + m[0].length);
+      anchors.push([lineAt(stripped, m.index), endLn]);
 
-    // Zustand stores: export const useXxxStore = create<State>()(...)
-    for (const m of stripped.matchAll(/^export\s+const\s+(use\w+Store)\s*=\s*create(?:<[^>]*>)?\s*\(/gm)) {
-      // Extract the State interface name from create<StateName>
-      const stateType = m[0].match(/create<([\w]+)>/)?.[1] || '';
-      sigs.push(`export const ${m[1]} = create<${stateType}>(...)`);
-      // Extract action/state keys from the embedded interface in same file
-      const ifaceRe = new RegExp(`interface\\s+${stateType}\\s*\\{([\\s\\S]*?)\\}`);
-      const ifm = stripped.match(ifaceRe);
-      if (ifm) {
-        for (const fm of ifm[1].matchAll(/^\s+(\w+)\s*(?:\([^)]*\))?\s*:/gm)) {
-          sigs.push(`  ${fm[1]}`);
+      // Hooks: capture compact return object shape for use* functions.
+      if (m[1].startsWith('use')) {
+        if (bodyStart !== -1) {
+          const body = stripped.slice(bodyStart, bodyStart + 800);
+          const ret = body.match(/return\s*\{([^}]{1,260})\}/);
+          if (ret) {
+            const keys = ret[1]
+              .split(',')
+              .map((s) => s.trim().split(':')[0].split('(')[0].trim())
+              .filter(Boolean)
+              .slice(0, 8);
+            if (keys.length) {
+              sigs[sigs.length - 1] += ` → { ${keys.join(', ')} }`;
+            }
+          }
         }
       }
     }
 
-    // API client objects: export default { method: async (...) => ... }
-    // Pattern: const xxxApi = { methodName: async ... }
-    for (const m of stripped.matchAll(/^(?:export\s+default\s+|const\s+)(\w*[Aa]pi\w*)\s*=\s*\{/gm)) {
-      const apiName = m[1];
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
-      const methods = [];
-      for (const mm of block.matchAll(/^\s+(\w+)\s*:\s*(?:async\s+)?(?:\([^)]*\)|\w+)\s*=>/gm)) {
-        methods.push(mm[1]);
+    // Zustand stores: export const useXxxStore = create<State>()(...)
+    for (const m of stripped.matchAll(/^export\s+const\s+(use\w+Store)\s*=\s*create(?:<[^>]*>)?\s*\(/gm)) {
+      const stateType = m[0].match(/create<([\w]+)>/)?.[1] || '';
+      const startLn = lineAt(stripped, m.index);
+      sigs.push(`export const ${m[1]} = create<${stateType}>(...)`);
+      anchors.push([startLn, startLn]);
+      const ifaceRe = new RegExp(`interface\\s+${stateType}\\s*\\{([\\s\\S]*?)\\}`);
+      const ifm = stripped.match(ifaceRe);
+      if (ifm) {
+        for (const fm of ifm[1].matchAll(/^\s+(\w+)\s*(?:\([^)]*\))?\s*:/gm)) { sigs.push(`  ${fm[1]}`); anchors.push(null); }
       }
-      if (methods.length) sigs.push(`${apiName}: { ${methods.join(', ')} }`);
     }
-  
-    return sigs.slice(0, 35);
+
+    // API client objects: const xxxApi = { method: async () => {} }
+    for (const m of stripped.matchAll(/^(?:export\s+default\s+|const\s+)(\w*[Aa]pi\w*)\s*=\s*\{/gm)) {
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      const methods = [...block.matchAll(/^\s+(\w+)\s*:\s*(?:async\s+)?(?:\([^)]*\)|\w+)\s*=>/gm)].map(mm => mm[1]);
+      if (methods.length) {
+        sigs.push(`${m[1]}: { ${methods.join(', ')} }`);
+        anchors.push([lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)]);
+      }
+    }
+
+    return sigs
+      .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+      .slice(0, 35);
   }
-  
+
   function extractBlock(src, startIndex) {
     let depth = 1;
     let i = startIndex;
@@ -1905,47 +2004,59 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
     }
     return src.slice(startIndex, i - 1);
   }
-  
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block`, so the caller can resolve member line anchors.
   function extractInterfaceMembers(block) {
     const members = [];
     for (const m of block.matchAll(/^\s+(readonly\s+)?(\w+)(\??):\s*([^;]+);/gm)) {
       const readonly = m[1] ? 'readonly ' : '';
       const optional = m[3] ? '?' : '';
       const typeStr = m[4].trim().replace(/\s+/g, ' ').slice(0, 35);
-      members.push(`${readonly}${m[2]}${optional}: ${typeStr}`);
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      members.push({ text: `${readonly}${m[2]}${optional}: ${typeStr}`, start, end: m.index + m[0].length });
     }
     for (const m of block.matchAll(/^\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)\s*:/gm)) {
-      members.push(`${m[1]}(${normalizeParams(m[2])})`);
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      members.push({ text: `${m[1]}(${normalizeParams(m[2])})`, start, end: m.index + m[0].length });
     }
     return members.slice(0, 8);
   }
-  
+
+  const _CTRL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'do', 'try', 'catch', 'finally', 'else', 'return']);
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block` (end = the method's closing brace), so the caller can resolve
+  // per-method line anchors that span the method body.
   function extractClassMembers(block) {
     const members = [];
-    // Public methods (skip private/protected/_ prefixed)
+    // Public methods (skip private/protected/_ prefixed and control-flow keywords)
     const methodRe = /^\s+(?:public\s+|static\s+|async\s+|override\s+)*(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*[^{;]+)?\s*\{/gm;
     for (const m of block.matchAll(methodRe)) {
+      if (_CTRL_KEYWORDS.has(m[1])) continue;
       if (/^(private|protected|_)/.test(m[1])) continue;
-      if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+      const bodyStart = m.index + m[0].length; // just past the opening brace
+      const end = bodyStart + extractBlock(block, bodyStart).length;
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
       const isAsync = m[0].includes('async ') ? 'async ' : '';
       const isStatic = m[0].includes('static ') ? 'static ' : '';
       const retMatch = m[0].match(/\)\s*:\s*([^{;]+)\s*\{/);
       const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 20) : '';
-      const retStr = retType ? ` \u2192 ${retType}` : '';
-      members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const retStr = retType ? ` → ${retType}` : '';
+      members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
     }
     return members.slice(0, 8);
   }
-  
+
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ').replace(/:[^,)]+/g, '').trim();
   }
-  
-  module.exports = { extract };
-  
-};
 
+  module.exports = { extract };
+
+};
 // ── ./src/extractors/graphql ──
 __factories["./src/extractors/graphql"] = function(module, exports) {
   
@@ -9154,10 +9265,18 @@ function computeEffectiveMaxTokens(fileEntries, config) {
 
 function applyTokenBudget(fileEntries, maxTokens) {
   // fileEntries: [{ filePath, sigs, mtime }]
-  // Reserve ~10% for formatting overhead (section headers, code fences, top-level header)
-  const effectiveBudget = Math.floor(maxTokens * 0.90);
-  let total = fileEntries.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')), 0);
-  if (total <= effectiveBudget) return fileEntries;
+  // Per-file rendered overhead: "### <path>", code fences, trailing blank line.
+  // A signature-only budget undercounts this, so when many files survive the
+  // section headers alone can blow maxTokens.
+  const sectionOverhead = (e) => estimateTokens(String(e.filePath || '')) + 6;
+  const renderedTotal = (entries) =>
+    entries.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')) + sectionOverhead(e), 0);
+  // The generated file also carries a ~150-token fixed preamble (SigMap command
+  // table + headers). Reserve at least that much so small budgets don't overflow;
+  // for large budgets this matches the historical 10% reserve.
+  const budgetForEntries = Math.max(1, maxTokens - Math.max(200, Math.ceil(maxTokens * 0.10)));
+  let total = renderedTotal(fileEntries);
+  if (total <= budgetForEntries) return fileEntries;
 
   // v6.12 Surgical Context — progressive disclosure: before dropping whole files,
   // collapse signature BODIES to their line-anchor pointers (keep `symbol :start-end`).
@@ -9171,12 +9290,13 @@ function applyTokenBudget(fileEntries, maxTokens) {
     });
     return { ...e, sigs: slim };
   });
-  const collapsedTotal = collapsed.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')), 0);
-  if (collapsedTotal < total) {
-    console.warn(`[sigmap] budget: collapsed bodies to anchors, reclaimed ~${total - collapsedTotal} tokens`);
+  const collapsedRendered = renderedTotal(collapsed);
+  if (collapsedRendered < total) {
+    console.warn(`[sigmap] budget: collapsed bodies to anchors, reclaimed ~${total - collapsedRendered} tokens`);
     working = collapsed;
-    total = collapsedTotal;
-    if (total <= effectiveBudget) return working; // anchor collapse alone fit the budget
+    total = collapsedRendered;
+    // Collapsing keeps every file, so the section overhead must fit too — not just sigs.
+    if (total <= budgetForEntries) return working;
   }
 
   // Sort by drop priority (drop first = index 0)
@@ -9203,12 +9323,13 @@ function applyTokenBudget(fileEntries, maxTokens) {
 
   const kept = [];
   const verboseDropped = [];
-  // Iterate forward: highest drop-priority files (generated=10, mock=9, test=8) are at index 0
-  // Drop those first until we're under budget, then keep everything else
+  // Iterate forward: highest drop-priority files (generated=10, mock=9, test=8) are at index 0.
+  // Drop those first until the RENDERED total (sigs + section overhead) fits maxTokens,
+  // then keep everything else.
+  let rendered = renderedTotal(withPriority);
   for (const entry of withPriority) {
-    const entryTokens = estimateTokens(entry.sigs.join('\n'));
-    if (total > effectiveBudget) {
-      total -= entryTokens;
+    if (rendered > budgetForEntries) {
+      rendered -= estimateTokens(entry.sigs.join('\n')) + sectionOverhead(entry);
       verboseDropped.push({ filePath: entry.filePath, reason: entry.dropReason });
     } else {
       kept.push(entry);

--- a/src/extractors/javascript.js
+++ b/src/extractors/javascript.js
@@ -1,57 +1,88 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from JavaScript source code.
+ * Top-level declarations and class members carry a `:start-end` line anchor
+ * (see line-anchor.js); kept parallel to `sigs` and applied once at return.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  const anchors = [];
   const returnHints = buildReturnHints(src);
 
+  // Block comments are blanked newline-by-newline (non-newline chars → spaces)
+  // so character offsets AND line numbers stay exact for anchors.
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+  const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+  // End line for a function whose match ends at `matchEnd` (before its body brace).
+  const fnEndLine = (matchEnd, startLn) => {
+    const brace = stripped.indexOf('{', matchEnd);
+    return brace !== -1 ? lineAt(stripped, blockEndIdx(brace + 1)) : startLn;
+  };
 
   // Classes
   const classRegex = /^(export\s+(?:default\s+)?)?class\s+(\w+)(?:\s+extends\s+[\w.]+)?\s*\{/gm;
   for (const m of stripped.matchAll(classRegex)) {
     const prefix = m[1] ? m[1].trim() + ' ' : '';
+    const bodyStart = m.index + m[0].length;
     sigs.push(`${prefix}class ${m[2]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const meth of extractClassMembers(block, returnHints)) sigs.push(`  ${meth}`);
+    anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+    const block = extractBlock(stripped, bodyStart);
+    for (const meth of extractClassMembers(block, returnHints)) {
+      sigs.push(`  ${meth.text}`);
+      anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+    }
   }
 
   // Exported named functions
   for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
     const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
   // Exported arrow functions
   for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(([^)]*)\)\s*=>/gm)) {
     const asyncKw = m[0].includes('async') ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
   // module.exports = { ... }
   const moduleExports = stripped.match(/^module\.exports\s*=\s*\{([^}]+)\}/m);
   if (moduleExports) {
     const names = moduleExports[1].split(',').map((s) => s.trim()).filter(Boolean);
-    if (names.length > 0) sigs.push(`module.exports = { ${names.join(', ')} }`);
+    if (names.length > 0) {
+      const startLn = lineAt(stripped, moduleExports.index);
+      sigs.push(`module.exports = { ${names.join(', ')} }`);
+      anchors.push([startLn, lineAt(stripped, moduleExports.index + moduleExports[0].length)]);
+    }
   }
 
   // Top-level named functions (non-exported)
   for (const m of stripped.matchAll(/^(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
     const asyncKw = m[0].startsWith('async') ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
-  return sigs.slice(0, 25);
+  return sigs
+    .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+    .slice(0, 25);
 }
 
 function extractBlock(src, startIndex) {
@@ -66,15 +97,21 @@ function extractBlock(src, startIndex) {
   return src.slice(startIndex, i - 1);
 }
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block` (end = the method's closing brace), so the caller can resolve
+// per-method line anchors that span the method body.
 function extractClassMembers(block, returnHints) {
   const members = [];
   for (const m of block.matchAll(/^\s+(?:static\s+|async\s+|get\s+|set\s+)*(\w+)\s*\(([^)]*)\)\s*\{/gm)) {
     if (/^_/.test(m[1])) continue;
-    if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+    const bodyStart = m.index + m[0].length; // just past the opening brace
+    const end = bodyStart + extractBlock(block, bodyStart).length;
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
     const isAsync = m[0].includes('async ') ? 'async ' : '';
     const isStatic = m[0].includes('static ') ? 'static ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
-    members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/typescript.js
+++ b/src/extractors/typescript.js
@@ -35,7 +35,10 @@ function extract(src) {
     // Collect members
     const block = extractBlock(stripped, bodyStart);
     const members = extractInterfaceMembers(block);
-    for (const mem of members) { sigs.push(`  ${mem}`); anchors.push(null); }
+    for (const mem of members) {
+      sigs.push(`  ${mem.text}`);
+      anchors.push([lineAt(stripped, bodyStart + mem.start), lineAt(stripped, bodyStart + mem.end)]);
+    }
   }
 
   // Exported type aliases
@@ -61,7 +64,10 @@ function extract(src) {
     anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
     const block = extractBlock(stripped, bodyStart);
     const methods = extractClassMembers(block);
-    for (const meth of methods) { sigs.push(`  ${meth}`); anchors.push(null); }
+    for (const meth of methods) {
+      sigs.push(`  ${meth.text}`);
+      anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+    }
   }
 
   // Exported top-level functions (not methods)
@@ -163,22 +169,29 @@ function extractBlock(src, startIndex) {
   return src.slice(startIndex, i - 1);
 }
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block`, so the caller can resolve member line anchors.
 function extractInterfaceMembers(block) {
   const members = [];
   for (const m of block.matchAll(/^\s+(readonly\s+)?(\w+)(\??):\s*([^;]+);/gm)) {
     const readonly = m[1] ? 'readonly ' : '';
     const optional = m[3] ? '?' : '';
     const typeStr = m[4].trim().replace(/\s+/g, ' ').slice(0, 35);
-    members.push(`${readonly}${m[2]}${optional}: ${typeStr}`);
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    members.push({ text: `${readonly}${m[2]}${optional}: ${typeStr}`, start, end: m.index + m[0].length });
   }
   for (const m of block.matchAll(/^\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)\s*:/gm)) {
-    members.push(`${m[1]}(${normalizeParams(m[2])})`);
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    members.push({ text: `${m[1]}(${normalizeParams(m[2])})`, start, end: m.index + m[0].length });
   }
   return members.slice(0, 8);
 }
 
 const _CTRL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'do', 'try', 'catch', 'finally', 'else', 'return']);
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block` (end = the method's closing brace), so the caller can resolve
+// per-method line anchors that span the method body.
 function extractClassMembers(block) {
   const members = [];
   // Public methods (skip private/protected/_ prefixed and control-flow keywords)
@@ -186,13 +199,16 @@ function extractClassMembers(block) {
   for (const m of block.matchAll(methodRe)) {
     if (_CTRL_KEYWORDS.has(m[1])) continue;
     if (/^(private|protected|_)/.test(m[1])) continue;
-    if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+    const bodyStart = m.index + m[0].length; // just past the opening brace
+    const end = bodyStart + extractBlock(block, bodyStart).length;
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
     const isAsync = m[0].includes('async ') ? 'async ' : '';
     const isStatic = m[0].includes('static ') ? 'static ' : '';
     const retMatch = m[0].match(/\)\s*:\s*([^{;]+)\s*\{/);
     const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 20) : '';
     const retStr = retType ? ` → ${retType}` : '';
-    members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
   }
   return members.slice(0, 8);
 }

--- a/test/expected/javascript.txt
+++ b/test/expected/javascript.txt
@@ -1,12 +1,12 @@
-class EventEmitter
-  constructor()
-  on(event, handler)
-  emit(event, data)
-  static create()
-export class ApiClient
-  constructor(baseUrl)
-  async get(path)
-  async post(path, body)
-export async function fetchUser(id)
-export const createSession = async (userId) =>
-module.exports = { EventEmitter, ApiClient, fetchUser }
+class EventEmitter  :3-20
+  constructor()  :4-6
+  on(event, handler)  :8-11
+  emit(event, data)  :13-15
+  static create()  :17-19
+export class ApiClient  :22-35
+  constructor(baseUrl)  :23-26
+  async get(path)  :28-30
+  async post(path, body)  :32-34
+export async function fetchUser(id)  :37-39
+export const createSession = async (userId) =>  :41-43
+module.exports = { EventEmitter, ApiClient, fetchUser }  :45-45

--- a/test/expected/typescript.txt
+++ b/test/expected/typescript.txt
@@ -1,16 +1,16 @@
 export interface UserService  :3-7
-  readonly version: string
-  getUser(id)
-  createUser(data)
+  readonly version: string  :6-6
+  getUser(id)  :4-4
+  createUser(data)  :5-5
 export type UserId  :9-9
 export type UserRole  :10-10
 export enum Status  :12-16
 export class UserRepository  :18-36
-  constructor(private db)
-  async findById(id) → Promise<User | null>
-  async save(user) → Promise<void>
-  static create(db) → UserRepository
+  constructor(private db)  :19-19
+  async findById(id) → Promise<User | null>  :21-23
+  async save(user) → Promise<void>  :25-27
+  static create(db) → UserRepository  :29-31
 class InternalHelper  :54-58
-  process(data) → string
+  process(data) → string  :55-57
 export async function hashPassword(password) → Promise<string>  :38-40
 export const useAuth = (loginId, password) => → { user, isAuthenticated, login, logout }  :46-52

--- a/test/integration/extractors/line-anchors.test.js
+++ b/test/integration/extractors/line-anchors.test.js
@@ -13,6 +13,7 @@ const assert = require('assert');
 
 const ROOT = path.resolve(__dirname, '../../..');
 const ts   = require(path.join(ROOT, 'src', 'extractors', 'typescript'));
+const js   = require(path.join(ROOT, 'src', 'extractors', 'javascript'));
 const py   = require(path.join(ROOT, 'src', 'extractors', 'python'));
 const { lineAt, anchor, withAnchor } = require(path.join(ROOT, 'src', 'extractors', 'line-anchor'));
 
@@ -55,14 +56,14 @@ test('3. TS top-level function carries :start-end', () => {
     `expected foo :1-3, got:\n${sigs.join('\n')}`);
 });
 
-test('4. TS indented members are NOT anchored', () => {
+test('4. TS class members carry their own anchor (v6.12.x member anchors)', () => {
   const src = `export class Svc {
   doThing(x: string): void {}
 }`;
   const sigs = ts.extract(src);
   const member = sigs.find(s => s.includes('doThing('));
   assert.ok(member, 'doThing member must be present');
-  assert.ok(!/:\d+-\d+/.test(member), `member must not carry an anchor, got "${member}"`);
+  assert.ok(/:2-2$/.test(member), `member must carry its own anchor :2-2, got "${member}"`);
   const header = sigs.find(s => s.startsWith('export class Svc'));
   assert.ok(/:1-3$/.test(header), `class header must be anchored :1-3, got "${header}"`);
 });
@@ -135,6 +136,72 @@ test('9. Python class header anchored, methods not', () => {
     `expected class Svc :1-3, got:\n${sigs.join('\n')}`);
   const method = sigs.find(s => s.includes('do_it'));
   assert.ok(method && !/:\d+-\d+/.test(method), `method must not be anchored, got "${method}"`);
+});
+
+// ── TypeScript interface members (v6.12.x) ─────────────────────────────────────
+
+test('10. TS interface members carry their own anchor', () => {
+  const src = `export interface Repo {
+  id: string;
+  fetch(query: string): Promise<Row[]>;
+}`;
+  const sigs = ts.extract(src);
+  assert.ok(sigs.some(s => /^\s+id: string  :2-2$/.test(s)),
+    `expected id member :2-2, got:\n${sigs.join('\n')}`);
+  assert.ok(sigs.some(s => /^\s+fetch\(query\)  :3-3$/.test(s)),
+    `expected fetch member :3-3, got:\n${sigs.join('\n')}`);
+});
+
+// ── JavaScript (v6.12.x — anchors added in this PR) ────────────────────────────
+
+test('11. JS top-level function carries :start-end', () => {
+  const src = `export function foo(a, b) {
+  return a + b;
+}`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => /export function foo\(a, b\)  :1-3$/.test(s)),
+    `expected foo :1-3, got:\n${sigs.join('\n')}`);
+});
+
+test('12. JS class members carry their own anchor (not the parent class)', () => {
+  const src = `class Gateway {
+  async charge(amount, currency) {
+    return null;
+  }
+  refund(id) {
+    return null;
+  }
+}`;
+  const sigs = js.extract(src);
+  const header = sigs.find(s => s.startsWith('class Gateway'));
+  assert.ok(/:1-8$/.test(header), `class header :1-8, got "${header}"`);
+  const charge = sigs.find(s => s.includes('charge('));
+  const refund = sigs.find(s => s.includes('refund('));
+  assert.ok(/:2-4$/.test(charge), `charge member :2-4, got "${charge}"`);
+  assert.ok(/:5-7$/.test(refund), `refund member :5-7, got "${refund}"`);
+});
+
+test('13. JS block-comment regression — multiline comment does not shift line numbers', () => {
+  // Before the newline-preserving strip, the JS extractor deleted block-comment
+  // newlines, which would shift createCharge up from :5 to ~:2.
+  const src = `/* a
+   multi-line
+   block comment */
+export function createCharge(customerId, amountCents) {
+  return doIt();
+}`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => s.includes('export function createCharge(') && s.endsWith(':4-6')),
+    `expected createCharge :4-6 (newlines preserved), got:\n${sigs.join('\n')}`);
+});
+
+test('14. JS module.exports carries an anchor', () => {
+  const src = `function a() {}
+function b() {}
+module.exports = { a, b };`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => /^module\.exports = \{ a, b \}  :3-3$/.test(s)),
+    `expected module.exports :3-3, got:\n${sigs.join('\n')}`);
 });
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/test/integration/surgical-context.test.js
+++ b/test/integration/surgical-context.test.js
@@ -129,5 +129,34 @@ test('--since restricts output to files changed since a git ref', () => {
   });
 });
 
+test('--mode index materially collapses real anchored JavaScript (issue #223)', () => {
+  withTempProject((dir) => {
+    // Real extraction: verbose top-level JS functions now carry anchors, so
+    // index mode can collapse the param lists (was a no-op before #223).
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    const lines = [];
+    for (let i = 0; i < 6; i++) {
+      lines.push(`export function handleRequest${i}(requestContext, payloadEnvelope, authToken, traceId, retryPolicyConfig, idempotencyKey) {`);
+      lines.push('  return null;');
+      lines.push('}');
+    }
+    fs.writeFileSync(path.join(dir, 'src', 'handlers.js'), lines.join('\n'));
+    fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({ secretScan: false }));
+    run(dir, ''); // generate context (runs the JS extractor → anchored verbose sigs)
+
+    const full = JSON.parse(run(dir, 'ask "handle request payload" --json').trim());
+    const idx = JSON.parse(run(dir, 'ask "handle request payload" --mode index --json').trim());
+
+    assert.ok(idx.contextTokens < full.contextTokens * 0.85,
+      `index (${idx.contextTokens}) should cut >15% vs default (${full.contextTokens})`);
+
+    // Default keeps the param list; index drops it but keeps the anchor.
+    run(dir, 'ask "handle request payload" --mode index');
+    const out = fs.readFileSync(path.join(dir, '.context', 'query-context.md'), 'utf8');
+    assert.ok(!out.includes('retryPolicyConfig'), 'index mode must drop the parameter list');
+    assert.ok(/handleRequest0\s+:\d+-\d+/.test(out), 'index mode must keep symbol + anchor');
+  });
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/test/integration/token-budget.test.js
+++ b/test/integration/token-budget.test.js
@@ -96,9 +96,11 @@ test('Test files are dropped before source files', () => {
     const testFile = path.join(srcDir, 'bigfile.test.js');
     writeJsFile(testFile, 600);
 
-    // Budget: enough for source files but not for the giant test file
+    // Budget: enough for source files but not for the giant test file.
+    // autoMaxTokens:false pins the 500 budget (otherwise auto-scale floors it at 4000).
     fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({
       maxTokens: 500,
+      autoMaxTokens: false,
       outputs: ['copilot'],
       secretScan: false,
     }));


### PR DESCRIPTION
Closes #223. Surgical Context Phase 2.1 (first of a phased rollout).

## Why
v6.11.0 line anchors covered only **2 of 18 code extractors** (TS, Python) and only **top-level** declarations. Real-repo measurement showed `ask --mode index` cut only **~4.6%** weighted tokens — most sigs had no anchor to collapse or to target with `get_lines`.

## What
- **`javascript.js` — top-level anchors.** Functions, classes, exported arrows, and `module.exports` now carry `:start-end`. Block-comment stripping switched to the newline-preserving blank so line numbers stay exact below `/* … */` (same fix v6.11.0 applied to TS/Python).
- **Member-level anchors (TS + JS).** Class methods and interface members now carry their **own** anchor spanning the member body — unlocking method-level `get_lines` targeting. Helper functions return `{text, start, end}` block offsets.
- **Bundle sync.** Both extractors mirrored into the bundled `gen-context.js` factories — the standalone bundle was stale (never got v6.11.0 anchors).
- **Budget fix (`applyTokenBudget`).** Anchors made JS sigs collapsible, which exposed that the signature-only budget undercounts per-file section headers + the fixed ~150-token preamble, letting many-file output exceed `maxTokens`. Now budgets **rendered cost** (sigs + section overhead) against `maxTokens − max(200, 10%)`.

## Evidence (direct extractor, real repos)
Index-mode token cut **4.6% → 32–42%**, all now 100% anchored:

| Repo | anchored | cut (was) |
|------|---------|-----------|
| axios | 100% | **42.1%** (5.8%) |
| fastify | 100% | **41.1%** (13.2%) |
| svelte | 100% | **36.8%** (7.2%) |
| vue-core | 100% | **32.4%** (0.2%) |

## Out of scope (follow-ups)
Remaining extractors: java, kotlin, go, rust, csharp, cpp, ruby, php, swift, dart, scala, gdscript, vue_sfc, svelte, typescript_react. Separately noted: `buildSigIndex`'s cache/cold-merge can prefer stale param-less entries, blunting the `ask`-path realization of the extractor-level cut — worth a look in a later phase.

## Test plan
- [x] `node test/integration/all.js` — 64/0
- [x] unit (`node test/run.js`) 23/0, R-language pass
- [x] New: JS top-level + member anchor golden-range tests, JS block-comment regression, `module.exports` anchor, TS interface/class member anchors, real-extraction `--mode index` collapse (>15% on a JS fixture)
- [x] Refreshed typescript/javascript golden expected files
- [x] Bundle verified standalone (no `src/`) emits correct anchors

Release flow: merge to develop → `/update-docs` → `/ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)