### PR TITLE
feat(verify): verify-ai-output hallucination guard prototype

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -10737,6 +10737,8 @@ Usage:
   ${cmd} --impact <file>                   Show every file impacted by changing <file>
   ${cmd} --impact <file> --json            Impact as JSON {changed, direct, transitive, tests, routes}
   ${cmd} --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited)
+  ${cmd} verify-ai-output <answer.md>      Flag fake files/imports/symbols in an AI answer
+  ${cmd} verify-ai-output <answer.md> --json  Hallucination report as JSON (exits 1 if issues)
   ${cmd} --init                            Write example config + .contextignore scaffold
   ${cmd} --help                            Show this message
   ${cmd} --version                         Show version
@@ -11856,6 +11858,45 @@ function main() {
     console.log('\nMonorepo:', result.isMonorepo ? 'yes' : 'no');
     console.log('Confidence:', result.confidence);
     process.exit(0);
+  }
+
+  // `sigmap verify-ai-output <answer.md>` — Hallucination Guard (deterministic core)
+  if (args[0] === 'verify-ai-output') {
+    const target = args[1];
+    const jsonOut = args.includes('--json');
+    if (!target || target.startsWith('--')) {
+      console.error('[sigmap] Usage: sigmap verify-ai-output <answer.md> [--json]');
+      process.exit(1);
+    }
+    const absTarget = path.resolve(cwd, target);
+    if (!fs.existsSync(absTarget)) {
+      console.error(`[sigmap] file not found: ${target}`);
+      process.exit(1);
+    }
+
+    const answerText = fs.readFileSync(absTarget, 'utf8');
+    const { verify } = requireSourceOrBundled('./src/verify/hallucination-guard');
+    const { issues, summary } = verify(answerText, cwd);
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify({ file: path.relative(cwd, absTarget) || target, issues, summary }) + '\n');
+      process.exit(summary.total > 0 ? 1 : 0);
+    }
+
+    const rel = path.relative(cwd, absTarget) || target;
+    if (summary.total === 0) {
+      console.log(`[sigmap] ✓ ${rel} — no hallucinations detected (${summary.symbolsIndexed} symbols indexed)`);
+      process.exit(0);
+    }
+
+    const labels = { 'fake-file': 'Fake file', 'fake-import': 'Fake import', 'fake-symbol': 'Fake symbol' };
+    console.log(`[sigmap] ✗ ${rel} — ${summary.total} issue${summary.total === 1 ? '' : 's'} found`);
+    console.log(`  fake-file: ${summary.byType['fake-file']}  fake-import: ${summary.byType['fake-import']}  fake-symbol: ${summary.byType['fake-symbol']}`);
+    console.log('');
+    for (const issue of issues) {
+      console.log(`  L${issue.line}  [${labels[issue.type] || issue.type}]  ${issue.message}`);
+    }
+    process.exit(1);
   }
 
   // Feature 1: `sigmap explain <file>` — why a file is included or excluded

