### PR TITLE
Release v6.13.0 — Line anchors for JavaScript + member anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [6.13.0] — 2026-06-05
+
+### Added
+
+- **Line anchors for JavaScript + member-level anchors (Surgical Context Phase 2.1, #223, PR #224):**
+  - The **JavaScript extractor** now emits `:start-end` line anchors on top-level functions, classes, exported arrow functions, and `module.exports` — previously only TypeScript and Python carried anchors. JS block-comment stripping switched to the newline-preserving blank so anchor line numbers stay exact below a `/* … */`.
+  - **Class methods and interface members** (TypeScript **and** JavaScript) now carry their **own** `:start-end` anchor spanning the member body, instead of inheriting nothing — unlocking method-level targeting with the `get_lines` MCP tool.
+  - Measured effect: index-mode token reduction on real repos rises from ~4.6% to **32–42%** (axios 42.1%, fastify 41.1%, svelte 36.8%, vue-core 32.4%), now 100% anchored.
+
+### Changed
+
+- The bundled standalone `gen-context.js` extractor factories are re-synced with `src/` (the bundle had been stale since v6.11.0), so anchors work in the single-file distribution too.
+
+### Fixed
+
+- **Token budget could exceed `maxTokens` with many files.** The budget was signature-only and undercounted per-file section headers plus the fixed ~150-token preamble; with anchored (collapsible) signatures keeping more files alive, output could overflow. `applyTokenBudget` now budgets *rendered* cost (signatures + section overhead) against `maxTokens` minus a `max(200, 10%)` preamble reserve.
+
+---
+
 ## [6.12.0] — 2026-06-05
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,9 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
+### Recent Contributors (v6.13.0)
+- **@manojmallick** — feat: line anchors for JavaScript + member-level anchors (TS & JS); index-mode token cut 4.6% → 32–42% on real repos; overhead-aware token budget (#223, PR #224)
+
 ### Recent Contributors (v6.12.0)
 - **@manojmallick** — feat: Surgical Context Phase 2 — `get_lines` MCP tool, `ask --mode index`, `ask --since`, budget-aware body collapse, Token Reduction dashboard panel (#219, PR #220)
 - **@manojmallick** — ci: add `workflow_dispatch` to the develop→main sync workflow (PR #218)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ask → Rank → Context → Validate → Judge → Learn
 ## Benchmark
 
 ```
-Benchmark : sigmap-v6.12-main (21 repositories, including R language)
+Benchmark : sigmap-v6.13-main (21 repositories, including R language)
 Date      : 2026-06-05
 
 Hit@5          : 81.1%   (baseline 13.6%  — 6.0× lift)

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Benchmark overview
-description: Official v6.12.0 benchmark snapshot. 96.5% average token reduction across 21 repos, 81% retrieval hit@5, 41.8% fewer prompts, and R language support verified.
+description: Official v6.13.0 benchmark snapshot. 96.5% average token reduction across 21 repos, 81% retrieval hit@5, 41.8% fewer prompts, and R language support verified.
 head:
   - - meta
     - property: og:title
-      content: "SigMap benchmark overview — v6.12.0 snapshot with R language"
+      content: "SigMap benchmark overview — v6.13.0 snapshot with R language"
   - - meta
     - property: og:description
-      content: "Token, retrieval, quality, and task metrics from latest v6.12.0 benchmark run (2026-06-05) with 21 repositories including R language support."
+      content: "Token, retrieval, quality, and task metrics from latest v6.13.0 benchmark run (2026-06-05) with 21 repositories including R language support."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/benchmark"
@@ -15,8 +15,8 @@ head:
 
 # Benchmark overview
 
-::: info Official v6.12.0 benchmark snapshot (21 repos, including R language)
-**Benchmark ID:** sigmap-v6.12-main &nbsp;·&nbsp; **Date:** 2026-06-05
+::: info Official v6.13.0 benchmark snapshot (21 repos, including R language)
+**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05
 
 | Metric | Value |
 |---|---:|
@@ -37,9 +37,9 @@ This is the landing page for the public benchmark story. It answers four differe
 | SigMap reduces retries and wrong-context answers | [Task benchmark](/guide/task-benchmark) |
 | SigMap keeps large repos inside model limits | [Quality benchmark](/guide/quality-benchmark) |
 
-## Official v6.12.0 snapshot (with R language support)
+## Official v6.13.0 snapshot (with R language support)
 
-Latest saved benchmark run: **2026-06-05 (v6.12.0)**
+Latest saved benchmark run: **2026-06-05 (v6.13.0)**
 
 | Metric | Result |
 |---|---:|
@@ -66,6 +66,7 @@ Latest saved benchmark run: **2026-06-05 (v6.12.0)**
   - dplyr: 93.4% reduction (145.1K → 9.5K tokens)
   - shiny: 96.2% reduction (264.6K → 10.0K tokens)
 - **New in v6.12.0:** demand-driven *Surgical Context* (`ask --mode index` + the `get_lines` MCP tool) cuts upfront `ask` context further on top of the figures above by emitting symbol pointers instead of bodies — see the [Surgical Context guide](/guide/surgical-context).
+- **New in v6.13.0:** line anchors extended to JavaScript and to class methods / interface members (TS & JS), raising index-mode token reduction on real repos from ~4.6% to 32–42% (axios 42.1%, fastify 41.1%, svelte 36.8%, vue-core 32.4%).
 
 ### 2. Retrieval quality
 

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -125,7 +125,7 @@ With `--json` the output is a machine-readable object with `intent`, `coverage`,
 
 When coverage drops below 70%, a warning is emitted on stderr pointing to `sigmap validate`.
 
-**Line anchors (v6.11.0):** top-level TypeScript and Python signatures carry a `:start-end` source range, e.g. `export class UserRepository  :18-36`. This is the first step of *Surgical Context* — an agent can open the exact lines instead of the whole file. Anchors appear automatically in `ask` output, the generated `CLAUDE.md`, and every adapter; no flag is required.
+**Line anchors (v6.11.0+):** signatures carry a `:start-end` source range, e.g. `export class UserRepository  :18-36`, so an agent can open the exact lines instead of the whole file. Top-level TypeScript and Python decls were first (v6.11.0); **v6.13.0 adds JavaScript and per-member anchors** — TypeScript/JavaScript class methods and interface members now carry their own range, not the parent's. Anchors appear automatically in `ask` output, the generated `CLAUDE.md`, and every adapter; no flag is required.
 
 ### ask --followup
 

--- a/docs-vp/guide/generalization.md
+++ b/docs-vp/guide/generalization.md
@@ -1,6 +1,6 @@
 ---
 title: Generalization — SigMap across languages, domains & repo sizes
-description: SigMap generalizes across 21 repos, 31 languages, and multiple domains with 81.1% hit@5 in the latest saved v6.12.0 retrieval run.
+description: SigMap generalizes across 21 repos, 31 languages, and multiple domains with 81.1% hit@5 in the latest saved v6.13.0 retrieval run.
 head:
   - - meta
     - property: og:title
@@ -19,8 +19,8 @@ head:
 SigMap was not tuned for one repo. This benchmark matters because it shows the same workflow transfers across different languages, repo sizes, and architectures without manual tuning.
 :::
 
-::: info Official v6.12.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.12-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.13.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
 
 | Metric | Value |
 |---|---:|
@@ -37,7 +37,7 @@ The important part of SigMap's benchmark story is not just the topline score. It
 ::: info What "generalization" means here
 SigMap's signature extractors are hand-written regex patterns, not ML models. Generalization
 means: *do the patterns hold up on codebases the authors never inspected?* The answer across
-these 90 tasks is yes — 81% hit@5 with no per-repo tuning in the latest saved v6.12.0 run.
+these 90 tasks is yes — 81% hit@5 with no per-repo tuning in the latest saved v6.13.0 run.
 :::
 
 - **21 repos** (including 3 R language repos)

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Quality benchmark
-description: What token reduction means operationally in v6.12.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
+description: What token reduction means operationally in v6.13.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
 head:
   - - meta
     - property: og:title
@@ -15,8 +15,8 @@ head:
 
 # Quality benchmark
 
-::: info Official v6.12.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.12-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.13.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
 
 | Metric | Value |
 |---|---:|
@@ -34,7 +34,7 @@ Token reduction is the mechanism. This benchmark shows the operational consequen
 - how much code would be hidden without SigMap?
 - what does that mean for API cost?
 
-Latest saved run: **2026-06-05 (v6.12.0)**
+Latest saved run: **2026-06-05 (v6.13.0)**
 
 ## Headline numbers
 

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Retrieval benchmark
-description: Latest saved retrieval benchmark for SigMap v6.12.0. 81% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
+description: Latest saved retrieval benchmark for SigMap v6.13.0. 81% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
 head:
   - - meta
     - property: og:title
@@ -15,8 +15,8 @@ head:
 
 # Retrieval benchmark
 
-::: info Official v6.12.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.12-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.13.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
 
 | Metric | Value |
 |---|---:|
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-05 (v6.12.0)**
+Latest saved run: **2026-06-05 (v6.13.0)**
 
 **Result:** SigMap finds the right file in the top 5 far more often than chance — **81% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.11.1, with recent releases adding line anchors (Surgical Context Phase 1) to TypeScript and Python signatures and a community MCP hot-cold bundle fix.
+description: SigMap version history and roadmap. From v0.0 to v6.13.0, with recent releases adding demand-driven Surgical Context (get_lines MCP tool, --mode index, --since) and line anchors for JavaScript plus per-member anchors.
 head:
   - - meta
     - property: og:title
@@ -20,9 +20,9 @@ head:
 ---
 # Roadmap
 
-Fifty-seven versions shipped. MIT open source from day one.
+Fifty-eight versions shipped. MIT open source from day one.
 
-**Stats:** 96.5% overall token reduction · 735 tests passing · 29 languages · 17-language source resolver · 0 npm deps
+**Stats:** 96.5% overall token reduction · 741 tests passing · 29 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -796,9 +796,19 @@ The demand-driven half of **Surgical Context**. A new **`get_lines` MCP tool** (
 
 ---
 
-## Current milestone — v6.13+ (Hallucination Guard)
+### v6.13.0 — Surgical Context Phase 2.1 (JavaScript + member anchors) ✓ (tagged v6.13.0 — 2026-06-05)
 
-v6.0–v6.12.0 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, JVM project structure auto-detection, enhanced monorepo JVM support, 2-hop graph boost with hub suppression, session-aware context carry-forward with safe change planning, segmented benchmarks with answer usefulness evaluation, monorepo workspace-scoped retrieval, R language support with S4 patterns, Python AST extraction for complex signatures, open-source agent/local LLM integration guides, complete Python import detection for accurate Python blast radius, line anchors on signatures (Surgical Context Phase 1), and demand-driven retrieval with the `get_lines` MCP tool, `--mode index`, and `--since` delta context (Surgical Context Phase 2). Next: **`verify-ai-output` (Hallucination Guard)** — a deterministic verifier that flags fake files, imports, and symbols in an AI answer against the live symbol index and file map — extended language/framework coverage (line anchors for the remaining extractors, S3 methods in R), and performance optimizations for very large monorepos (>50K files).
+Widens line-anchor coverage so demand-driven retrieval actually pays off. The **JavaScript extractor** now emits `:start-end` anchors on top-level functions, classes, exported arrows, and `module.exports` (with a newline-preserving comment strip so line numbers stay exact below `/* … */`). **Class methods and interface members** (TypeScript and JavaScript) now carry their **own** anchor spanning the member body, unlocking method-level `get_lines` targeting. The standalone bundle's extractor factories were re-synced (stale since v6.11.0), and a latent token-budget bug — signature-only accounting that undercounted section headers + the fixed preamble and could exceed `maxTokens` — was made overhead-aware.
+
+**Tags:** `line anchors` · `surgical context` · `javascript` · `member anchors` · `token budget` · `issue #223` · `PR #224`
+
+**Impact:** index-mode token reduction on real repos rises from ~4.6% to **32–42%** (axios 42.1%, fastify 41.1%, svelte 36.8%, vue-core 32.4%), now 100% anchored — with no `hit@5` regression.
+
+---
+
+## Current milestone — v6.14+ (Hallucination Guard)
+
+v6.0–v6.13.0 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, JVM project structure auto-detection, enhanced monorepo JVM support, 2-hop graph boost with hub suppression, session-aware context carry-forward with safe change planning, segmented benchmarks with answer usefulness evaluation, monorepo workspace-scoped retrieval, R language support with S4 patterns, Python AST extraction for complex signatures, open-source agent/local LLM integration guides, complete Python import detection for accurate Python blast radius, line anchors on signatures (Surgical Context Phase 1), demand-driven retrieval with the `get_lines` MCP tool, `--mode index`, and `--since` delta context (Surgical Context Phase 2), and JavaScript + per-member line anchors (Phase 2.1). Next: **`verify-ai-output` (Hallucination Guard)** — a deterministic verifier that flags fake files, imports, and symbols in an AI answer against the live symbol index and file map — line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/guide/surgical-context.md
+++ b/docs-vp/guide/surgical-context.md
@@ -26,6 +26,12 @@ The `:start-end` suffix is a 1-based, inclusive line range. An agent that sees
 `loadConfig  :42-58` can read those 17 lines instead of re-opening the whole
 file — the core idea behind Surgical Context.
 
+Coverage grows by release: TypeScript and Python top-level declarations first
+(v6.11.0); **v6.13.0 adds JavaScript and per-member anchors** — TypeScript/
+JavaScript class methods and interface members now carry their own range
+(spanning the member body), so `get_lines` can target an individual method.
+Remaining languages are being added in subsequent phases.
+
 ## `--mode index` — two-tier output
 
 `sigmap ask` normally writes ranked signature blocks. With `--mode index` it

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Task benchmark
-description: Latest saved task benchmark for SigMap v6.12.0. 53.3% correct, 41.8% fewer prompts, 81% hit@5 across 90 tasks, with R language support.
+description: Latest saved task benchmark for SigMap v6.13.0. 53.3% correct, 41.8% fewer prompts, 81% hit@5 across 90 tasks, with R language support.
 head:
   - - meta
     - property: og:title
@@ -15,8 +15,8 @@ head:
 
 # Task benchmark
 
-::: info Official v6.12.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.12-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.13.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
 
 | Metric | Value |
 |---|---:|
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-05 (v6.12.0)** — Now includes R language support (ggplot2, dplyr, shiny)
+Latest saved run: **2026-06-05 (v6.13.0)** — Now includes R language support (ggplot2, dplyr, shiny)
 
 This page answers the question people care about most:
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,12 +78,12 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v6.12.0</span>
+  <span><strong>Release:</strong> v6.13.0</span>
   <span>·</span>
-  <span>Surgical Context Phase 2 — demand-driven + delta</span>
+  <span>Line anchors for JavaScript + per-member anchors</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
-  <span><strong>Benchmark:</strong> sigmap-v6.12-main</span>
+  <span><strong>Benchmark:</strong> sigmap-v6.13-main</span>
   <span>·</span>
   <span>81% hit@5 · 96.5% token reduction · 2026-06-05</span>
 </div>
@@ -176,7 +176,7 @@ See the full [end-to-end walkthrough](/guide/walkthrough) to watch this in actio
 | Overall token reduction | — | **96.5%** |
 | GPT-4o overflow repos | 16/21 | **0/21** |
 
-Latest saved benchmark run: **2026-06-05 (v6.12.0)**.
+Latest saved benchmark run: **2026-06-05 (v6.13.0)**.
 
 </div>
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -916,61 +916,92 @@ __factories["./src/extractors/java"] = function(module, exports) {
 
 // ── ./src/extractors/javascript ──
 __factories["./src/extractors/javascript"] = function(module, exports) {
-  
+
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from JavaScript source code.
+   * Top-level declarations and class members carry a `:start-end` line anchor
+   * (see line-anchor.js); kept parallel to `sigs` and applied once at return.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    const anchors = [];
     const returnHints = buildReturnHints(src);
-  
+
+    // Block comments are blanked newline-by-newline (non-newline chars → spaces)
+    // so character offsets AND line numbers stay exact for anchors.
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
-  
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+    const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+    // End line for a function whose match ends at `matchEnd` (before its body brace).
+    const fnEndLine = (matchEnd, startLn) => {
+      const brace = stripped.indexOf('{', matchEnd);
+      return brace !== -1 ? lineAt(stripped, blockEndIdx(brace + 1)) : startLn;
+    };
+
     // Classes
     const classRegex = /^(export\s+(?:default\s+)?)?class\s+(\w+)(?:\s+extends\s+[\w.]+)?\s*\{/gm;
     for (const m of stripped.matchAll(classRegex)) {
       const prefix = m[1] ? m[1].trim() + ' ' : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`${prefix}class ${m[2]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const meth of extractClassMembers(block, returnHints)) sigs.push(`  ${meth}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+      const block = extractBlock(stripped, bodyStart);
+      for (const meth of extractClassMembers(block, returnHints)) {
+        sigs.push(`  ${meth.text}`);
+        anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+      }
     }
-  
+
     // Exported named functions
     for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
       const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
+
     // Exported arrow functions
     for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(([^)]*)\)\s*=>/gm)) {
       const asyncKw = m[0].includes('async') ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
+
     // module.exports = { ... }
     const moduleExports = stripped.match(/^module\.exports\s*=\s*\{([^}]+)\}/m);
     if (moduleExports) {
       const names = moduleExports[1].split(',').map((s) => s.trim()).filter(Boolean);
-      if (names.length > 0) sigs.push(`module.exports = { ${names.join(', ')} }`);
+      if (names.length > 0) {
+        const startLn = lineAt(stripped, moduleExports.index);
+        sigs.push(`module.exports = { ${names.join(', ')} }`);
+        anchors.push([startLn, lineAt(stripped, moduleExports.index + moduleExports[0].length)]);
+      }
     }
-  
+
     // Top-level named functions (non-exported)
     for (const m of stripped.matchAll(/^(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
       const asyncKw = m[0].startsWith('async') ? 'async ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
+      const startLn = lineAt(stripped, m.index);
       sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
-  
-    return sigs.slice(0, 25);
+
+    return sigs
+      .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+      .slice(0, 25);
   }
-  
+
   function extractBlock(src, startIndex) {
     let depth = 1;
     let i = startIndex;
@@ -982,16 +1013,22 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
     }
     return src.slice(startIndex, i - 1);
   }
-  
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block` (end = the method's closing brace), so the caller can resolve
+  // per-method line anchors that span the method body.
   function extractClassMembers(block, returnHints) {
     const members = [];
     for (const m of block.matchAll(/^\s+(?:static\s+|async\s+|get\s+|set\s+)*(\w+)\s*\(([^)]*)\)\s*\{/gm)) {
       if (/^_/.test(m[1])) continue;
-      if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+      const bodyStart = m.index + m[0].length; // just past the opening brace
+      const end = bodyStart + extractBlock(block, bodyStart).length;
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
       const isAsync = m[0].includes('async ') ? 'async ' : '';
       const isStatic = m[0].includes('static ') ? 'static ' : '';
       const retStr = formatReturnHint(returnHints.get(m[1]));
-      members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
     }
     return members.slice(0, 8);
   }
@@ -1016,18 +1053,17 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
   }
 
   function formatReturnHint(type) {
-    return type ? ` \u2192 ${type}` : '';
+    return type ? ` → ${type}` : '';
   }
-  
+
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ');
   }
-  
-  module.exports = { extract };
-  
-};
 
+  module.exports = { extract };
+
+};
 // ── ./src/extractors/kotlin ──
 __factories["./src/extractors/kotlin"] = function(module, exports) {
   
@@ -1799,101 +1835,164 @@ __factories["./src/extractors/swift"] = function(module, exports) {
 
 // ── ./src/extractors/typescript ──
 __factories["./src/extractors/typescript"] = function(module, exports) {
-  
+
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from TypeScript source code.
+   * Top-level declarations carry a `:start-end` line anchor (see line-anchor.js);
+   * indented members do not.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
-  
-    // Strip single-line comments
+    // anchors[i] is [start, end] for a top-level sig, or null for an indented member.
+    // Kept parallel to `sigs` so existing push/mutation logic stays untouched;
+    // anchors are applied once at return.
+    const anchors = [];
+
+    // Strip comments to simplify matching. Block comments are blanked
+    // newline-by-newline (non-newline chars → spaces) so character offsets AND
+    // line numbers stay exact. Line comments preserve their trailing newline.
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
-  
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+    // Index of the closing brace for a block whose body starts at bodyStart.
+    const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+
     // Exported interfaces
     for (const m of stripped.matchAll(/^export\s+interface\s+(\w+)(?:<[^{]*>)?\s*(?:extends\s+[^{]+)?\{/gm)) {
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export interface ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
       // Collect members
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
+      const block = extractBlock(stripped, bodyStart);
       const members = extractInterfaceMembers(block);
-      for (const mem of members) sigs.push(`  ${mem}`);
+      for (const mem of members) {
+        sigs.push(`  ${mem.text}`);
+        anchors.push([lineAt(stripped, bodyStart + mem.start), lineAt(stripped, bodyStart + mem.end)]);
+      }
     }
-  
+
     // Exported type aliases
     for (const m of stripped.matchAll(/^export\s+type\s+(\w+)(?:<[^=]*>)?\s*=/gm)) {
       sigs.push(`export type ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, m.index + m[0].length)]);
     }
-  
+
     // Exported enums
     for (const m of stripped.matchAll(/^export\s+(?:const\s+)?enum\s+(\w+)\s*\{/gm)) {
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export enum ${m[1]}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
     }
-  
+
     // Classes (exported and internal)
     const classRegex = /^(export\s+)?(abstract\s+)?class\s+(\w+)(?:<[^{]*>)?(?:\s+extends\s+[\w<>, .]+)?(?:\s+implements\s+[\w<> ,]+)?\s*\{/gm;
     for (const m of stripped.matchAll(classRegex)) {
       const prefix = m[1] ? 'export ' : '';
       const abs = m[2] ? 'abstract ' : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`${prefix}${abs}class ${m[3]}`);
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+      const block = extractBlock(stripped, bodyStart);
       const methods = extractClassMembers(block);
-      for (const meth of methods) sigs.push(`  ${meth}`);
+      for (const meth of methods) {
+        sigs.push(`  ${meth.text}`);
+        anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+      }
     }
-  
+
     // Exported top-level functions (not methods)
     for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*[^{]+)?\s*\{/gm)) {
       const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
       const params = normalizeParams(m[2]);
       const retMatch = m[0].match(/\)\s*:\s*([^{]+)\s*\{/);
       const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 30) : '';
-      const retStr = retType ? ` \u2192 ${retType}` : '';
+      const retStr = retType ? ` → ${retType}` : '';
+      const bodyStart = m.index + m[0].length;
       sigs.push(`export ${asyncKw}function ${m[1]}(${params})${retStr}`);
+      anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+
+      // Hooks: capture compact return object shape for use* functions.
+      if (m[1].startsWith('use')) {
+        const body = stripped.slice(bodyStart, bodyStart + 800);
+        const ret = body.match(/return\s*\{([^}]{1,260})\}/);
+        if (ret) {
+          const keys = ret[1]
+            .split(',')
+            .map((s) => s.trim().split(':')[0].split('(')[0].trim())
+            .filter(Boolean)
+            .slice(0, 8);
+          if (keys.length) {
+            sigs[sigs.length - 1] += ` → { ${keys.join(', ')} }`;
+          }
+        }
+      }
     }
-  
+
     // Exported arrow functions / const functions
     for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?\(([^)]*)\)\s*(?::\s*[^=>{]+)?\s*=>/gm)) {
       const asyncKw = /=\s*async\s+/.test(m[0]) ? 'async ' : '';
       const params = normalizeParams(m[2]);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${params}) =>`);
-    }
+      const bodyStart = stripped.indexOf('{', m.index + m[0].length);
+      const endLn = bodyStart !== -1
+        ? lineAt(stripped, blockEndIdx(bodyStart + 1))
+        : lineAt(stripped, m.index + m[0].length);
+      anchors.push([lineAt(stripped, m.index), endLn]);
 
-    // Zustand stores: export const useXxxStore = create<State>()(...)
-    for (const m of stripped.matchAll(/^export\s+const\s+(use\w+Store)\s*=\s*create(?:<[^>]*>)?\s*\(/gm)) {
-      // Extract the State interface name from create<StateName>
-      const stateType = m[0].match(/create<([\w]+)>/)?.[1] || '';
-      sigs.push(`export const ${m[1]} = create<${stateType}>(...)`);
-      // Extract action/state keys from the embedded interface in same file
-      const ifaceRe = new RegExp(`interface\\s+${stateType}\\s*\\{([\\s\\S]*?)\\}`);
-      const ifm = stripped.match(ifaceRe);
-      if (ifm) {
-        for (const fm of ifm[1].matchAll(/^\s+(\w+)\s*(?:\([^)]*\))?\s*:/gm)) {
-          sigs.push(`  ${fm[1]}`);
+      // Hooks: capture compact return object shape for use* functions.
+      if (m[1].startsWith('use')) {
+        if (bodyStart !== -1) {
+          const body = stripped.slice(bodyStart, bodyStart + 800);
+          const ret = body.match(/return\s*\{([^}]{1,260})\}/);
+          if (ret) {
+            const keys = ret[1]
+              .split(',')
+              .map((s) => s.trim().split(':')[0].split('(')[0].trim())
+              .filter(Boolean)
+              .slice(0, 8);
+            if (keys.length) {
+              sigs[sigs.length - 1] += ` → { ${keys.join(', ')} }`;
+            }
+          }
         }
       }
     }
 
-    // API client objects: export default { method: async (...) => ... }
-    // Pattern: const xxxApi = { methodName: async ... }
-    for (const m of stripped.matchAll(/^(?:export\s+default\s+|const\s+)(\w*[Aa]pi\w*)\s*=\s*\{/gm)) {
-      const apiName = m[1];
-      const start = m.index + m[0].length;
-      const block = extractBlock(stripped, start);
-      const methods = [];
-      for (const mm of block.matchAll(/^\s+(\w+)\s*:\s*(?:async\s+)?(?:\([^)]*\)|\w+)\s*=>/gm)) {
-        methods.push(mm[1]);
+    // Zustand stores: export const useXxxStore = create<State>()(...)
+    for (const m of stripped.matchAll(/^export\s+const\s+(use\w+Store)\s*=\s*create(?:<[^>]*>)?\s*\(/gm)) {
+      const stateType = m[0].match(/create<([\w]+)>/)?.[1] || '';
+      const startLn = lineAt(stripped, m.index);
+      sigs.push(`export const ${m[1]} = create<${stateType}>(...)`);
+      anchors.push([startLn, startLn]);
+      const ifaceRe = new RegExp(`interface\\s+${stateType}\\s*\\{([\\s\\S]*?)\\}`);
+      const ifm = stripped.match(ifaceRe);
+      if (ifm) {
+        for (const fm of ifm[1].matchAll(/^\s+(\w+)\s*(?:\([^)]*\))?\s*:/gm)) { sigs.push(`  ${fm[1]}`); anchors.push(null); }
       }
-      if (methods.length) sigs.push(`${apiName}: { ${methods.join(', ')} }`);
     }
-  
-    return sigs.slice(0, 35);
+
+    // API client objects: const xxxApi = { method: async () => {} }
+    for (const m of stripped.matchAll(/^(?:export\s+default\s+|const\s+)(\w*[Aa]pi\w*)\s*=\s*\{/gm)) {
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      const methods = [...block.matchAll(/^\s+(\w+)\s*:\s*(?:async\s+)?(?:\([^)]*\)|\w+)\s*=>/gm)].map(mm => mm[1]);
+      if (methods.length) {
+        sigs.push(`${m[1]}: { ${methods.join(', ')} }`);
+        anchors.push([lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)]);
+      }
+    }
+
+    return sigs
+      .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+      .slice(0, 35);
   }
-  
+
   function extractBlock(src, startIndex) {
     let depth = 1;
     let i = startIndex;
@@ -1905,47 +2004,59 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
     }
     return src.slice(startIndex, i - 1);
   }
-  
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block`, so the caller can resolve member line anchors.
   function extractInterfaceMembers(block) {
     const members = [];
     for (const m of block.matchAll(/^\s+(readonly\s+)?(\w+)(\??):\s*([^;]+);/gm)) {
       const readonly = m[1] ? 'readonly ' : '';
       const optional = m[3] ? '?' : '';
       const typeStr = m[4].trim().replace(/\s+/g, ' ').slice(0, 35);
-      members.push(`${readonly}${m[2]}${optional}: ${typeStr}`);
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      members.push({ text: `${readonly}${m[2]}${optional}: ${typeStr}`, start, end: m.index + m[0].length });
     }
     for (const m of block.matchAll(/^\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)\s*:/gm)) {
-      members.push(`${m[1]}(${normalizeParams(m[2])})`);
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      members.push({ text: `${m[1]}(${normalizeParams(m[2])})`, start, end: m.index + m[0].length });
     }
     return members.slice(0, 8);
   }