--- a/src/verify/hallucination-guard.js
+++ b/src/verify/hallucination-guard.js
@@ -1,0 +1,219 @@
+'use strict';
+
+/**
+ * Hallucination Guard — deterministic core (Phase 1 MVP).
+ *
+ * Given the text of an AI answer, flag claims that do not match the repo:
+ *   - fake-file   : a referenced path is not on disk
+ *   - fake-import : a relative import does not resolve; a bare import is
+ *                   absent from package.json deps (builtins allow-listed)
+ *   - fake-symbol : a called function/class is absent from the symbol index
+ *
+ * No network, no LLM. Reuses SigMap primitives (buildSigIndex) but every
+ * external dependency is injectable via `opts` so the core stays unit-testable.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const parsers = require('./parsers');
+
+const NODE_BUILTINS = new Set([
+  'fs', 'path', 'os', 'util', 'events', 'stream', 'http', 'https', 'crypto',
+  'child_process', 'url', 'querystring', 'assert', 'zlib', 'readline', 'net',
+  'tls', 'dns', 'buffer', 'process', 'vm', 'module', 'console', 'timers',
+  'string_decoder', 'perf_hooks', 'worker_threads', 'cluster', 'dgram', 'v8',
+  'tty', 'repl', 'async_hooks', 'inspector', 'fs/promises', 'path/posix',
+]);
+
+const PY_BUILTINS = new Set([
+  'os', 'sys', 're', 'json', 'math', 'typing', 'collections', 'itertools',
+  'functools', 'datetime', 'pathlib', 'subprocess', 'abc', 'dataclasses',
+  'enum', 'io', 'time', 'random', 'logging', 'argparse', 'unittest', 'asyncio',
+  'copy', 'hashlib', 'threading', 'string', 'csv', 'glob', 'shutil', 'tempfile',
+]);
+
+const LANG_GLOBALS = new Set([
+  // JS
+  'console', 'require', 'module', 'exports', 'process', 'Object', 'Array',
+  'String', 'Number', 'Boolean', 'Math', 'JSON', 'Date', 'Promise', 'Map',
+  'Set', 'WeakMap', 'WeakSet', 'RegExp', 'Error', 'Symbol', 'parseInt',
+  'parseFloat', 'isNaN', 'setTimeout', 'setInterval', 'clearTimeout', 'fetch',
+  'Buffer', 'Function', 'eval', 'encodeURIComponent', 'decodeURIComponent',
+  // Python
+  'print', 'len', 'range', 'str', 'int', 'float', 'dict', 'list', 'tuple',
+  'set', 'bool', 'open', 'enumerate', 'zip', 'map', 'filter', 'sorted',
+  'sum', 'min', 'max', 'abs', 'isinstance', 'super', 'type', 'getattr',
+  'setattr', 'hasattr',
+]);
+
+const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
+const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
+
+/** Build the set of known symbol identifiers from the SigMap signature index. */
+function buildSymbolSet(cwd) {
+  const set = new Set();
+  let fileKeys = [];
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const idx = buildSigIndex(cwd);
+    fileKeys = [...idx.keys()];
+    for (const sigs of idx.values()) {
+      for (const sig of sigs) {
+        const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+        const ids = cleaned.match(/[A-Za-z_$][\w$]*/g) || [];
+        for (const id of ids) set.add(id);
+      }
+    }
+  } catch (_) {}
+  return { set, fileKeys };
+}
+
+/** Load declared dependency names from package.json. */
+function loadDeps(cwd) {
+  const deps = new Set();
+  let hasPkg = false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    hasPkg = true;
+    for (const k of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+      if (pkg[k] && typeof pkg[k] === 'object') {
+        for (const name of Object.keys(pkg[k])) deps.add(name);
+      }
+    }
+  } catch (_) {}
+  return { deps, hasPkg };
+}
+
+/** Default file-existence check: resolve a referenced path against cwd. */
+function defaultFileExists(cwd, ref) {
+  const clean = ref.replace(/^\.\//, '');
+  for (const c of [path.resolve(cwd, clean), path.resolve(cwd, ref)]) {
+    try {
+      if (fs.existsSync(c)) return true;
+    } catch (_) {}
+  }
+  return false;
+}
+
+/** Default relative-import resolver: fs candidates + basename match in index. */
+function defaultRelativeResolvable(cwd, mod, fileBasenames) {
+  const base = path.resolve(cwd, mod);
+  for (const e of REL_EXTS) {
+    try {
+      if (fs.existsSync(base + e)) return true;
+    } catch (_) {}
+  }
+  for (const idx of REL_INDEX) {
+    try {
+      if (fs.existsSync(path.join(base, idx))) return true;
+    } catch (_) {}
+  }
+  // Fall back to basename match against the indexed file set (the answer's
+  // import is relative to a file we cannot know, so a name match is enough
+  // to avoid false positives).
+  const wantBase = path.basename(mod).replace(/\.[^.]+$/, '').toLowerCase();
+  return fileBasenames.has(wantBase);
+}
+
+/**
+ * Verify an AI answer against the repository.
+ *
+ * @param {string} answerText
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {Set<string>} [opts.symbolSet]      override known symbols
+ * @param {Set<string>} [opts.deps]           override package deps
+ * @param {boolean}     [opts.hasPkg]         whether a package.json exists
+ * @param {(ref: string) => boolean} [opts.fileExists]          override file check
+ * @param {(mod: string) => boolean} [opts.relativeResolvable]  override rel-import check
+ * @returns {{ issues: object[], summary: object }}
+ */
+function verify(answerText, cwd, opts = {}) {
+  let symbolSet = opts.symbolSet;
+  let fileBasenames = opts.fileBasenames;
+  if (!symbolSet) {
+    const built = buildSymbolSet(cwd);
+    symbolSet = built.set;
+    fileBasenames = new Set(built.fileKeys.map(
+      (k) => path.basename(k).replace(/\.[^.]+$/, '').toLowerCase()
+    ));
+  }
+  if (!fileBasenames) fileBasenames = new Set();
+
+  let deps = opts.deps;
+  let hasPkg = opts.hasPkg;
+  if (!deps) {
+    const loaded = loadDeps(cwd);
+    deps = loaded.deps;
+    if (hasPkg === undefined) hasPkg = loaded.hasPkg;
+  }
+
+  const fileExists = opts.fileExists || ((ref) => defaultFileExists(cwd, ref));
+  const relativeResolvable = opts.relativeResolvable
+    || ((mod) => defaultRelativeResolvable(cwd, mod, fileBasenames));
+
+  const issues = [];
+  const dedupe = new Set();
+  const add = (issue) => {
+    const key = `${issue.type}::${issue.value}`;
+    if (dedupe.has(key)) return;
+    dedupe.add(key);
+    issues.push(issue);
+  };
+
+  // 1. fake-file
+  for (const { path: p, line } of parsers.extractFilePaths(answerText)) {
+    if (!fileExists(p)) {
+      add({ type: 'fake-file', value: p, line, message: `File not found on disk: ${p}` });
+    }
+  }
+
+  // 2. fake-import
+  for (const imp of parsers.extractImports(answerText)) {
+    if (imp.relative) {
+      if (!relativeResolvable(imp.module)) {
+        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}` });
+      }
+      continue;
+    }
+    // Bare module — only verifiable for JS when a package.json exists.
+    const top = imp.module.split('/')[0];
+    if (imp.kind === 'js') {
+      if (!hasPkg) continue;
+      if (NODE_BUILTINS.has(imp.module) || NODE_BUILTINS.has(top)) continue;
+      if (top.startsWith('@')) {
+        const scoped = imp.module.split('/').slice(0, 2).join('/');
+        if (deps.has(scoped) || deps.has(imp.module)) continue;
+      } else if (deps.has(top) || deps.has(imp.module)) {
+        continue;
+      }
+      add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Package not in dependencies: ${imp.module}` });
+    }
+    // Python bare imports: stdlib is unbounded offline — skip to keep precision.
+  }
+
+  // 3. fake-symbol
+  if (symbolSet.size > 0) {
+    for (const { name, line } of parsers.extractSymbols(answerText)) {
+      if (symbolSet.has(name)) continue;
+      if (LANG_GLOBALS.has(name) || NODE_BUILTINS.has(name) || PY_BUILTINS.has(name)) continue;
+      add({ type: 'fake-symbol', value: name, line, message: `Symbol not found in repo index: ${name}()` });
+    }
+  }
+
+  issues.sort((a, b) => a.line - b.line);
+
+  const byType = { 'fake-file': 0, 'fake-import': 0, 'fake-symbol': 0 };
+  for (const i of issues) byType[i.type] = (byType[i.type] || 0) + 1;
+
+  const summary = {
+    total: issues.length,
+    byType,
+    clean: issues.length === 0,
+    symbolsIndexed: symbolSet.size,
+  };
+
+  return { issues, summary };
+}
+
+module.exports = { verify, buildSymbolSet, loadDeps };

--- a/src/verify/parsers.js
+++ b/src/verify/parsers.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * Parsers for the Hallucination Guard (verify-ai-output).
+ *
+ * Extract the verifiable claims an AI answer makes about a codebase:
+ *   - file paths it references
+ *   - import / require statements it shows
+ *   - function / class symbols it calls
+ *   - fenced code blocks (so callers can scope checks to code vs prose)
+ *
+ * Everything here is deterministic and offline — pure string analysis.
+ */
+
+// Extensions we are confident name a source/code/config file (no slash required).
+const KNOWN_CODE_EXT = new Set([
+  'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'py', 'pyw', 'rb', 'go', 'rs',
+  'java', 'kt', 'swift', 'c', 'h', 'cpp', 'hpp', 'cs', 'php', 'r',
+  'vue', 'svelte', 'css', 'scss', 'less', 'html', 'json', 'yml', 'yaml',
+  'toml', 'xml', 'sql', 'graphql', 'gql', 'proto', 'tf', 'md', 'sh',
+  'gd', 'gdscript',
+]);
+
+/**
+ * Extract fenced code blocks.
+ * @param {string} text
+ * @returns {{ lang: string, content: string, line: number }[]}
+ */
+function extractCodeBlocks(text) {
+  const blocks = [];
+  const lines = text.split('\n');
+  let inBlock = false;
+  let lang = '';
+  let buf = [];
+  let startLine = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^```(\w*)/);
+    if (m) {
+      if (!inBlock) {
+        inBlock = true;
+        lang = m[1] || '';
+        buf = [];
+        startLine = i + 2; // first content line (1-based)
+      } else {
+        blocks.push({ lang, content: buf.join('\n'), line: startLine });
+        inBlock = false;
+      }
+      continue;
+    }
+    if (inBlock) buf.push(lines[i]);
+  }
+  return blocks;
+}
+
+/**
+ * Extract file-path references (deduped, first-seen line kept).
+ * A token counts as a path when it has a `.<letter…>` extension AND
+ * either contains a `/` or carries a known code/config extension.
+ * @param {string} text
+ * @returns {{ path: string, line: number }[]}
+ */
+function extractFilePaths(text) {
+  const lines = text.split('\n');
+  const seen = new Map();
+  const re = /(?:^|[\s`"'(\[<])([A-Za-z0-9_][\w./-]*\.[A-Za-z][A-Za-z0-9]*)/g;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(line)) !== null) {
+      const p = m[1];
+      if (/^https?:/i.test(p)) continue;
+      const ext = (p.split('.').pop() || '').toLowerCase();
+      const hasSlash = p.includes('/');
+      if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
+      if (!seen.has(p)) seen.set(p, i + 1);
+    }
+  }
+  return [...seen.entries()].map(([p, line]) => ({ path: p, line }));
+}
+
+/**
+ * Extract import / require statements.
+ * @param {string} text
+ * @returns {{ module: string, kind: 'js'|'py', relative: boolean, line: number, raw: string }[]}
+ */
+function extractImports(text) {
+  const lines = text.split('\n');
+  const out = [];
+  const push = (module, kind, line, raw) => {
+    if (!module) return;
+    out.push({ module, kind, relative: /^[./]/.test(module), line, raw: raw.trim() });
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let m;
+    // JS/TS: import ... from 'x'  |  export ... from 'x'
+    if ((m = line.match(/\b(?:import|export)\b[^'"]*\bfrom\s*['"]([^'"]+)['"]/))) {
+      push(m[1], 'js', i + 1, line);
+    } else if ((m = line.match(/\bimport\s*['"]([^'"]+)['"]/))) {
+      // side-effect import 'x'
+      push(m[1], 'js', i + 1, line);
+    }
+    // require('x') / dynamic import('x') — may co-occur, scan separately
+    const reqRe = /\b(?:require|import)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+    let r;
+    while ((r = reqRe.exec(line)) !== null) push(r[1], 'js', i + 1, line);
+
+    // Python: from x import y  |  import x
+    if ((m = line.match(/^\s*from\s+([.\w]+)\s+import\b/))) {
+      push(m[1], 'py', i + 1, line);
+    } else if ((m = line.match(/^\s*import\s+([A-Za-z_][\w.]*)/))) {
+      push(m[1], 'py', i + 1, line);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract function/class symbol references that look like calls.
+ * Restricted to backtick-wrapped calls (`foo(...)`) for high precision.
+ * @param {string} text
+ * @returns {{ name: string, line: number }[]}
+ */
+function extractSymbols(text) {
+  const lines = text.split('\n');
+  const out = [];
+  const seen = new Set();
+  const re = /`([A-Za-z_$][\w$]*)\s*\([^`]*\)`/g;
+  for (let i = 0; i < lines.length; i++) {
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(lines[i])) !== null) {
+      const name = m[1];
+      const key = name + '@' + (i + 1);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ name, line: i + 1 });
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  extractCodeBlocks,
+  extractFilePaths,
+  extractImports,
+  extractSymbols,
+};

--- a/test/integration/verify-ai-output.test.js
+++ b/test/integration/verify-ai-output.test.js
@@ -1,0 +1,237 @@
+'use strict';
+
+/**
+ * Integration tests for `verify-ai-output` — Hallucination Guard (Phase 1 MVP).
+ *
+ * Covers:
+ *   Parsers
+ *    1. extractFilePaths finds path-like tokens, skips URLs/version numbers
+ *    2. extractImports finds js + py imports and marks relative vs bare
+ *    3. extractSymbols finds backtick-wrapped call references
+ *   Module (verify, injected fixtures — deterministic)
+ *    4. fake-file flagged when path absent
+ *    5. fake-import flagged for unresolved relative + missing bare package
+ *    6. fake-symbol flagged for unknown symbol; real symbol passes
+ *    7. clean answer → zero issues, summary.clean true
+ *    8. node/py builtins + scoped/real deps are not flagged
+ *   CLI dispatch (against a generated fixture repo)
+ *    9. dirty answer exits 1 and reports fake-file + fake-import
+ *   10. clean answer exits 0
+ *   11. --json emits { file, issues, summary } and exits 1 on issues
+ *   12. missing file / missing arg → exit 1 with usage
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const parsers = require(path.join(ROOT, 'src', 'verify', 'parsers'));
+const { verify } = require(path.join(ROOT, 'src', 'verify', 'hallucination-guard'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  FAIL  ${name}`);
+    console.error(`        ${err.message}`);
+    failed++;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Parsers
+// --------------------------------------------------------------------------
+test('extractFilePaths finds paths, skips URLs and version numbers', () => {
+  const text = 'See `src/config/loader.js` and visit https://example.com/x.js — released v6.13.0';
+  const paths = parsers.extractFilePaths(text).map((p) => p.path);
+  assert.ok(paths.includes('src/config/loader.js'), 'should find the path');
+  assert.ok(!paths.some((p) => p.startsWith('http')), 'should skip URLs');
+  assert.ok(!paths.includes('6.13.0'), 'should skip version numbers');
+});
+
+test('extractImports finds js + py imports and flags relative vs bare', () => {
+  const text = [
+    "import { rank } from './ranker';",
+    "const fs = require('fs');",
+    'from os import path',
+    'import chalk from "chalk";',
+  ].join('\n');
+  const imps = parsers.extractImports(text);
+  const byMod = Object.fromEntries(imps.map((i) => [i.module, i]));
+  assert.strictEqual(byMod['./ranker'].relative, true);
+  assert.strictEqual(byMod['fs'].relative, false);
+  assert.strictEqual(byMod['fs'].kind, 'js');
+  assert.strictEqual(byMod['os'].kind, 'py');
+  assert.ok(byMod['chalk']);
+});
+
+test('extractSymbols finds backtick-wrapped calls', () => {
+  const text = 'Call `loadConfig()` then `doThing(a, b)`, but plain loadConfig() is ignored.';
+  const names = parsers.extractSymbols(text).map((s) => s.name);
+  assert.ok(names.includes('loadConfig'));
+  assert.ok(names.includes('doThing'));
+  assert.strictEqual(names.length, 2, 'only backtick calls counted');
+});
+
+// --------------------------------------------------------------------------
+// Module: verify() with injected fixtures (deterministic, no fs/index needed)
+// --------------------------------------------------------------------------
+const realFiles = new Set(['src/index.js', 'src/util.js']);
+const baseOpts = {
+  symbolSet: new Set(['realFunc', 'helper', 'loadConfig']),
+  fileBasenames: new Set(['index', 'util', 'ranker']),
+  deps: new Set(['chalk', '@scope/pkg']),
+  hasPkg: true,
+  fileExists: (ref) => realFiles.has(ref.replace(/^\.\//, '')),
+  relativeResolvable: (mod) => /index|util|ranker/.test(mod),
+};
+
+test('fake-file flagged when path absent', () => {
+  const { issues } = verify('See `src/ghost.js` and `src/index.js`.', '/x', baseOpts);
+  const files = issues.filter((i) => i.type === 'fake-file').map((i) => i.value);
+  assert.deepStrictEqual(files, ['src/ghost.js']);
+});
+
+test('fake-import flagged for unresolved relative + missing bare package', () => {
+  const text = [
+    "import a from './util';",       // resolvable → ok
+    "import b from './nope';",       // unresolved → flag
+    "import c from 'chalk';",        // real dep → ok
+    "import d from 'ghost-pkg';",    // missing dep → flag
+  ].join('\n');
+  const { issues } = verify(text, '/x', baseOpts);
+  const imps = issues.filter((i) => i.type === 'fake-import').map((i) => i.value).sort();
+  assert.deepStrictEqual(imps, ['./nope', 'ghost-pkg']);
+});
+
+test('fake-symbol flagged for unknown symbol; real symbol passes', () => {
+  const { issues } = verify('Use `realFunc()` then `phantomFn()`.', '/x', baseOpts);
+  const syms = issues.filter((i) => i.type === 'fake-symbol').map((i) => i.value);
+  assert.deepStrictEqual(syms, ['phantomFn']);
+});
+
+test('clean answer → zero issues and summary.clean true', () => {
+  const text = "File `src/index.js` exposes `realFunc()`.\n\nimport x from './util';";
+  const { issues, summary } = verify(text, '/x', baseOpts);
+  assert.strictEqual(issues.length, 0);
+  assert.strictEqual(summary.clean, true);
+  assert.strictEqual(summary.total, 0);
+});
+
+test('builtins + scoped/real deps are not flagged', () => {
+  const text = [
+    "const fs = require('fs');",
+    "import os from 'os';",
+    "import s from '@scope/pkg';",
+    'from json import dumps',
+  ].join('\n');
+  const { issues } = verify(text, '/x', baseOpts);
+  assert.strictEqual(issues.filter((i) => i.type === 'fake-import').length, 0);
+});
+
+// --------------------------------------------------------------------------
+// CLI dispatch against a generated fixture repo
+// --------------------------------------------------------------------------
+function makeFixtureRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-verify-'));
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'fx', version: '1.0.0', dependencies: { chalk: '^5.0.0' } }, null, 2)
+  );
+  fs.writeFileSync(
+    path.join(dir, 'src', 'index.js'),
+    'function realFunc(a) { return a; }\nmodule.exports = { realFunc };\n'
+  );
+  fs.writeFileSync(
+    path.join(dir, 'src', 'util.js'),
+    'function helper() { return 1; }\nmodule.exports = { helper };\n'
+  );
+  // Generate context so buildSigIndex has a symbol index.
+  spawnSync('node', [SCRIPT, '--cwd', dir], { cwd: ROOT, encoding: 'utf8' });
+  return dir;
+}
+
+function runVerify(dir, answerPath, extra = []) {
+  return spawnSync('node', [SCRIPT, 'verify-ai-output', answerPath, '--cwd', dir, ...extra], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+const fixtureDir = makeFixtureRepo();
+
+const dirtyAnswer = path.join(fixtureDir, 'dirty.md');
+fs.writeFileSync(dirtyAnswer, [
+  '# Answer',
+  'Edit `src/index.js` and the missing `src/ghost.js`.',
+  '',
+  '```js',
+  "import { helper } from './src/util';",
+  "import x from './src/missing';",
+  "import chalk from 'chalk';",
+  "import y from 'totally-not-real-pkg';",
+  '```',
+].join('\n'));
+
+const cleanAnswer = path.join(fixtureDir, 'clean.md');
+fs.writeFileSync(cleanAnswer, [
+  '# Answer',
+  'Edit `src/index.js` which exports `realFunc()`.',
+  '',
+  '```js',
+  "import { helper } from './src/util';",
+  "import chalk from 'chalk';",
+  '```',
+].join('\n'));
+
+test('CLI: dirty answer exits 1 and reports fake-file + fake-import', () => {
+  const res = runVerify(fixtureDir, dirtyAnswer);
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}\n${res.stdout}${res.stderr}`);
+  assert.ok(/src\/ghost\.js/.test(res.stdout), 'reports fake file');
+  assert.ok(/src\/missing/.test(res.stdout), 'reports unresolved import');
+  assert.ok(/totally-not-real-pkg/.test(res.stdout), 'reports missing package');
+});
+
+test('CLI: clean answer exits 0', () => {
+  const res = runVerify(fixtureDir, cleanAnswer);
+  assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}\n${res.stdout}${res.stderr}`);
+  assert.ok(/no hallucinations/.test(res.stdout));
+});
+
+test('CLI: --json emits { file, issues, summary } and exits 1 on issues', () => {
+  const res = runVerify(fixtureDir, dirtyAnswer, ['--json']);
+  assert.strictEqual(res.status, 1);
+  const obj = JSON.parse(res.stdout.trim());
+  assert.ok(Array.isArray(obj.issues));
+  assert.ok(obj.summary && typeof obj.summary.total === 'number');
+  assert.ok(obj.summary.total >= 3);
+  assert.ok(obj.issues.every((i) => i.type && typeof i.line === 'number' && i.message));
+});
+
+test('CLI: missing file → exit 1', () => {
+  const res = runVerify(fixtureDir, path.join(fixtureDir, 'does-not-exist.md'));
+  assert.strictEqual(res.status, 1);
+  assert.ok(/file not found/i.test(res.stderr));
+});
+
+test('CLI: missing arg → exit 1 with usage', () => {
+  const res = spawnSync('node', [SCRIPT, 'verify-ai-output', '--cwd', fixtureDir], { cwd: ROOT, encoding: 'utf8' });
+  assert.strictEqual(res.status, 1);
+  assert.ok(/Usage: sigmap verify-ai-output/.test(res.stderr));
+});
+
+// Cleanup
+try { fs.rmSync(fixtureDir, { recursive: true, force: true }); } catch (_) {}
+
+console.log(`\nverify-ai-output: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #227.

## What
Adds `sigmap verify-ai-output <answer.md>` — a deterministic, offline Hallucination Guard that flags fabricated claims in an AI answer.

Detectors (no network, no LLM):
- **fake-file** — referenced path is not on disk
- **fake-import** — relative import does not resolve; bare import absent from `package.json` deps (node/python builtins allow-listed, scoped packages handled)
- **fake-symbol** — called function/class absent from the SigMap symbol index (`buildSigIndex`)

## How
- `src/verify/parsers.js` — extracts file paths, import/require statements, backtick-wrapped symbol calls, and fenced code blocks from the answer text.
- `src/verify/hallucination-guard.js` — `verify(answerText, cwd, opts) → { issues, summary }`. Reuses `buildSigIndex` for the symbol set; all external lookups (file existence, deps, relative-import resolution) are injectable so the core is unit-testable.
- `gen-context.js` dispatch — `verify-ai-output <file> [--json]`. Markdown by default, JSON for CI. Exits `1` when any issue is found, `0` when clean.

## Tests
`test/integration/verify-ai-output.test.js` — 13 tests across parsers, the `verify()` module (injected fixtures), and the CLI run against a generated fixture repo. Full suite: **65 passed, 0 failed**.

## Notes
- Targets **v6.14.0** (v6.13.0 is already released). Version bump/CHANGELOG handled later by `/update-docs`.
- Zero new runtime deps; offline-only — consistent with the core trust story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)