-  
+
+  const _CTRL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'do', 'try', 'catch', 'finally', 'else', 'return']);
+
+  // Returns members as { text, start, end } where start/end are char offsets
+  // WITHIN `block` (end = the method's closing brace), so the caller can resolve
+  // per-method line anchors that span the method body.
   function extractClassMembers(block) {
     const members = [];
-    // Public methods (skip private/protected/_ prefixed)
+    // Public methods (skip private/protected/_ prefixed and control-flow keywords)
     const methodRe = /^\s+(?:public\s+|static\s+|async\s+|override\s+)*(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*[^{;]+)?\s*\{/gm;
     for (const m of block.matchAll(methodRe)) {
+      if (_CTRL_KEYWORDS.has(m[1])) continue;
       if (/^(private|protected|_)/.test(m[1])) continue;
-      if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+      const bodyStart = m.index + m[0].length; // just past the opening brace
+      const end = bodyStart + extractBlock(block, bodyStart).length;
+      const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+      if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
       const isAsync = m[0].includes('async ') ? 'async ' : '';
       const isStatic = m[0].includes('static ') ? 'static ' : '';
       const retMatch = m[0].match(/\)\s*:\s*([^{;]+)\s*\{/);
       const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 20) : '';
-      const retStr = retType ? ` \u2192 ${retType}` : '';
-      members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const retStr = retType ? ` → ${retType}` : '';
+      members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
     }
     return members.slice(0, 8);
   }
-  
+
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ').replace(/:[^,)]+/g, '').trim();
   }
-  
-  module.exports = { extract };
-  
-};
 
+  module.exports = { extract };
+
+};
 // ── ./src/extractors/graphql ──
 __factories["./src/extractors/graphql"] = function(module, exports) {
   
@@ -9154,10 +9265,18 @@ function computeEffectiveMaxTokens(fileEntries, config) {
 
 function applyTokenBudget(fileEntries, maxTokens) {
   // fileEntries: [{ filePath, sigs, mtime }]
-  // Reserve ~10% for formatting overhead (section headers, code fences, top-level header)
-  const effectiveBudget = Math.floor(maxTokens * 0.90);
-  let total = fileEntries.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')), 0);
-  if (total <= effectiveBudget) return fileEntries;
+  // Per-file rendered overhead: "### <path>", code fences, trailing blank line.
+  // A signature-only budget undercounts this, so when many files survive the
+  // section headers alone can blow maxTokens.
+  const sectionOverhead = (e) => estimateTokens(String(e.filePath || '')) + 6;
+  const renderedTotal = (entries) =>
+    entries.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')) + sectionOverhead(e), 0);
+  // The generated file also carries a ~150-token fixed preamble (SigMap command
+  // table + headers). Reserve at least that much so small budgets don't overflow;
+  // for large budgets this matches the historical 10% reserve.
+  const budgetForEntries = Math.max(1, maxTokens - Math.max(200, Math.ceil(maxTokens * 0.10)));
+  let total = renderedTotal(fileEntries);
+  if (total <= budgetForEntries) return fileEntries;
 
   // v6.12 Surgical Context — progressive disclosure: before dropping whole files,
   // collapse signature BODIES to their line-anchor pointers (keep `symbol :start-end`).
@@ -9171,12 +9290,13 @@ function applyTokenBudget(fileEntries, maxTokens) {
     });
     return { ...e, sigs: slim };
   });
-  const collapsedTotal = collapsed.reduce((s, e) => s + estimateTokens(e.sigs.join('\n')), 0);
-  if (collapsedTotal < total) {
-    console.warn(`[sigmap] budget: collapsed bodies to anchors, reclaimed ~${total - collapsedTotal} tokens`);
+  const collapsedRendered = renderedTotal(collapsed);
+  if (collapsedRendered < total) {
+    console.warn(`[sigmap] budget: collapsed bodies to anchors, reclaimed ~${total - collapsedRendered} tokens`);
     working = collapsed;
-    total = collapsedTotal;
-    if (total <= effectiveBudget) return working; // anchor collapse alone fit the budget
+    total = collapsedRendered;
+    // Collapsing keeps every file, so the section overhead must fit too — not just sigs.
+    if (total <= budgetForEntries) return working;
   }
 
   // Sort by drop priority (drop first = index 0)
@@ -9203,12 +9323,13 @@ function applyTokenBudget(fileEntries, maxTokens) {
 
   const kept = [];
   const verboseDropped = [];
-  // Iterate forward: highest drop-priority files (generated=10, mock=9, test=8) are at index 0
-  // Drop those first until we're under budget, then keep everything else
+  // Iterate forward: highest drop-priority files (generated=10, mock=9, test=8) are at index 0.
+  // Drop those first until the RENDERED total (sigs + section overhead) fits maxTokens,
+  // then keep everything else.
+  let rendered = renderedTotal(withPriority);
   for (const entry of withPriority) {
-    const entryTokens = estimateTokens(entry.sigs.join('\n'));
-    if (total > effectiveBudget) {
-      total -= entryTokens;
+    if (rendered > budgetForEntries) {
+      rendered -= estimateTokens(entry.sigs.join('\n')) + sectionOverhead(entry);
       verboseDropped.push({ filePath: entry.filePath, reason: entry.dropReason });
     } else {
       kept.push(entry);

--- a/gen-context.js
+++ b/gen-context.js
@@ -6154,7 +6154,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-  version: '6.12.0',
+  version: '6.13.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
   
@@ -8978,7 +8978,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.12.0';
+const VERSION = '6.13.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/extractors/javascript.js
+++ b/src/extractors/javascript.js
@@ -1,57 +1,88 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from JavaScript source code.
+ * Top-level declarations and class members carry a `:start-end` line anchor
+ * (see line-anchor.js); kept parallel to `sigs` and applied once at return.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  const anchors = [];
   const returnHints = buildReturnHints(src);
 
+  // Block comments are blanked newline-by-newline (non-newline chars → spaces)
+  // so character offsets AND line numbers stay exact for anchors.
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+
+  const blockEndIdx = (bodyStart) => bodyStart + extractBlock(stripped, bodyStart).length;
+  // End line for a function whose match ends at `matchEnd` (before its body brace).
+  const fnEndLine = (matchEnd, startLn) => {
+    const brace = stripped.indexOf('{', matchEnd);
+    return brace !== -1 ? lineAt(stripped, blockEndIdx(brace + 1)) : startLn;
+  };
 
   // Classes
   const classRegex = /^(export\s+(?:default\s+)?)?class\s+(\w+)(?:\s+extends\s+[\w.]+)?\s*\{/gm;
   for (const m of stripped.matchAll(classRegex)) {
     const prefix = m[1] ? m[1].trim() + ' ' : '';
+    const bodyStart = m.index + m[0].length;
     sigs.push(`${prefix}class ${m[2]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const meth of extractClassMembers(block, returnHints)) sigs.push(`  ${meth}`);
+    anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
+    const block = extractBlock(stripped, bodyStart);
+    for (const meth of extractClassMembers(block, returnHints)) {
+      sigs.push(`  ${meth.text}`);
+      anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+    }
   }
 
   // Exported named functions
   for (const m of stripped.matchAll(/^export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
     const asyncKw = /export\s+async/.test(m[0]) ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
   // Exported arrow functions
   for (const m of stripped.matchAll(/^export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(([^)]*)\)\s*=>/gm)) {
     const asyncKw = m[0].includes('async') ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
   // module.exports = { ... }
   const moduleExports = stripped.match(/^module\.exports\s*=\s*\{([^}]+)\}/m);
   if (moduleExports) {
     const names = moduleExports[1].split(',').map((s) => s.trim()).filter(Boolean);
-    if (names.length > 0) sigs.push(`module.exports = { ${names.join(', ')} }`);
+    if (names.length > 0) {
+      const startLn = lineAt(stripped, moduleExports.index);
+      sigs.push(`module.exports = { ${names.join(', ')} }`);
+      anchors.push([startLn, lineAt(stripped, moduleExports.index + moduleExports[0].length)]);
+    }
   }
 
   // Top-level named functions (non-exported)
   for (const m of stripped.matchAll(/^(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm)) {
     const asyncKw = m[0].startsWith('async') ? 'async ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
+    const startLn = lineAt(stripped, m.index);
     sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
-  return sigs.slice(0, 25);
+  return sigs
+    .map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s))
+    .slice(0, 25);
 }
 
 function extractBlock(src, startIndex) {
@@ -66,15 +97,21 @@ function extractBlock(src, startIndex) {
   return src.slice(startIndex, i - 1);
 }
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block` (end = the method's closing brace), so the caller can resolve
+// per-method line anchors that span the method body.
 function extractClassMembers(block, returnHints) {
   const members = [];
   for (const m of block.matchAll(/^\s+(?:static\s+|async\s+|get\s+|set\s+)*(\w+)\s*\(([^)]*)\)\s*\{/gm)) {
     if (/^_/.test(m[1])) continue;
-    if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+    const bodyStart = m.index + m[0].length; // just past the opening brace
+    const end = bodyStart + extractBlock(block, bodyStart).length;
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
     const isAsync = m[0].includes('async ') ? 'async ' : '';
     const isStatic = m[0].includes('static ') ? 'static ' : '';
     const retStr = formatReturnHint(returnHints.get(m[1]));
-    members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/typescript.js
+++ b/src/extractors/typescript.js
@@ -35,7 +35,10 @@ function extract(src) {
     // Collect members
     const block = extractBlock(stripped, bodyStart);
     const members = extractInterfaceMembers(block);
-    for (const mem of members) { sigs.push(`  ${mem}`); anchors.push(null); }
+    for (const mem of members) {
+      sigs.push(`  ${mem.text}`);
+      anchors.push([lineAt(stripped, bodyStart + mem.start), lineAt(stripped, bodyStart + mem.end)]);
+    }
   }
 
   // Exported type aliases
@@ -61,7 +64,10 @@ function extract(src) {
     anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
     const block = extractBlock(stripped, bodyStart);
     const methods = extractClassMembers(block);
-    for (const meth of methods) { sigs.push(`  ${meth}`); anchors.push(null); }
+    for (const meth of methods) {
+      sigs.push(`  ${meth.text}`);
+      anchors.push([lineAt(stripped, bodyStart + meth.start), lineAt(stripped, bodyStart + meth.end)]);
+    }
   }
 
   // Exported top-level functions (not methods)
@@ -163,22 +169,29 @@ function extractBlock(src, startIndex) {
   return src.slice(startIndex, i - 1);
 }
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block`, so the caller can resolve member line anchors.
 function extractInterfaceMembers(block) {
   const members = [];
   for (const m of block.matchAll(/^\s+(readonly\s+)?(\w+)(\??):\s*([^;]+);/gm)) {
     const readonly = m[1] ? 'readonly ' : '';
     const optional = m[3] ? '?' : '';
     const typeStr = m[4].trim().replace(/\s+/g, ' ').slice(0, 35);
-    members.push(`${readonly}${m[2]}${optional}: ${typeStr}`);
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    members.push({ text: `${readonly}${m[2]}${optional}: ${typeStr}`, start, end: m.index + m[0].length });
   }
   for (const m of block.matchAll(/^\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)\s*:/gm)) {
-    members.push(`${m[1]}(${normalizeParams(m[2])})`);
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    members.push({ text: `${m[1]}(${normalizeParams(m[2])})`, start, end: m.index + m[0].length });
   }
   return members.slice(0, 8);
 }
 
 const _CTRL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'do', 'try', 'catch', 'finally', 'else', 'return']);
 
+// Returns members as { text, start, end } where start/end are char offsets
+// WITHIN `block` (end = the method's closing brace), so the caller can resolve
+// per-method line anchors that span the method body.
 function extractClassMembers(block) {
   const members = [];
   // Public methods (skip private/protected/_ prefixed and control-flow keywords)
@@ -186,13 +199,16 @@ function extractClassMembers(block) {
   for (const m of block.matchAll(methodRe)) {
     if (_CTRL_KEYWORDS.has(m[1])) continue;
     if (/^(private|protected|_)/.test(m[1])) continue;
-    if (m[1] === 'constructor') { members.push(`constructor(${normalizeParams(m[2])})`); continue; }
+    const bodyStart = m.index + m[0].length; // just past the opening brace
+    const end = bodyStart + extractBlock(block, bodyStart).length;
+    const start = m.index + (m[0].length - m[0].replace(/^\s+/, '').length);
+    if (m[1] === 'constructor') { members.push({ text: `constructor(${normalizeParams(m[2])})`, start, end }); continue; }
     const isAsync = m[0].includes('async ') ? 'async ' : '';
     const isStatic = m[0].includes('static ') ? 'static ' : '';
     const retMatch = m[0].match(/\)\s*:\s*([^{;]+)\s*\{/);
     const retType = retMatch ? retMatch[1].trim().replace(/\s+/g, ' ').slice(0, 20) : '';
     const retStr = retType ? ` → ${retType}` : '';
-    members.push(`${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({ text: `${isStatic}${isAsync}${m[1]}(${normalizeParams(m[2])})${retStr}`, start, end });
   }
   return members.slice(0, 8);
 }

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.12.0',
+  version: '6.13.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/expected/javascript.txt
+++ b/test/expected/javascript.txt
@@ -1,12 +1,12 @@
-class EventEmitter
-  constructor()
-  on(event, handler)
-  emit(event, data)
-  static create()
-export class ApiClient
-  constructor(baseUrl)
-  async get(path)
-  async post(path, body)
-export async function fetchUser(id)
-export const createSession = async (userId) =>
-module.exports = { EventEmitter, ApiClient, fetchUser }
+class EventEmitter  :3-20
+  constructor()  :4-6
+  on(event, handler)  :8-11
+  emit(event, data)  :13-15
+  static create()  :17-19
+export class ApiClient  :22-35
+  constructor(baseUrl)  :23-26
+  async get(path)  :28-30
+  async post(path, body)  :32-34
+export async function fetchUser(id)  :37-39
+export const createSession = async (userId) =>  :41-43
+module.exports = { EventEmitter, ApiClient, fetchUser }  :45-45

--- a/test/expected/typescript.txt
+++ b/test/expected/typescript.txt
@@ -1,16 +1,16 @@
 export interface UserService  :3-7
-  readonly version: string
-  getUser(id)
-  createUser(data)
+  readonly version: string  :6-6
+  getUser(id)  :4-4
+  createUser(data)  :5-5
 export type UserId  :9-9
 export type UserRole  :10-10
 export enum Status  :12-16
 export class UserRepository  :18-36
-  constructor(private db)
-  async findById(id) → Promise<User | null>
-  async save(user) → Promise<void>
-  static create(db) → UserRepository
+  constructor(private db)  :19-19
+  async findById(id) → Promise<User | null>  :21-23
+  async save(user) → Promise<void>  :25-27
+  static create(db) → UserRepository  :29-31
 class InternalHelper  :54-58
-  process(data) → string
+  process(data) → string  :55-57
 export async function hashPassword(password) → Promise<string>  :38-40
 export const useAuth = (loginId, password) => → { user, isAuthenticated, login, logout }  :46-52

--- a/test/integration/extractors/line-anchors.test.js
+++ b/test/integration/extractors/line-anchors.test.js
@@ -13,6 +13,7 @@ const assert = require('assert');
 
 const ROOT = path.resolve(__dirname, '../../..');
 const ts   = require(path.join(ROOT, 'src', 'extractors', 'typescript'));
+const js   = require(path.join(ROOT, 'src', 'extractors', 'javascript'));
 const py   = require(path.join(ROOT, 'src', 'extractors', 'python'));
 const { lineAt, anchor, withAnchor } = require(path.join(ROOT, 'src', 'extractors', 'line-anchor'));
 
@@ -55,14 +56,14 @@ test('3. TS top-level function carries :start-end', () => {
     `expected foo :1-3, got:\n${sigs.join('\n')}`);
 });
 
-test('4. TS indented members are NOT anchored', () => {
+test('4. TS class members carry their own anchor (v6.12.x member anchors)', () => {
   const src = `export class Svc {
   doThing(x: string): void {}
 }`;
   const sigs = ts.extract(src);
   const member = sigs.find(s => s.includes('doThing('));
   assert.ok(member, 'doThing member must be present');
-  assert.ok(!/:\d+-\d+/.test(member), `member must not carry an anchor, got "${member}"`);
+  assert.ok(/:2-2$/.test(member), `member must carry its own anchor :2-2, got "${member}"`);
   const header = sigs.find(s => s.startsWith('export class Svc'));
   assert.ok(/:1-3$/.test(header), `class header must be anchored :1-3, got "${header}"`);
 });
@@ -135,6 +136,72 @@ test('9. Python class header anchored, methods not', () => {
     `expected class Svc :1-3, got:\n${sigs.join('\n')}`);
   const method = sigs.find(s => s.includes('do_it'));
   assert.ok(method && !/:\d+-\d+/.test(method), `method must not be anchored, got "${method}"`);
+});
+
+// ── TypeScript interface members (v6.12.x) ─────────────────────────────────────
+
+test('10. TS interface members carry their own anchor', () => {
+  const src = `export interface Repo {
+  id: string;
+  fetch(query: string): Promise<Row[]>;
+}`;
+  const sigs = ts.extract(src);
+  assert.ok(sigs.some(s => /^\s+id: string  :2-2$/.test(s)),
+    `expected id member :2-2, got:\n${sigs.join('\n')}`);
+  assert.ok(sigs.some(s => /^\s+fetch\(query\)  :3-3$/.test(s)),
+    `expected fetch member :3-3, got:\n${sigs.join('\n')}`);
+});
+
+// ── JavaScript (v6.12.x — anchors added in this PR) ────────────────────────────
+
+test('11. JS top-level function carries :start-end', () => {
+  const src = `export function foo(a, b) {
+  return a + b;
+}`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => /export function foo\(a, b\)  :1-3$/.test(s)),
+    `expected foo :1-3, got:\n${sigs.join('\n')}`);
+});
+
+test('12. JS class members carry their own anchor (not the parent class)', () => {
+  const src = `class Gateway {
+  async charge(amount, currency) {
+    return null;
+  }
+  refund(id) {
+    return null;
+  }
+}`;
+  const sigs = js.extract(src);
+  const header = sigs.find(s => s.startsWith('class Gateway'));
+  assert.ok(/:1-8$/.test(header), `class header :1-8, got "${header}"`);
+  const charge = sigs.find(s => s.includes('charge('));
+  const refund = sigs.find(s => s.includes('refund('));
+  assert.ok(/:2-4$/.test(charge), `charge member :2-4, got "${charge}"`);
+  assert.ok(/:5-7$/.test(refund), `refund member :5-7, got "${refund}"`);
+});
+
+test('13. JS block-comment regression — multiline comment does not shift line numbers', () => {
+  // Before the newline-preserving strip, the JS extractor deleted block-comment
+  // newlines, which would shift createCharge up from :5 to ~:2.
+  const src = `/* a
+   multi-line
+   block comment */
+export function createCharge(customerId, amountCents) {
+  return doIt();
+}`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => s.includes('export function createCharge(') && s.endsWith(':4-6')),
+    `expected createCharge :4-6 (newlines preserved), got:\n${sigs.join('\n')}`);
+});
+
+test('14. JS module.exports carries an anchor', () => {
+  const src = `function a() {}
+function b() {}
+module.exports = { a, b };`;
+  const sigs = js.extract(src);
+  assert.ok(sigs.some(s => /^module\.exports = \{ a, b \}  :3-3$/.test(s)),
+    `expected module.exports :3-3, got:\n${sigs.join('\n')}`);
 });
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -122,8 +122,8 @@ test('workflow: Ask → Rank → Context → Validate → Judge → Learn', () =
 
 // ── Section 7: Benchmark ─────────────────────────────────────────────────────
 
-test('benchmark: sigmap-v6.12-main ID present', () => {
-  assert.ok(src.includes('sigmap-v6.12-main'), 'missing sigmap-v6.12-main benchmark ID');
+test('benchmark: sigmap-v6.13-main ID present', () => {
+  assert.ok(src.includes('sigmap-v6.13-main'), 'missing sigmap-v6.13-main benchmark ID');
 });
 
 test('benchmark: date 2026-06-05 present', () => {

--- a/test/integration/surgical-context.test.js
+++ b/test/integration/surgical-context.test.js
@@ -129,5 +129,34 @@ test('--since restricts output to files changed since a git ref', () => {
   });
 });
 
+test('--mode index materially collapses real anchored JavaScript (issue #223)', () => {
+  withTempProject((dir) => {
+    // Real extraction: verbose top-level JS functions now carry anchors, so
+    // index mode can collapse the param lists (was a no-op before #223).
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    const lines = [];
+    for (let i = 0; i < 6; i++) {
+      lines.push(`export function handleRequest${i}(requestContext, payloadEnvelope, authToken, traceId, retryPolicyConfig, idempotencyKey) {`);
+      lines.push('  return null;');
+      lines.push('}');
+    }
+    fs.writeFileSync(path.join(dir, 'src', 'handlers.js'), lines.join('\n'));
+    fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({ secretScan: false }));
+    run(dir, ''); // generate context (runs the JS extractor → anchored verbose sigs)
+
+    const full = JSON.parse(run(dir, 'ask "handle request payload" --json').trim());
+    const idx = JSON.parse(run(dir, 'ask "handle request payload" --mode index --json').trim());
+
+    assert.ok(idx.contextTokens < full.contextTokens * 0.85,
+      `index (${idx.contextTokens}) should cut >15% vs default (${full.contextTokens})`);
+
+    // Default keeps the param list; index drops it but keeps the anchor.
+    run(dir, 'ask "handle request payload" --mode index');
+    const out = fs.readFileSync(path.join(dir, '.context', 'query-context.md'), 'utf8');
+    assert.ok(!out.includes('retryPolicyConfig'), 'index mode must drop the parameter list');
+    assert.ok(/handleRequest0\s+:\d+-\d+/.test(out), 'index mode must keep symbol + anchor');
+  });
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/test/integration/token-budget.test.js
+++ b/test/integration/token-budget.test.js
@@ -96,9 +96,11 @@ test('Test files are dropped before source files', () => {
     const testFile = path.join(srcDir, 'bigfile.test.js');
     writeJsFile(testFile, 600);
 
-    // Budget: enough for source files but not for the giant test file
+    // Budget: enough for source files but not for the giant test file.
+    // autoMaxTokens:false pins the 500 budget (otherwise auto-scale floors it at 4000).
     fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({
       maxTokens: 500,
+      autoMaxTokens: false,
       outputs: ['copilot'],
       secretScan: false,
     }));

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "6.12.0",
+  "version": "6.13.0",
   "benchmark_date": "2026-06-05",
-  "benchmark_id": "sigmap-v6.12-main",
+  "benchmark_id": "sigmap-v6.13-main",
   "languages": 31,
   "mcp_tools": 10,
   "tests": 60,


### PR DESCRIPTION
Promotes **v6.13.0** from `develop` to `main` for tagging + release.

## Summary
- **Surgical Context Phase 2.1** (PR #224, closes #223): JavaScript line anchors + per-member anchors (TS & JS); index-mode token cut 4.6% → 32–42% on real repos; overhead-aware token budget fix.
- **Release prep** (PR #225, `/update-docs`): version sync 6.12.0 → 6.13.0, CHANGELOG, CONTRIBUTORS, docs, `version.json` (`sigmap-v6.13-main`).

## Changes
- Extractors: `src/extractors/javascript.js`, `src/extractors/typescript.js` (+ bundled factories in `gen-context.js`).
- Budget: `applyTokenBudget` rendered-cost accounting.
- Docs: cli.md, surgical-context.md, roadmap.md, benchmark/retrieval/quality/task/generalization, index.md.

## Test plan
- [x] `node test/integration/all.js` — 64/0
- [x] unit 23/0, R-language pass
- [x] `npm run docs:build` passes
- [x] Benchmarks re-run

After merge: tag `v6.13.0` on the main merge commit → release workflows fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)