### PR TITLE
release: v6.15.0 — Hallucination Guard Reliable MVP + Memory tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Memory tools — `note`, `status`, and the `read_memory` MCP tool (Phase 1.5):** closes the cold-start gap so an agent can recall *what we were doing and why* without re-scanning the repo.
+  - **`sigmap note "<text>"`** — append to a cross-session decision log stored as append-only NDJSON at `.context/notes.ndjson` (each entry records text, ISO timestamp, and git branch). `sigmap note` with no text lists recent notes (`--list <N>`, `--json`). New module `src/session/notes.js`.
+  - **`sigmap status`** — repo state at a glance: branch (with an unborn-branch fallback), dirty-file count, last index run (time, version, file count) with a **staleness** signal (tracked files modified since the last index), and notes summary. `--json` supported.
+  - **`read_memory` MCP tool (11th tool)** — returns recent notes (most recent first) plus the last ranking-session focus from `ask`, formatted for agent consumption. Registered in `src/mcp/tools.js`, `handlers.js`, and `server.js`; bundled into the standalone binary.
+  - New guide: `docs-vp/guide/memory.md`.
+- New integration suite `test/integration/memory-tools.test.js` (13 cases) covering the notes store, `note`/`status` CLI, and `read_memory` over the MCP wire; wired into `npm run test:integration`.
+
+### Fixed
+- `npm run test:integration` referenced a non-existent `test/integration/mcp-server.test.js`; corrected to `test/integration/mcp/server.test.js`.
+
 ---
 
 ## [6.14.0] — 2026-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **`verify-ai-output` — Hallucination Guard Reliable MVP (Phase 1):**
+  - Two new deterministic detectors — **`fake-test-file`** (a referenced `*.test`/`*.spec`/`__tests__`/`test_*.py` path absent on disk, reported separately from `fake-file`) and **`fake-npm-script`** (`npm run X` where `X` is not a `package.json` script).
+  - **Closest-match suggestions** (`src/verify/closest-match.js`) — Levenshtein + file-proximity over the symbol index attaches a heuristic hint to flagged names ("Did you mean `loadConfig()` in `src/config/loader.js:42`?"). Labeled as heuristic, with its own confidence bucketing.
+  - **Finalized JSON schema** — every issue now carries `{ type, value, line, location, message, confidence, suggestion }`; `summary` gains `withSuggestion`. Detection confidence is `high` for path/dep/script checks and `medium` for symbol checks.
+  - **Parser hardening** — multi-line `import { … } from '…'` statements and TypeScript `import X = require('…')` are now detected; `npm`/`pnpm`/`yarn run` script references are extracted.
+  - **HTML report view** (`src/format/verify-report.js`) — `sigmap verify-ai-output <answer> --report [out.html]` writes a standalone, self-contained red/amber/green report (no external assets/scripts); a Markdown renderer shares the same structure for CI/PR comments.
+  - **Proof harness** — `npm run benchmark:verify` scores each detector group against labeled cases and enforces precision targets (file ≥ 95%, import ≥ 85%, symbol ≥ 75%, script ≥ 95%), emitting a precision/recall CSV. Runs offline via a synthetic self-test; point it at real repos with `--manifest`.
+  - New guide: `docs-vp/guide/verify-ai-output.md`.
+- The `verify-ai-output` integration test (29 cases) is now part of `npm run test:integration`.
+
+### Fixed
+- `npm run test:integration` referenced a non-existent `test/integration/mcp-server.test.js`; corrected to `test/integration/mcp/server.test.js`.
+
 ---
 
 ## [6.14.0] — 2026-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+---
+
+## [6.15.0] — 2026-06-09
+
 ### Added
-- **`verify-ai-output` — Hallucination Guard Reliable MVP (Phase 1):**
+- **`verify-ai-output` — Hallucination Guard Reliable MVP (Phase 1, #232):**
   - Two new deterministic detectors — **`fake-test-file`** (a referenced `*.test`/`*.spec`/`__tests__`/`test_*.py` path absent on disk, reported separately from `fake-file`) and **`fake-npm-script`** (`npm run X` where `X` is not a `package.json` script).
   - **Closest-match suggestions** (`src/verify/closest-match.js`) — Levenshtein + file-proximity over the symbol index attaches a heuristic hint to flagged names ("Did you mean `loadConfig()` in `src/config/loader.js:42`?"). Labeled as heuristic, with its own confidence bucketing.
   - **Finalized JSON schema** — every issue now carries `{ type, value, line, location, message, confidence, suggestion }`; `summary` gains `withSuggestion`. Detection confidence is `high` for path/dep/script checks and `medium` for symbol checks.
@@ -17,13 +21,15 @@ Format: [Semantic Versioning](https://semver.org/)
   - **HTML report view** (`src/format/verify-report.js`) — `sigmap verify-ai-output <answer> --report [out.html]` writes a standalone, self-contained red/amber/green report (no external assets/scripts); a Markdown renderer shares the same structure for CI/PR comments.
   - **Proof harness** — `npm run benchmark:verify` scores each detector group against labeled cases and enforces precision targets (file ≥ 95%, import ≥ 85%, symbol ≥ 75%, script ≥ 95%), emitting a precision/recall CSV. Runs offline via a synthetic self-test; point it at real repos with `--manifest`.
   - New guide: `docs-vp/guide/verify-ai-output.md`.
-- The `verify-ai-output` integration test (29 cases) is now part of `npm run test:integration`.
-- **Memory tools — `note`, `status`, and the `read_memory` MCP tool (Phase 1.5):** closes the cold-start gap so an agent can recall *what we were doing and why* without re-scanning the repo.
+- **Memory tools — `note`, `status`, and the `read_memory` MCP tool (Phase 1.5, #233):** closes the cold-start gap so an agent can recall *what we were doing and why* without re-scanning the repo.
   - **`sigmap note "<text>"`** — append to a cross-session decision log stored as append-only NDJSON at `.context/notes.ndjson` (each entry records text, ISO timestamp, and git branch). `sigmap note` with no text lists recent notes (`--list <N>`, `--json`). New module `src/session/notes.js`.
   - **`sigmap status`** — repo state at a glance: branch (with an unborn-branch fallback), dirty-file count, last index run (time, version, file count) with a **staleness** signal (tracked files modified since the last index), and notes summary. `--json` supported.
   - **`read_memory` MCP tool (11th tool)** — returns recent notes (most recent first) plus the last ranking-session focus from `ask`, formatted for agent consumption. Registered in `src/mcp/tools.js`, `handlers.js`, and `server.js`; bundled into the standalone binary.
   - New guide: `docs-vp/guide/memory.md`.
-- New integration suite `test/integration/memory-tools.test.js` (13 cases) covering the notes store, `note`/`status` CLI, and `read_memory` over the MCP wire; wired into `npm run test:integration`.
+- The `verify-ai-output` (29 cases) and new `memory-tools` (13 cases) integration suites are now part of `npm run test:integration`.
+
+### Changed
+- MCP server now exposes **11 tools** (was 10) with the addition of `read_memory`; `version.json` `mcp_tools`, the `mcp.md` guide, and all tool-count test gates updated accordingly.
 
 ### Fixed
 - `npm run test:integration` referenced a non-existent `test/integration/mcp-server.test.js`; corrected to `test/integration/mcp/server.test.js`.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ SigMap extracts function and class signatures from your codebase and feeds the r
 
 ## Why SigMap?
 
-- **81.1% hit@5** — right file found in top 5 results (vs 13.6% baseline)
-- **96.5% token reduction** — average across 21 real repos
-- **53.3% task success rate** — up from 10% without context
-- **1.66 prompts per task** — down from 2.84 (41.8% fewer retries)
+- **75.6% hit@5** — right file found in top 5 results (vs 13.6% baseline)
+- **97.1% token reduction** — average across 21 real repos
+- **51.1% task success rate** — up from 10% without context
+- **1.73 prompts per task** — down from 2.84 (39.0% fewer retries)
 - **31 languages supported** — TypeScript, Python, Go, Rust, Java, R, and 25 others
 - **No vendor lock-in** — works with any AI assistant or local LLM
 - **No API costs** — use local models (Ollama, llama.cpp, vLLM) with zero token fees
@@ -63,7 +63,7 @@ SigMap extracts function and class signatures from your codebase and feeds the r
 
 | Without SigMap | With SigMap |
 |---|---|
-| ❌ Guessing which files are relevant | ✅ Right file in context — 81% of the time |
+| ❌ Guessing which files are relevant | ✅ Right file in context — 76% of the time |
 | ❌ Sending the full repo to your AI | ✅ Minimal context — only what matters |
 | ❌ Embeddings / vector DB required | ✅ Grounded answers, no infra needed |
 
@@ -87,13 +87,13 @@ Ask → Rank → Context → Validate → Judge → Learn
 ## Benchmark
 
 ```
-Benchmark : sigmap-v6.13-main (21 repositories, including R language)
-Date      : 2026-06-05
+Benchmark : sigmap-v6.15-main (21 repositories, including R language)
+Date      : 2026-06-09
 
-Hit@5          : 81.1%   (baseline 13.6%  — 6.0× lift)
-Token reduction: 96.5%   (across 21 repos)
-Prompt reduction : 41.8% (2.84 → 1.66 prompts per task)
-Task success   : 53.3%   (baseline 10%)
+Hit@5          : 75.6%   (baseline 13.6%  — 5.6× lift)
+Token reduction: 97.1%   (across 21 repos)
+Prompt reduction : 39.0% (2.84 → 1.73 prompts per task)
+Task success   : 51.1%   (baseline 10%)
 Repos tested   : 21 (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift, Ruby, PHP, Scala, Kotlin, and more)
 ```
 

--- a/docs-vp/.vitepress/config.mts
+++ b/docs-vp/.vitepress/config.mts
@@ -43,6 +43,7 @@ export default defineConfig({
         items: [
           { text: 'ask', link: '/guide/ask' },
           { text: 'Surgical Context', link: '/guide/surgical-context' },
+          { text: 'Hallucination Guard', link: '/guide/verify-ai-output' },
           { text: 'validate', link: '/guide/validate' },
           { text: 'judge', link: '/guide/judge' },
           { text: 'Learning & weights', link: '/guide/learning' },

--- a/docs-vp/.vitepress/config.mts
+++ b/docs-vp/.vitepress/config.mts
@@ -46,6 +46,7 @@ export default defineConfig({
           { text: 'validate', link: '/guide/validate' },
           { text: 'judge', link: '/guide/judge' },
           { text: 'Learning & weights', link: '/guide/learning' },
+          { text: 'Memory & notes', link: '/guide/memory' },
           { text: 'compare & share', link: '/guide/compare' },
         ],
       },

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Benchmark overview
-description: Official v6.13.0 benchmark snapshot. 96.5% average token reduction across 21 repos, 81% retrieval hit@5, 41.8% fewer prompts, and R language support verified.
+description: Official v6.15.0 benchmark snapshot. 97.1% average token reduction across 21 repos, 76% retrieval hit@5, 39.0% fewer prompts, and R language support verified.
 head:
   - - meta
     - property: og:title
-      content: "SigMap benchmark overview — v6.13.0 snapshot with R language"
+      content: "SigMap benchmark overview — v6.15.0 snapshot with R language"
   - - meta
     - property: og:description
-      content: "Token, retrieval, quality, and task metrics from latest v6.13.0 benchmark run (2026-06-05) with 21 repositories including R language support."
+      content: "Token, retrieval, quality, and task metrics from latest v6.15.0 benchmark run (2026-06-09) with 21 repositories including R language support."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/benchmark"
@@ -15,16 +15,16 @@ head:
 
 # Benchmark overview
 
-::: info Official v6.13.0 benchmark snapshot (21 repos, including R language)
-**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05
+::: info Official v6.15.0 benchmark snapshot (21 repos, including R language)
+**Benchmark ID:** sigmap-v6.15-main &nbsp;·&nbsp; **Date:** 2026-06-09
 
 | Metric | Value |
 |---|---:|
-| Hit@5 (18 core repos) | **81%** vs 13.6% baseline |
-| Token reduction (21 repos) | **96.5%** |
-| Retrieval lift | **6.0×** |
-| Prompt reduction | **41.8%** (2.84 → 1.66) |
-| Task success proxy | **53.3%** |
+| Hit@5 (18 core repos) | **76%** vs 13.6% baseline |
+| Token reduction (21 repos) | **97.1%** |
+| Retrieval lift | **5.6×** |
+| Prompt reduction | **39.0%** (2.84 → 1.73) |
+| Task success proxy | **51.1%** |
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
@@ -37,20 +37,20 @@ This is the landing page for the public benchmark story. It answers four differe
 | SigMap reduces retries and wrong-context answers | [Task benchmark](/guide/task-benchmark) |
 | SigMap keeps large repos inside model limits | [Quality benchmark](/guide/quality-benchmark) |
 
-## Official v6.13.0 snapshot (with R language support)
+## Official v6.15.0 snapshot (with R language support)
 
-Latest saved benchmark run: **2026-06-05 (v6.13.0)**
+Latest saved benchmark run: **2026-06-09 (v6.15.0)**
 
 | Metric | Result |
 |---|---:|
 | Token reduction repos | 21 (including R: ggplot2, dplyr, shiny) |
 | Retrieval benchmark repos | 18 (core languages) |
 | Total tasks | 90 |
-| Average token reduction (all 21) | **96.5%** |
-| Retrieval hit@5 (18 core) | **81%** |
-| Graph-boosted hit@5 | **81%** |
+| Average token reduction (all 21) | **97.1%** |
+| Retrieval hit@5 (18 core) | **76%** |
+| Graph-boosted hit@5 | **76%** |
 | Random baseline hit@5 | 13.6% |
-| Prompt reduction | **41.8%** (2.84 → 1.66 prompts) |
+| Prompt reduction | **39.0%** (2.84 → 1.73 prompts) |
 | GPT-4o overflow repos without SigMap | **16 / 21** |
 | GPT-4o monthly input savings at 10 calls/day | **$9,899.90** |
 
@@ -60,18 +60,18 @@ Latest saved benchmark run: **2026-06-05 (v6.13.0)**
 
 - Raw source across benchmark set: **13,499,894** tokens (21 repos)
 - Final SigMap output: **~470,000** tokens
-- Overall reduction: **96.5%**
+- Overall reduction: **97.1%**
 - **New in v6.11.1:** R language support verified
   - ggplot2: 94.3% reduction (381.5K → 21.7K tokens)
   - dplyr: 93.4% reduction (145.1K → 9.5K tokens)
   - shiny: 96.2% reduction (264.6K → 10.0K tokens)
 - **New in v6.12.0:** demand-driven *Surgical Context* (`ask --mode index` + the `get_lines` MCP tool) cuts upfront `ask` context further on top of the figures above by emitting symbol pointers instead of bodies — see the [Surgical Context guide](/guide/surgical-context).
-- **New in v6.13.0:** line anchors extended to JavaScript and to class methods / interface members (TS & JS), raising index-mode token reduction on real repos from ~4.6% to 32–42% (axios 42.1%, fastify 41.1%, svelte 36.8%, vue-core 32.4%).
+- **Line anchors (v6.13.0):** extended to JavaScript and to class methods / interface members (TS & JS), raising index-mode token reduction on real repos from ~4.6% to 32–42% (axios 42.1%, fastify 41.1%, svelte 36.8%, vue-core 32.4%).
 
 ### 2. Retrieval quality
 
-- SigMap hit@5: **81%**
-- Graph-boosted hit@5: **81%** (+0.0pp with dependency graph)
+- SigMap hit@5: **76%**
+- Graph-boosted hit@5: **76%** (+0.0pp with dependency graph)
 - Random baseline: **13.6%**
 - Lift: **6.0x**
 
@@ -79,10 +79,10 @@ This is the best benchmark when the question is: *"Does SigMap actually put the 
 
 ### 3. Task outcomes
 
-- Correct: **48 / 90** (53.3%)
+- Correct: **46 / 90** (51.1%)
 - Partial: **24 / 90** (26.7%)
 - Wrong: **18 / 90** (20%)
-- Average prompts: **2.84 → 1.66**
+- Average prompts: **2.84 → 1.73**
 
 This is the best benchmark when the question is: *"Does the developer need fewer retries to finish the job?"*
 

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -1,13 +1,13 @@
 ---
 title: CLI reference
-description: Complete SigMap CLI reference. All commands and flags with examples — ask, plan, bench, judge, validate, roots, history, --package, --global, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more.
+description: Complete SigMap CLI reference. All commands and flags with examples — ask, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --package, --global, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more.
 head:
   - - meta
     - property: og:title
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 40 SigMap commands and flags documented with examples. ask, plan, bench, judge, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 42 SigMap commands and flags documented with examples. ask, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 40 SigMap commands and flags documented with examples. ask, plan, bench, judge, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 42 SigMap commands and flags documented with examples. ask, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -51,7 +51,8 @@ If you are new to the product, start with the workflow pages first:
 | `ask "<query>" --since <ref>` | Delta context: restrict ranked output to files changed since a git ref |
 | `plan "<goal>"` | Analyze change impact and plan modifications — returns files grouped by confidence |
 | `judge --response <f> --context <f>` | Rule-based groundedness scoring for LLM responses |
-| `verify-ai-output <answer.md>` | Hallucination Guard — flag fake files, imports, and symbols in an AI answer (deterministic, offline) |
+| `verify-ai-output <answer.md>` | Hallucination Guard — flag fake files, test files, imports, symbols, and npm scripts in an AI answer (deterministic, offline) |
+| `verify-ai-output <answer.md> --report [out.html]` | Write a standalone red/amber/green HTML report of the findings |
 | `validate` | Validate config and coverage; optional query symbol check |
 | `learn` | Boost, penalize, or reset learned file ranking weights |
 | `weights` | Show learned file multipliers or emit them as JSON |
@@ -67,6 +68,8 @@ If you are new to the product, start with the workflow pages first:
 |----------------|-------------|
 | `roots [--explain | --json | --fix]` | Auto-detect source roots for 17 languages and 50+ frameworks; shows confidence and scoring |
 | `history` | Show usage log + benchmark trend sparklines (hit@5, token reduction) |
+| `note "<text>"` | Append a note to the cross-session decision log (`note` alone lists recent) |
+| `status` | Repo state — branch, dirty files, index freshness, notes |
 | `learn` | Boost, penalize, or reset learned file ranking weights |
 | `weights` | Show learned file multipliers or emit them as JSON |
 | `suggest-profile` | Auto-detect context profile from git state |
@@ -297,29 +300,33 @@ Exit code `0` = pass, `1` = fail. Use in CI to gate on response quality.
 
 ## verify-ai-output
 
-Hallucination Guard (prototype). Scans an AI answer (markdown or plain text) and flags claims that do not match the repository: fake file paths, unresolvable imports, and function/class symbols that are not in the SigMap index. Fully deterministic — runs offline, no LLM API.
+Hallucination Guard. Scans an AI answer (markdown or plain text) and flags claims that do not match the repository: fake file paths, fake test files, unresolvable imports, symbols not in the SigMap index, and `npm run` scripts that don't exist. Fully deterministic — runs offline, no LLM API. Where a flagged name is a near miss for something real, a heuristic closest-match suggestion is attached.
 
 ```bash
 sigmap verify-ai-output ai-answer.md
 sigmap verify-ai-output ai-answer.md --json
+sigmap verify-ai-output ai-answer.md --report report.html
 ```
 
 ```
 [sigmap] ✗ ai-answer.md — 3 issues found
-  fake-file: 1  fake-import: 1  fake-symbol: 1
+  fake-file: 0  fake-test-file: 1  fake-import: 1  fake-symbol: 1  fake-npm-script: 0
 
-  L6   [Fake file]    File not found on disk: src/extractors/nonexistent.js
-  L10  [Fake import]  Import does not resolve: ./src/totally/madeup
-  L4   [Fake symbol]  Symbol not found in repo index: magicallyFix()
+  L4   [Fake symbol]     Symbol not found in repo index: loadConfg()
+         ↳ Did you mean `loadConfig()` in src/config/loader.js:42?
+  L6   [Fake test file]  Test file not found on disk: src/extractors/nonexistent.test.js
+  L10  [Fake import]     Import does not resolve: ./src/totally/madeup
 ```
 
-Three deterministic detectors:
+Five deterministic detectors:
 
-| Detector | Flags |
-|----------|-------|
-| `fake-file` | A referenced path that is not present on disk |
-| `fake-import` | A relative import that does not resolve, or a bare package absent from `package.json` dependencies (Node/Python builtins and scoped packages are allow-listed) |
-| `fake-symbol` | A called function/class (`` `name()` ``) absent from the SigMap symbol index (`buildSigIndex`) |
+| Detector | Flags | Confidence |
+|----------|-------|------------|
+| `fake-file` | A referenced path that is not present on disk | High |
+| `fake-test-file` | A referenced **test** path (`*.test`/`*.spec`/`__tests__`/`test_*.py`) absent on disk | High |
+| `fake-import` | A relative import that does not resolve, or a bare package absent from `package.json` dependencies (Node/Python builtins and scoped packages are allow-listed) | High |
+| `fake-symbol` | A called function/class (`` `name()` ``) absent from the SigMap symbol index (`buildSigIndex`) | Medium |
+| `fake-npm-script` | An `npm run X` (or `pnpm`/`yarn run X`) where `X` is not a `package.json` script | High |
 
 JSON output (`--json`) for CI:
 
@@ -327,17 +334,67 @@ JSON output (`--json`) for CI:
 {
   "file": "ai-answer.md",
   "issues": [
-    { "type": "fake-file", "value": "src/ghost.js", "line": 6, "message": "File not found on disk: src/ghost.js" }
+    { "type": "fake-symbol", "value": "loadConfg", "line": 4, "location": "L4", "message": "Symbol not found in repo index: loadConfg()", "confidence": "medium", "suggestion": "Did you mean `loadConfig()` in src/config/loader.js:42?" }
   ],
-  "summary": { "total": 1, "byType": { "fake-file": 1, "fake-import": 0, "fake-symbol": 0 }, "clean": false, "symbolsIndexed": 288 }
+  "summary": { "total": 1, "byType": { "fake-file": 0, "fake-test-file": 0, "fake-import": 0, "fake-symbol": 1, "fake-npm-script": 0 }, "clean": false, "symbolsIndexed": 288, "withSuggestion": 1 }
 }
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--json` | Emit machine-readable `{ file, issues, summary }` instead of the markdown report |
+| `--report [out.html]` | Write a standalone, self-contained HTML report (red/amber/green per issue, suggestions inline); defaults to `sigmap-verify-report.html`. Combinable with `--json`. |
 
-Exit code `0` = clean (no hallucinations), `1` = at least one issue found. Use in CI to gate AI-generated patches or answers before they are trusted.
+Exit code `0` = clean (no hallucinations), `1` = at least one issue found. Use in CI to gate AI-generated patches or answers before they are trusted. See the [Hallucination Guard guide](/guide/verify-ai-output) for the full workflow.
+
+---
+
+## note
+
+Append a note to a cross-session decision log so an agent (or you) can recall *what we were doing and why* later. Notes are stored as append-only NDJSON at `.context/notes.ndjson` (text + ISO timestamp + git branch). Running `note` with no text lists recent notes.
+
+```bash
+sigmap note "switched auth to JWT; refresh-token flow still TODO"
+sigmap note               # list the last 10
+sigmap note --list 25     # list the last 25
+sigmap note --json        # machine-readable
+```
+
+```
+[sigmap] noted (feat/auth): switched auth to JWT; refresh-token flow still TODO
+```
+
+| Option | Description |
+|--------|-------------|
+| `--list <N>` | List the most recent N notes instead of appending |
+| `--json` | Emit `{ added }` (on append) or `{ notes }` (on list) |
+
+The same log is surfaced to agents through the [`read_memory` MCP tool](/guide/mcp). See the [Memory & notes guide](/guide/memory).
+
+---
+
+## status
+
+Repo state at a glance — useful before kicking off a task or in a pre-commit check.
+
+```bash
+sigmap status
+sigmap status --json
+```
+
+```
+[sigmap] status
+  Branch:        feat/auth-refresh
+  Working tree:  3 files changed
+  Last index:    2h ago (v6.15.0, 412 files) — STALE: 5 files changed since
+  Notes:         7 (latest: switched auth to JWT; refresh-token flow still TODO)
+```
+
+`Last index` reads the usage log and compares the index time against your tracked files' mtimes, so you can see whether the context an agent is using is stale.
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Emit `{ branch, dirty, lastIndex, indexVersion, indexFiles, changedSinceIndex, notes, lastNote }` |
 
 ---
 
@@ -535,9 +592,9 @@ sigmap compare --json
 ────────────────────────────────────────────
  SigMap vs Baseline
 ────────────────────────────────────────────
- hit@5         81.1% vs 13.6%   (6.0× lift)
- Avg prompts   1.66 vs 2.84
- Token story   96.5% overall reduction
+ hit@5         75.6% vs 13.6%   (5.6× lift)
+ Avg prompts   1.73 vs 2.84
+ Token story   97.1% overall reduction
 ────────────────────────────────────────────
 ```
 
@@ -553,7 +610,7 @@ sigmap share
 
 ```
 Generated with SigMap — zero-dependency AI context engine
-96.5% fewer tokens · 81.1% retrieval hit@5 · 41.8% fewer prompts
+97.1% fewer tokens · 75.6% retrieval hit@5 · 39.0% fewer prompts
 https://sigmap.dev
 [sigmap] Copied to clipboard.
 ```
@@ -578,7 +635,7 @@ sigmap bench --submit --json
  Submitted      : 2026-05-03
 ────────────────────────────────────────────────────────
  Canonical metrics (official release):
- hit@5          : 81.1%
+ hit@5          : 75.6%
  token reduction: 96.8%
 ────────────────────────────────────────────────────────
  Local run metrics: none yet — run node scripts/run-retrieval-benchmark.mjs

--- a/docs-vp/guide/compare-alternatives.md
+++ b/docs-vp/guide/compare-alternatives.md
@@ -1,13 +1,13 @@
 ---
 title: SigMap vs alternatives
-description: How SigMap compares to embeddings, RAG, RepoMix, and Copilot context. Zero infra, deterministic, 6.0× better retrieval than sending everything.
+description: How SigMap compares to embeddings, RAG, RepoMix, and Copilot context. Zero infra, deterministic, 5.6× better retrieval than sending everything.
 head:
   - - meta
     - property: og:title
       content: "SigMap vs embeddings, RAG, RepoMix, and Copilot context"
   - - meta
     - property: og:description
-      content: "Side-by-side comparison: SigMap vs RAG, embeddings, RepoMix, and Copilot context. Zero infra, deterministic, 6.0× retrieval lift."
+      content: "Side-by-side comparison: SigMap vs RAG, embeddings, RepoMix, and Copilot context. Zero infra, deterministic, 5.6× retrieval lift."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/compare-alternatives"
@@ -45,7 +45,7 @@ RepoMix compresses files. SigMap extracts what matters and ranks by relevance.
 | | SigMap | RepoMix |
 |---|---|---|
 | Token reduction | **97–98%** | ~90% |
-| Retrieval accuracy (hit@5) | **81.1%** | 13.6% (random-equivalent) |
+| Retrieval accuracy (hit@5) | **75.6%** | 13.6% (random-equivalent) |
 | Query-aware context | **Yes** — ranked per query | No — same output every time |
 | Dependency graph | **Yes** — import-aware BFS | No |
 | Learn from usage | **Yes** — `sigmap learn` | No |
@@ -53,7 +53,7 @@ RepoMix compresses files. SigMap extracts what matters and ranks by relevance.
 | Judge answer groundedness | **Yes** — `sigmap judge` | No |
 | Works with MCP tools | **Yes** — 9 tools | No |
 
-The key difference: RepoMix's output is the same regardless of what you ask. SigMap's output is ranked to the specific query, which is why retrieval accuracy is 6.0× higher.
+The key difference: RepoMix's output is the same regardless of what you ask. SigMap's output is ranked to the specific query, which is why retrieval accuracy is 5.6× higher.
 
 ## SigMap vs Copilot / IDE context window
 
@@ -79,7 +79,7 @@ Some teams maintain a hand-written `AGENTS.md` or instructions file. SigMap gene
 |---|---|---|
 | Keeps up with code changes | **Yes** — regenerates on every commit | Manual update required |
 | Structured by module | **Yes** — per-module signature blocks | Usually flat text |
-| Benchmark-tested accuracy | **81.1% hit@5** | Not measured |
+| Benchmark-tested accuracy | **75.6% hit@5** | Not measured |
 | Time to set up | **30 seconds** | Hours |
 
 ## What SigMap does not replace

--- a/docs-vp/guide/generalization.md
+++ b/docs-vp/guide/generalization.md
@@ -1,10 +1,10 @@
 ---
 title: Generalization — SigMap across languages, domains & repo sizes
-description: SigMap generalizes across 21 repos, 31 languages, and multiple domains with 81.1% hit@5 in the latest saved v6.13.0 retrieval run.
+description: SigMap generalizes across 21 repos, 31 languages, and multiple domains with 75.6% hit@5 in the latest saved v6.15.0 retrieval run.
 head:
   - - meta
     - property: og:title
-      content: "SigMap Generalization — 81.1% hit@5 across 31 languages with R support"
+      content: "SigMap Generalization — 75.6% hit@5 across 31 languages with R support"
   - - meta
     - property: og:description
       content: "SigMap's latest public snapshot spans 18 repos, 13 languages, and 9 domains without per-repo tuning."
@@ -19,16 +19,16 @@ head:
 SigMap was not tuned for one repo. This benchmark matters because it shows the same workflow transfers across different languages, repo sizes, and architectures without manual tuning.
 :::
 
-::: info Official v6.13.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.15.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.15-main &nbsp;·&nbsp; **Date:** 2026-06-09 (with R language)
 
 | Metric | Value |
 |---|---:|
 | Hit@5 | **81%** vs 13.6% baseline |
-| Retrieval lift | **6.0×** |
-| Prompt reduction | **41.8%** (2.84 → 1.66) |
-| Task success proxy | **53.3%** |
-| Overall token reduction | **96.5%** |
+| Retrieval lift | **5.6×** |
+| Prompt reduction | **39.0%** (2.84 → 1.73) |
+| Task success proxy | **51.1%** |
+| Overall token reduction | **97.1%** |
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
@@ -37,13 +37,13 @@ The important part of SigMap's benchmark story is not just the topline score. It
 ::: info What "generalization" means here
 SigMap's signature extractors are hand-written regex patterns, not ML models. Generalization
 means: *do the patterns hold up on codebases the authors never inspected?* The answer across
-these 90 tasks is yes — 81% hit@5 with no per-repo tuning in the latest saved v6.13.0 run.
+these 90 tasks is yes — 81% hit@5 with no per-repo tuning in the latest saved v6.15.0 run.
 :::
 
 - **21 repos** (including 3 R language repos)
 - **31 languages** (added R and GDScript)
 - **multiple domains**
-- **81.1%** overall hit@5
+- **75.6%** overall hit@5
 - **no per-repo tuning**
 
 That snapshot is shared with the [retrieval benchmark](/guide/retrieval-benchmark) and the [task benchmark](/guide/task-benchmark), so the public docs now use one release number set instead of mixing older runs.

--- a/docs-vp/guide/how-i-built-sigmap.md
+++ b/docs-vp/guide/how-i-built-sigmap.md
@@ -198,7 +198,7 @@ Date: 2026-05-12
 Hit@5:              78.9%  (baseline 13.6%  — 5.8× lift)
 Prompt reduction:   40.6%
 Task success:       52.2%  (baseline 10%)
-Prompts per task:   1.66   (baseline 2.84)
+Prompts per task:   1.73   (baseline 2.84)
 Token reduction:    40–98% (avg 97.9% across 21 repos, including R language)
 ```
 

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,13 +1,13 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 10 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 11 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
       content: "SigMap MCP Server — on-demand codebase context"
   - - meta
     - property: og:description
-      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 10 MCP tools over stdio."
+      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 11 MCP tools over stdio."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/mcp"
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 10 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 11 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -96,10 +96,10 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 }
 ```
 
-## 10 available tools
+## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 10 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 11 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.
@@ -116,6 +116,7 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `query_context` | Ranks all files by relevance to a free-text query using TF-IDF scoring. Returns top-K files. New in v2.3. | `query` (required string), `topK` (optional number, default 10) | `query_context(query="authentication flow")` |
 | `get_impact` | Returns the blast radius of a file — direct importers, transitive importers, affected tests and routes. | `file` (required string), `depth` (optional number, default 3) | `get_impact(file="src/auth/service.ts")` |
 | `get_lines` | **Surgical Context** demand-driven fetch: returns an exact line range from a file behind a `:start-end` anchor. Clamped to file bounds, secret-scanned, sandboxed to the project root. New in v6.12.0. | `file` (required string), `start` (required number), `end` (required number) | `get_lines(file="src/config/loader.js", start=42, end=58)` |
+| `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.16.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
 
 ## Token cost per tool call
 
@@ -146,7 +147,7 @@ Use `ask` to create `.context/query-context.md`, let the model answer, then run 
 
 ## Test the server
 
-Send a raw JSON-RPC request to confirm the server starts and returns all 9 tool definitions.
+Send a raw JSON-RPC request to confirm the server starts and returns all 11 tool definitions.
 
 ```bash
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node gen-context.js --mcp
@@ -169,7 +170,8 @@ Expected output:
       { "name": "get_routing" },
       { "name": "query_context" },
       { "name": "get_impact" },
-      { "name": "get_lines" }
+      { "name": "get_lines" },
+      { "name": "read_memory" }
     ]
   }
 }

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -116,7 +116,7 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `query_context` | Ranks all files by relevance to a free-text query using TF-IDF scoring. Returns top-K files. New in v2.3. | `query` (required string), `topK` (optional number, default 10) | `query_context(query="authentication flow")` |
 | `get_impact` | Returns the blast radius of a file — direct importers, transitive importers, affected tests and routes. | `file` (required string), `depth` (optional number, default 3) | `get_impact(file="src/auth/service.ts")` |
 | `get_lines` | **Surgical Context** demand-driven fetch: returns an exact line range from a file behind a `:start-end` anchor. Clamped to file bounds, secret-scanned, sandboxed to the project root. New in v6.12.0. | `file` (required string), `start` (required number), `end` (required number) | `get_lines(file="src/config/loader.js", start=42, end=58)` |
-| `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.16.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
+| `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.15.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
 
 ## Token cost per tool call
 

--- a/docs-vp/guide/memory.md
+++ b/docs-vp/guide/memory.md
@@ -1,0 +1,75 @@
+# Memory & notes
+
+SigMap keeps a small, cross-session **decision log** so an agent (or you) can
+recall *what we were doing and why* without re-reading the whole codebase. It's
+the cold-start killer: one MCP call at the start of a task instead of a full
+re-scan.
+
+Three pieces work together:
+
+| Piece | What it does | Surface |
+|---|---|---|
+| `sigmap note` | Append a note to the decision log | CLI |
+| `sigmap status` | Repo state at a glance — branch, dirty files, index freshness, notes | CLI |
+| `read_memory` | Return recent notes + last session focus to an agent | MCP tool |
+
+Notes are stored as append-only NDJSON at `.context/notes.ndjson` (alongside
+SigMap's other state logs). Zero dependencies, fully local.
+
+## `sigmap note`
+
+```bash
+sigmap note "switched auth to JWT; refresh-token flow still TODO"
+```
+
+Each note records the text, an ISO timestamp, and the current git branch. List
+recent notes by running `note` with no text:
+
+```bash
+sigmap note            # last 10
+sigmap note --list 25  # last 25
+sigmap note --json     # machine-readable
+```
+
+## `sigmap status`
+
+```bash
+$ sigmap status
+[sigmap] status
+  Branch:        feat/auth-refresh
+  Working tree:  3 files changed
+  Last index:    2h ago (v6.16.0, 412 files) — STALE: 5 files changed since
+  Notes:         7 (latest: switched auth to JWT; refresh-token flow still TODO)
+```
+
+`Last index` reads the usage log and compares the index time against your
+tracked files' mtimes, so you can see at a glance whether the context an agent
+is using is stale. Add `--json` for CI or scripting.
+
+## `read_memory` (MCP)
+
+The 11th MCP tool. Agents call it at the start of a task to recall the decision
+log plus the last ranking-session focus:
+
+```jsonc
+// tools/call
+{ "name": "read_memory", "arguments": { "limit": 10 } }
+```
+
+Returns Markdown — recent notes (most recent first) and, when available, the
+last query and focus files from `ask`:
+
+```markdown
+# SigMap memory
+
+## Recent notes (2)
+- [2026-06-08 10:13 (feat/auth-refresh)] switched auth to JWT; refresh-token flow still TODO
+- [2026-06-08 09:40 (feat/auth-refresh)] extracted token store into src/auth/tokens.ts
+
+## Last session
+**Last query:** refresh token rotation
+**Focus files:** src/auth/tokens.ts, src/auth/middleware.ts
+```
+
+Pair it with `note`: leave a note when you finish a chunk of work, and the next
+agent session starts already knowing where you left off.

--- a/docs-vp/guide/memory.md
+++ b/docs-vp/guide/memory.md
@@ -38,7 +38,7 @@ $ sigmap status
 [sigmap] status
   Branch:        feat/auth-refresh
   Working tree:  3 files changed
-  Last index:    2h ago (v6.16.0, 412 files) — STALE: 5 files changed since
+  Last index:    2h ago (v6.15.0, 412 files) — STALE: 5 files changed since
   Notes:         7 (latest: switched auth to JWT; refresh-token flow still TODO)
 ```
 

--- a/docs-vp/guide/methodology.md
+++ b/docs-vp/guide/methodology.md
@@ -64,7 +64,7 @@ Example tasks:
 
 **Baseline:** Random selection = ~13.6% (1 correct file out of ~90 files in typical repo)
 
-**SigMap score:** 81.1% — 6.0× better than random
+**SigMap score:** 75.6% — 5.6× better than random
 
 ### 2. Task success proxy (correct rank)
 
@@ -78,7 +78,7 @@ Example tasks:
 - **Wrong** (not in top 5) — likely multiple retries
 
 **SigMap breakdown:**
-- Correct: 53.3% of tasks
+- Correct: 51.1% of tasks
 - Partial: 26.7% of tasks
 - Wrong: 21.1% of tasks
 
@@ -90,7 +90,7 @@ Example tasks:
 
 **Metric:** Average prompts per task
 - **Without SigMap:** 2.84 prompts/task (cold start, no context)
-- **With SigMap:** 1.66 prompts/task
+- **With SigMap:** 1.73 prompts/task
 - **Reduction:** 41.0%
 
 ### 4. Token reduction

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Quality benchmark
-description: What token reduction means operationally in v6.13.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
+description: What token reduction means operationally in v6.15.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
 head:
   - - meta
     - property: og:title
@@ -15,16 +15,16 @@ head:
 
 # Quality benchmark
 
-::: info Official v6.13.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.15.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.15-main &nbsp;·&nbsp; **Date:** 2026-06-09 (with R language)
 
 | Metric | Value |
 |---|---:|
 | Hit@5 | **80%** vs 13.6% baseline |
-| Retrieval lift | **6.0×** |
-| Prompt reduction | **41.8%** (2.84 → 1.66) |
-| Task success proxy | **53.3%** |
-| Overall token reduction | **96.5%** |
+| Retrieval lift | **5.6×** |
+| Prompt reduction | **39.0%** (2.84 → 1.73) |
+| Task success proxy | **51.1%** |
+| Overall token reduction | **97.1%** |
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
@@ -34,7 +34,7 @@ Token reduction is the mechanism. This benchmark shows the operational consequen
 - how much code would be hidden without SigMap?
 - what does that mean for API cost?
 
-Latest saved run: **2026-06-05 (v6.13.0)**
+Latest saved run: **2026-06-09 (v6.15.0)**
 
 ## Headline numbers
 

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Retrieval benchmark
-description: Latest saved retrieval benchmark for SigMap v6.13.0. 81% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
+description: Latest saved retrieval benchmark for SigMap v6.15.0. 76% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
 head:
   - - meta
     - property: og:title
-      content: "SigMap retrieval benchmark — 81% hit@5"
+      content: "SigMap retrieval benchmark — 76% hit@5"
   - - meta
     - property: og:description
-      content: "Latest saved run: 81% hit@5 vs 13.6% random baseline, 6.0x lift, 90 tasks, 18 repos."
+      content: "Latest saved run: 76% hit@5 vs 13.6% random baseline, 6.0x lift, 90 tasks, 18 repos."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/retrieval-benchmark"
@@ -15,23 +15,23 @@ head:
 
 # Retrieval benchmark
 
-::: info Official v6.13.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.15.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.15-main &nbsp;·&nbsp; **Date:** 2026-06-09 (with R language)
 
 | Metric | Value |
 |---|---:|
-| Hit@5 | **81%** vs 13.6% baseline |
-| Graph-boosted hit@5 | **81%** |
-| Retrieval lift | **6.0×** |
-| Prompt reduction | **41.8%** (2.84 → 1.66) |
-| Task success proxy | **53.3%** |
-| Overall token reduction | **96.5%** |
+| Hit@5 | **76%** vs 13.6% baseline |
+| Graph-boosted hit@5 | **76%** |
+| Retrieval lift | **5.6×** |
+| Prompt reduction | **39.0%** (2.84 → 1.73) |
+| Task success proxy | **51.1%** |
+| Overall token reduction | **97.1%** |
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-05 (v6.13.0)**
+Latest saved run: **2026-06-09 (v6.15.0)**
 
-**Result:** SigMap finds the right file in the top 5 far more often than chance — **81% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
+**Result:** SigMap finds the right file in the top 5 far more often than chance — **76% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 
 ## Why this benchmark matters
 
@@ -47,10 +47,10 @@ This benchmark isolates that first question: *did the right file appear in conte
 
 | Metric | Without SigMap | With SigMap |
 |---|:---:|:---:|
-| Average hit@5 | 13.6% | **81.1%** |
-| Graph-boosted hit@5 | — | **81.1%** |
+| Average hit@5 | 13.6% | **75.6%** |
+| Graph-boosted hit@5 | — | **75.6%** |
 | Lift | — | **6.0x** |
-| Correct (rank 1) | ~1% | **53.3%** |
+| Correct (rank 1) | ~1% | **51.1%** |
 | Partial (ranks 2–5) | ~13% | **26.7%** |
 | Wrong (not in top 5) | ~86% | **21.1%** |
 
@@ -58,7 +58,7 @@ This benchmark isolates that first question: *did the right file appear in conte
 
 | Tier | Tasks | Share |
 |---|---:|---:|
-| Correct | 48 / 90 | **53.3%** |
+| Correct | 46 / 90 | **51.1%** |
 | Partial | 24 / 90 | **26.7%** |
 | Wrong | 19 / 90 | **21.1%** |
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v6.14.0, with recent releases adding the verify-ai-output Hallucination Guard prototype, demand-driven Surgical Context (get_lines MCP tool, --mode index, --since), and line anchors for JavaScript plus per-member anchors.
+description: SigMap version history and roadmap. From v0.0 to v6.15.0, with recent releases adding the verify-ai-output Hallucination Guard Reliable MVP (5 detectors, closest-match, HTML report), Memory tools (note, status, read_memory MCP tool), and demand-driven Surgical Context.
 head:
   - - meta
     - property: og:title
@@ -20,9 +20,9 @@ head:
 ---
 # Roadmap
 
-Fifty-eight versions shipped. MIT open source from day one.
+Fifty-nine versions shipped. MIT open source from day one.
 
-**Stats:** 96.5% overall token reduction · 914 tests passing · 29 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.1% overall token reduction · 949 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -816,9 +816,21 @@ The first headline verification command. `sigmap verify-ai-output <answer.md>` s
 
 ---
 
-## Current milestone — v6.15+ (Hallucination Guard — Reliable MVP)
+### v6.15.0 — Hallucination Guard Reliable MVP + Memory tools ✓ (2026-06-09)
 
-v6.0–v6.13.0 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire for 10 AI tools, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, JVM project structure auto-detection, enhanced monorepo JVM support, 2-hop graph boost with hub suppression, session-aware context carry-forward with safe change planning, segmented benchmarks with answer usefulness evaluation, monorepo workspace-scoped retrieval, R language support with S4 patterns, Python AST extraction for complex signatures, open-source agent/local LLM integration guides, complete Python import detection for accurate Python blast radius, line anchors on signatures (Surgical Context Phase 1), demand-driven retrieval with the `get_lines` MCP tool, `--mode index`, and `--since` delta context (Surgical Context Phase 2), JavaScript + per-member line anchors (Phase 2.1), and the **`verify-ai-output` (Hallucination Guard) prototype** — a deterministic verifier that flags fake files, imports, and symbols in an AI answer against the live symbol index and file map. Next: the **Hallucination Guard reliable MVP** — closest-match "did you mean?" suggestions, `fake-test-file` and `fake-npm-script` detectors, and a 5-repo precision proof — plus line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows the Hallucination Guard from three detectors to **five** — adding **fake-test-file** (a referenced `*.test`/`*.spec`/`__tests__`/`test_*.py` path absent on disk) and **fake-npm-script** (`npm run X` not in `package.json` scripts) — and adds **closest-match suggestions** (Levenshtein + file/symbol/script proximity → "Did you mean `loadConfig()` in `src/config/loader.js:42`?", labeled heuristic). The JSON schema is finalized (`{ type, value, line, location, message, confidence, suggestion }`), a standalone **HTML report** (`--report`, red/amber/green, no external assets) renders the findings, and a **proof harness** (`npm run benchmark:verify`) enforces per-detector precision targets (file ≥ 95%, import ≥ 85%, symbol ≥ 75%, script ≥ 95%).
+
+**Memory tools** (#233) close the agent cold-start gap. `sigmap note "<text>"` appends to a cross-session decision log (`.context/notes.ndjson`); `sigmap status` shows branch, dirty files, and index freshness/staleness; and the **`read_memory` MCP tool — the 11th** — recalls recent notes plus the last `ask` session focus so a fresh agent session starts already knowing where work left off.
+
+**Tags:** `verify-ai-output` · `fake-test-file` · `fake-npm-script` · `closest-match` · `--report` · `note` · `status` · `read_memory` · `11 MCP tools` · `PR #232` · `PR #233`
+
+**Impact:** 5-detector Hallucination Guard + heuristic suggestions; 11 MCP tools (was 10); 42 new tests (29 verify + 13 memory); 949 tests passing.
+
+---
+
+## Current milestone — v6.16+ (PR verification + Interactive Context Explorer)
+
+v6.0–v6.15.0 shipped graph-boosted retrieval with dependency-aware scoring, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, native tool registration, docs trust sync, intelligent source root detection, intent-aware retrieval with signal transparency, cross-session context memory with impact planning, monorepo workspace-scoped retrieval, R language support, Python AST extraction, line anchors on signatures (Surgical Context Phase 1), demand-driven retrieval with the `get_lines` MCP tool, `--mode index`, and `--since` delta context (Surgical Context Phase 2), JavaScript + per-member line anchors (Phase 2.1), the **`verify-ai-output` Hallucination Guard** — grown to a five-detector reliable MVP with closest-match suggestions, a standalone HTML report, and a precision proof harness — and **Memory tools** (`note`, `status`, and the `read_memory` MCP tool, now 11 tools total) that kill agent cold-start. Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Task benchmark
-description: Latest saved task benchmark for SigMap v6.13.0. 53.3% correct, 41.8% fewer prompts, 81% hit@5 across 90 tasks, with R language support.
+description: Latest saved task benchmark for SigMap v6.15.0. 51.1% correct, 39.0% fewer prompts, 76% hit@5 across 90 tasks, with R language support.
 head:
   - - meta
     - property: og:title
       content: "SigMap task benchmark — fewer retries, better context (with R language)"
   - - meta
     - property: og:description
-      content: "Latest saved run: 53.3% correct, 1.66 prompts per task, 41.8% prompt reduction, 90 tasks, 18+ repos with R support."
+      content: "Latest saved run: 51.1% correct, 1.73 prompts per task, 39.0% prompt reduction, 90 tasks, 18+ repos with R support."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/guide/task-benchmark"
@@ -15,21 +15,21 @@ head:
 
 # Task benchmark
 
-::: info Official v6.13.0 benchmark snapshot
-**Benchmark ID:** sigmap-v6.13-main &nbsp;·&nbsp; **Date:** 2026-06-05 (with R language)
+::: info Official v6.15.0 benchmark snapshot
+**Benchmark ID:** sigmap-v6.15-main &nbsp;·&nbsp; **Date:** 2026-06-09 (with R language)
 
 | Metric | Value |
 |---|---:|
-| Hit@5 | **81%** vs 13.6% baseline |
-| Graph-boosted hit@5 | **81%** |
-| Retrieval lift | **6.0×** |
-| Prompt reduction | **41.8%** (2.84 → 1.66) |
-| Task success proxy | **53.3%** |
-| Token reduction (21 repos) | **96.5%** |
+| Hit@5 | **76%** vs 13.6% baseline |
+| Graph-boosted hit@5 | **76%** |
+| Retrieval lift | **5.6×** |
+| Prompt reduction | **39.0%** (2.84 → 1.73) |
+| Task success proxy | **51.1%** |
+| Token reduction (21 repos) | **97.1%** |
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-05 (v6.13.0)** — Now includes R language support (ggplot2, dplyr, shiny)
+Latest saved run: **2026-06-09 (v6.15.0)** — Now includes R language support (ggplot2, dplyr, shiny)
 
 This page answers the question people care about most:
 
@@ -39,11 +39,11 @@ This page answers the question people care about most:
 
 | Metric | Without SigMap | With SigMap |
 |---|:---:|:---:|
-| Task success proxy | 10% | **53.3%** |
+| Task success proxy | 10% | **51.1%** |
 | Prompts per task | 2.84 | **1.67** |
-| Prompt reduction | — | **41.8%** |
-| Retrieval hit@5 | 13.6% | **81%** |
-| Token reduction | — | **96.5%** |
+| Prompt reduction | — | **39.0%** |
+| Retrieval hit@5 | 13.6% | **76%** |
+| Token reduction | — | **97.1%** |
 
 ## Why the task benchmark exists
 
@@ -63,7 +63,7 @@ The task benchmark models that outcome from the ranked file quality tiers:
 
 | Tier | Meaning | Tasks | Share |
 |---|---|---:|---:|
-| Correct | Right file was ranked first | 48 | **53.3%** |
+| Correct | Right file was ranked first | 46 | **51.1%** |
 | Partial | Right file was present but not first | 24 | **26.7%** |
 | Wrong | Right file never surfaced in top 5 | 19 | **21.1%** |
 
@@ -72,8 +72,8 @@ The task benchmark models that outcome from the ranked file quality tiers:
 | Metric | Value |
 |---|---:|
 | Average prompts without SigMap | 2.84 |
-| Average prompts with SigMap | **1.66** |
-| Reduction | **41.8%** |
+| Average prompts with SigMap | **1.73** |
+| Reduction | **39.0%** |
 | Average hit@5 lift | **6.0x** across repo baselines |
 
 ## What changed in the v5 story

--- a/docs-vp/guide/verify-ai-output.md
+++ b/docs-vp/guide/verify-ai-output.md
@@ -1,0 +1,111 @@
+# Hallucination Guard (`verify-ai-output`)
+
+`verify-ai-output` flags claims in an AI answer that don't match your real
+repository — fabricated files, imports, symbols, test paths, and npm scripts.
+It is **deterministic and fully offline**: no network, no second LLM. It reuses
+SigMap's symbol index, file map, and import resolver, so every check is grounded
+in your actual code.
+
+```bash
+sigmap verify-ai-output answer.md
+```
+
+Exit code is `1` when any issue is found, `0` when the answer is clean — drop it
+straight into CI.
+
+## What it detects
+
+| Type | Meaning | Confidence |
+|---|---|---|
+| `fake-file` | A referenced path is not on disk | High |
+| `fake-test-file` | A referenced **test** path is not on disk | High |
+| `fake-import` | A relative import doesn't resolve, or a bare package isn't in `package.json` | High |
+| `fake-symbol` | A called function/class isn't in the SigMap symbol index | Medium |
+| `fake-npm-script` | `npm run X` where `X` isn't a `package.json` script | High |
+
+Node/Python builtins, scoped packages, and language globals are allow-listed to
+keep precision high. Python bare imports are intentionally **not** flagged
+(stdlib is unbounded offline).
+
+## Closest-match suggestions
+
+When a flagged name is a near miss for something real, the report adds a
+heuristic suggestion (labeled as such — it's a Levenshtein guess, not a fact):
+
+```
+  L12  [Fake symbol]  Symbol not found in repo index: loadConfg()
+         ↳ Did you mean `loadConfig()` in src/config/loader.js:42?
+  L14  [Fake npm script]  npm script not in package.json: buidl
+         ↳ Did you mean `build`?
+```
+
+## Output modes
+
+### Terminal (default)
+
+Grouped counts plus one line per issue, with suggestions inline.
+
+### JSON — for CI
+
+```bash
+sigmap verify-ai-output answer.md --json
+```
+
+```json
+{
+  "file": "answer.md",
+  "issues": [
+    {
+      "type": "fake-symbol",
+      "value": "loadConfg",
+      "line": 12,
+      "location": "L12",
+      "message": "Symbol not found in repo index: loadConfg()",
+      "confidence": "medium",
+      "suggestion": "Did you mean `loadConfig()` in src/config/loader.js:42?"
+    }
+  ],
+  "summary": {
+    "total": 1,
+    "byType": { "fake-file": 0, "fake-test-file": 0, "fake-import": 0, "fake-symbol": 1, "fake-npm-script": 0 },
+    "clean": false,
+    "symbolsIndexed": 1842,
+    "withSuggestion": 1
+  }
+}
+```
+
+### HTML report
+
+```bash
+sigmap verify-ai-output answer.md --report report.html
+```
+
+Writes a standalone, self-contained HTML report (red/amber/green per issue,
+suggestions inline). It has no external assets or scripts, so it's safe to
+publish or paste as a screenshot into a PR. `--report` can be combined with
+`--json` (the report is written, JSON goes to stdout).
+
+## Use in CI
+
+```yaml
+- name: Verify AI answer against the repo
+  run: |
+    npx sigmap verify-ai-output answer.md --json > verify.json
+    npx sigmap verify-ai-output answer.md --report verify-report.html
+```
+
+A non-zero exit fails the job when the answer contains fabricated references.
+
+## Precision
+
+Detector precision is validated by a proof harness
+(`npm run benchmark:verify`) that scores each detector group against labeled
+cases and enforces targets (file ≥ 95%, import ≥ 85%, symbol ≥ 75%, script ≥
+95%). Point it at your own repos with a manifest:
+
+```bash
+node scripts/run-verify-benchmark.mjs --manifest cases.json
+```
+
+It emits a per-detector precision/recall CSV.

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -1,14 +1,14 @@
 ---
 layout: home
 title: SigMap — zero-dependency AI context engine
-description: SigMap makes AI coding answers more grounded with compact signatures, validation, judge scoring, and local learning. 81.1% hit@5, 41.8% fewer prompts, 96.5% average token reduction, 31 languages with R support.
+description: SigMap makes AI coding answers more grounded with compact signatures, validation, judge scoring, and local learning. 75.6% hit@5, 39.0% fewer prompts, 97.1% average token reduction, 31 languages with R support.
 head:
   - - meta
     - property: og:title
       content: "SigMap — grounded AI coding context"
   - - meta
     - property: og:description
-      content: "Ask, validate, judge, and learn from real code context. 81.1% hit@5, 41.8% fewer prompts, 96.5% overall token reduction."
+      content: "Ask, validate, judge, and learn from real code context. 75.6% hit@5, 39.0% fewer prompts, 97.1% overall token reduction."
   - - meta
     - property: og:url
       content: "https://manojmallick.github.io/sigmap/"
@@ -20,7 +20,7 @@ head:
       content: "SigMap — grounded AI coding context"
   - - meta
     - name: twitter:description
-      content: "Ask, validate, judge, and learn from real code context. 81.1% hit@5, 41.8% fewer prompts, 96.5% overall token reduction."
+      content: "Ask, validate, judge, and learn from real code context. 75.6% hit@5, 39.0% fewer prompts, 97.1% overall token reduction."
   - - meta
     - name: twitter:image:alt
       content: "SigMap — zero-dependency AI context engine"
@@ -31,7 +31,7 @@ head:
 hero:
   name: SigMap
   text: Better context. More grounded answers.
-  tagline: "Zero-dependency AI context engine. 81.1% hit@5 · 96.5% token reduction · Ask → Validate → Judge → Learn."
+  tagline: "Zero-dependency AI context engine. 75.6% hit@5 · 97.1% token reduction · Ask → Validate → Judge → Learn."
   actions:
     - theme: brand
       text: Get Started →
@@ -46,12 +46,12 @@ hero:
 features:
   - icon: 💬
     title: Fewer prompts to finish the task
-    details: "Latest saved run: 2.84 prompts without SigMap vs 1.66 with SigMap. That is a 41.8% reduction across 90 real coding tasks."
+    details: "Latest saved run: 2.84 prompts without SigMap vs 1.73 with SigMap. That is a 39.0% reduction across 90 real coding tasks."
     link: /guide/task-benchmark
     linkText: Task benchmark →
   - icon: 🎯
     title: Right file in context
-    details: 81.1% hit@5 across 21 repos and 90 tasks. Random selection finds the right file only 13.6% of the time.
+    details: 75.6% hit@5 across 21 repos and 90 tasks. Random selection finds the right file only 13.6% of the time.
     link: /guide/retrieval-benchmark
     linkText: Retrieval benchmark →
   - icon: ⚖️
@@ -78,14 +78,14 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v6.14.0</span>
+  <span><strong>Release:</strong> v6.15.0</span>
   <span>·</span>
-  <span>verify-ai-output — Hallucination Guard prototype</span>
+  <span>verify-ai-output Reliable MVP + Memory tools (note · status · read_memory)</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
-  <span><strong>Benchmark:</strong> sigmap-v6.13-main</span>
+  <span><strong>Benchmark:</strong> sigmap-v6.15-main</span>
   <span>·</span>
-  <span>81% hit@5 · 96.5% token reduction · 2026-06-05</span>
+  <span>76% hit@5 · 97.1% token reduction · 2026-06-09</span>
 </div>
 </div>
 
@@ -170,13 +170,13 @@ See the full [end-to-end walkthrough](/guide/walkthrough) to watch this in actio
 
 | Metric | Without SigMap | With SigMap |
 |---|:---:|:---:|
-| Task success proxy | 10% | **53.3%** |
-| Prompts per task | 2.84 | **1.66** |
-| Retrieval hit@5 | 13.6% | **81%** (81% graph-boosted) |
-| Overall token reduction | — | **96.5%** |
+| Task success proxy | 10% | **51.1%** |
+| Prompts per task | 2.84 | **1.73** |
+| Retrieval hit@5 | 13.6% | **76%** (76% graph-boosted) |
+| Overall token reduction | — | **97.1%** |
 | GPT-4o overflow repos | 16/21 | **0/21** |
 
-Latest saved benchmark run: **2026-06-05 (v6.13.0)**.
+Latest saved benchmark run: **2026-06-09 (v6.15.0)**.
 
 </div>
 

--- a/docs/comparison-chart.svg
+++ b/docs/comparison-chart.svg
@@ -30,13 +30,13 @@
   <!-- With row -->
   <text x="105" y="126" text-anchor="end" font-size="11" fill="#7c6af7">SigMap</text>
   <rect x="112" y="113" width="462" height="20" fill="#ede9fe" rx="4"/>
-  <!-- 81.1% of 462 = 374.7 -->
-  <rect x="112" y="113" width="375" height="20" fill="#7c6af7" rx="4"/>
-  <text x="492" y="127" text-anchor="end" font-size="11" font-weight="700" fill="#fff">81.1%</text>
+  <!-- 75.6% of 462 = 349.3 -->
+  <rect x="112" y="113" width="349" height="20" fill="#7c6af7" rx="4"/>
+  <text x="466" y="127" text-anchor="end" font-size="11" font-weight="700" fill="#fff">75.6%</text>
 
   <!-- Badge -->
   <rect x="588" y="95" width="94" height="32" fill="#7c6af7" rx="6"/>
-  <text x="635" y="108" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">+6.0× lift</text>
+  <text x="635" y="108" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">+5.6× lift</text>
   <text x="635" y="121" text-anchor="middle" font-size="9" fill="#ded9ff">retrieval</text>
 
   <!-- ═══════════════════════════════════════════ -->
@@ -54,13 +54,13 @@
   <!-- With row -->
   <text x="105" y="196" text-anchor="end" font-size="11" fill="#22c55e">SigMap</text>
   <rect x="112" y="183" width="462" height="20" fill="#dcfce7" rx="4"/>
-  <!-- 53.3% of 462 = 246.2 -->
-  <rect x="112" y="183" width="246" height="20" fill="#22c55e" rx="4"/>
-  <text x="352" y="197" text-anchor="end" font-size="11" font-weight="700" fill="#fff">53.3%</text>
+  <!-- 51.1% of 462 = 236.1 -->
+  <rect x="112" y="183" width="236" height="20" fill="#22c55e" rx="4"/>
+  <text x="342" y="197" text-anchor="end" font-size="11" font-weight="700" fill="#fff">51.1%</text>
 
   <!-- Badge -->
   <rect x="588" y="165" width="94" height="32" fill="#22c55e" rx="6"/>
-  <text x="635" y="178" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">×5.3 better</text>
+  <text x="635" y="178" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">×5.1 better</text>
   <text x="635" y="191" text-anchor="middle" font-size="9" fill="#bbf7d0">correctness</text>
 
   <!-- ═══════════════════════════════════════════ -->

--- a/docs/impact-banner.svg
+++ b/docs/impact-banner.svg
@@ -34,12 +34,12 @@
 
   <!-- STAT CARDS -->
 
-  <!-- Card 1: 5.3x -->
+  <!-- Card 1: 5.1x -->
   <rect x="22" y="56" width="228" height="116" rx="10" fill="#0f0a24" stroke="#3a2b88" stroke-width="1.5"/>
   <rect x="22" y="56" width="228" height="116" rx="10" fill="url(#cardglow)"/>
-  <text x="136" y="122" text-anchor="middle" font-size="64" font-weight="900" fill="#7c6af7">5.3x</text>
+  <text x="136" y="122" text-anchor="middle" font-size="64" font-weight="900" fill="#7c6af7">5.1x</text>
   <text x="136" y="142" text-anchor="middle" font-size="13" font-weight="700" fill="#b8adff">better answers</text>
-  <text x="136" y="161" text-anchor="middle" font-size="11" fill="#5b4fcc">correct: 10% to 53.3%</text>
+  <text x="136" y="161" text-anchor="middle" font-size="11" fill="#5b4fcc">correct: 10% to 51.1%</text>
 
   <!-- Card 2: 98.1% -->
   <rect x="266" y="56" width="228" height="116" rx="10" fill="#071a10" stroke="#155228" stroke-width="1.5"/>
@@ -48,12 +48,12 @@
   <text x="380" y="142" text-anchor="middle" font-size="13" font-weight="700" fill="#7de8a4">fewer tokens</text>
   <text x="380" y="161" text-anchor="middle" font-size="11" fill="#236b3a">80,000 to 2,000 / session</text>
 
-  <!-- Card 3: 41.8% -->
+  <!-- Card 3: 39.0% -->
   <rect x="510" y="56" width="228" height="116" rx="10" fill="#1a1100" stroke="#5a3b00" stroke-width="1.5"/>
   <rect x="510" y="56" width="228" height="116" rx="10" fill="url(#cardglow)"/>
-  <text x="624" y="122" text-anchor="middle" font-size="52" font-weight="900" fill="#f59e0b">41.8%</text>
+  <text x="624" y="122" text-anchor="middle" font-size="52" font-weight="900" fill="#f59e0b">39.0%</text>
   <text x="624" y="142" text-anchor="middle" font-size="13" font-weight="700" fill="#fcd28a">fewer prompts</text>
-  <text x="624" y="161" text-anchor="middle" font-size="11" fill="#7a5500">2.84 to 1.66 per task</text>
+  <text x="624" y="161" text-anchor="middle" font-size="11" fill="#7a5500">2.84 to 1.73 per task</text>
 
   <!-- DIVIDER -->
   <line x1="22" y1="192" x2="738" y2="192" stroke="#1e1440" stroke-width="1"/>
@@ -78,11 +78,11 @@
   <text x="402" y="237" font-size="12.5" fill="#86efac">+  Every function fully indexed</text>
   <text x="402" y="257" font-size="12.5" fill="#86efac">+  Right file in context, first prompt</text>
   <text x="402" y="277" font-size="12.5" fill="#86efac">+  1-2 prompts. Grounded answer.</text>
-  <text x="402" y="297" font-size="12.5" fill="#86efac">+  81.1% hit@5 on real repo tasks</text>
+  <text x="402" y="297" font-size="12.5" fill="#86efac">+  75.6% hit@5 on real repo tasks</text>
   <text x="402" y="320" font-size="10" fill="#1a4a2a">TASK SUCCESS</text>
   <rect x="402" y="326" width="320" height="17" fill="#071a0e" rx="4"/>
-  <rect x="402" y="326" width="171" height="17" fill="#22c55e" rx="4"/>
-  <text x="574" y="338" font-size="12" font-weight="800" fill="#22c55e">53.3% -- 5.3x better</text>
+  <rect x="402" y="326" width="164" height="17" fill="#22c55e" rx="4"/>
+  <text x="574" y="338" font-size="12" font-weight="800" fill="#22c55e">51.1% -- 5.1x better</text>
 
   <!-- FOOTER -->
   <line x1="22" y1="363" x2="738" y2="363" stroke="#1e1440" stroke-width="1"/>

--- a/gen-context.js
+++ b/gen-context.js
@@ -5506,476 +5506,559 @@ __factories["./src/graph/impact"] = function(module, exports) {
 
 // ── ./src/mcp/handlers ──
 __factories["./src/mcp/handlers"] = function(module, exports) {
-  
-  const fs   = require('fs');
-  const path = require('path');
-  const { execSync } = require('child_process');
-  
-  const CONTEXT_FILE = path.join('.github', 'copilot-instructions.md');
-  
-  // Section header keywords in PROJECT_MAP.md
-  const MAP_SECTIONS = {
-    imports: '### Import graph',
-    classes: '### Class hierarchy',
-    routes: '### Route table',
-  };
-  
-  /**
-   * read_context({ module? }) → string
-   *
-   * Returns the full context file, or just the sections whose file paths
-   * contain the given module substring.
-   */
-  function readContext(args, cwd) {
-    const contextPath = path.join(cwd, CONTEXT_FILE);
-    if (!fs.existsSync(contextPath)) {
-      return 'No context file found. Run: node gen-context.js';
-    }
-  
-    const content = fs.readFileSync(contextPath, 'utf8');
-  
-    if (!args || !args.module) return content;
-  
-    const mod = args.module.replace(/\\/g, '/').replace(/\/$/, '');
-    const lines = content.split('\n');
-    const result = [];
-    let capturing = false;
-  
-    for (const line of lines) {
-      if (line.startsWith('### ')) {
-        const filePath = line.slice(4).trim().replace(/\\/g, '/');
-        // Match if file path starts with mod or contains /mod/ or /mod
-        capturing =
-          filePath === mod ||
-          filePath.startsWith(mod + '/') ||
-          filePath.includes('/' + mod + '/') ||
-          filePath.includes('/' + mod);
-        if (capturing) result.push(line);
-        continue;
-      }
-      if (capturing) result.push(line);
-    }
-  
-    if (result.length === 0) return `No signatures found for module: ${mod}`;
-    return result.join('\n');
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const CONTEXT_FILE = path.join('.github', 'copilot-instructions.md');
+const CONTEXT_COLD_FILE = path.join('.github', 'context-cold.md');
+
+function _readContextFiles(cwd) {
+  const paths = [path.join(cwd, CONTEXT_FILE), path.join(cwd, CONTEXT_COLD_FILE)];
+  const chunks = [];
+  for (const p of paths) {
+    if (fs.existsSync(p)) chunks.push(fs.readFileSync(p, 'utf8'));
   }
-  
-  /**
-   * search_signatures({ query }) → string
-   *
-   * Case-insensitive search through all signature lines.
-   * Returns matching lines grouped by file path.
-   */
-  function searchSignatures(args, cwd) {
-    if (!args || !args.query) return 'Missing required argument: query';
-    const query = args.query.toLowerCase();
+  return chunks.join('\n');
+}
 
-    try {
-      const { buildSigIndex } = __require('./src/retrieval/ranker');
-      const index = buildSigIndex(cwd);
-      if (index.size === 0) {
-        return 'No context file found. Run: node gen-context.js';
-      }
-
-      const result = [];
-      for (const [file, sigs] of index.entries()) {
-        const hits = sigs.filter((s) => s.toLowerCase().includes(query));
-        if (hits.length === 0) continue;
-        if (result.length > 0) result.push('');
-        result.push(`### ${file}`);
-        result.push(...hits);
-      }
-
-      if (result.length === 0) return `No signatures found matching: ${args.query}`;
-      return result.join('\n');
-    } catch (err) {
-      return `_search_signatures failed: ${err.message}_`;
-    }
-  }
-  
-  /**
-   * get_map({ type }) → string
-   *
-   * Returns a section from PROJECT_MAP.md.
-   * type: 'imports' | 'classes' | 'routes'
-   */
-  function getMap(args, cwd) {
-    if (!args || !args.type) return 'Missing required argument: type';
-  
-    const header = MAP_SECTIONS[args.type];
-    if (!header) {
-      return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
-    }
-  
-    const mapPath = path.join(cwd, 'PROJECT_MAP.md');
-    if (!fs.existsSync(mapPath)) {
-      return 'PROJECT_MAP.md not found. Run: node gen-project-map.js';
-    }
-  
-    const content = fs.readFileSync(mapPath, 'utf8');
-    const idx = content.indexOf(header);
-    if (idx === -1) {
-      return `Section "${header}" not found in PROJECT_MAP.md`;
-    }
-  
-    // Extract from this header to the next ### header
-    const after = content.slice(idx);
-    const nextMatch = after.slice(header.length).search(/\n###\s/);
-    return nextMatch === -1 ? after : after.slice(0, header.length + nextMatch);
-  }
-  
-  /**
-   * create_checkpoint({ note? }) → string
-   *
-   * Returns a markdown checkpoint summarising current project state:
-   * - Timestamp and optional user note
-   * - Active git branch + last 5 commit messages
-   * - Token count of current context file
-   * - List of modules present in the context
-   * - Route count (if PROJECT_MAP.md exists)
-   */
-  function createCheckpoint(args, cwd) {
-    const note = (args && args.note) ? args.note.trim() : '';
-    const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
-    const lines = [
-      '# SigMap Checkpoint',
-      `**Created:** ${now}`,
-    ];
-  
-    if (note) lines.push(`**Note:** ${note}`);
-    lines.push('');
-  
-    // ── Git info ────────────────────────────────────────────────────────────
-    lines.push('## Git state');
-    try {
-      const branch = execSync('git rev-parse --abbrev-ref HEAD', {
-        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      lines.push(`**Branch:** ${branch}`);
-    } catch (_) {
-      lines.push('**Branch:** (not a git repo)');
-    }
-  
-    try {
-      const log = execSync(
-        'git log --oneline -5 --no-decorate 2>/dev/null',
-        { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-      ).trim();
-      if (log) {
-        lines.push('');
-        lines.push('**Recent commits:**');
-        for (const l of log.split('\n')) lines.push(`- ${l}`);
-      }
-    } catch (_) {} // ignore — not every project uses git
-    lines.push('');
-  
-    // ── Context stats ────────────────────────────────────────────────────────
-    lines.push('## Context snapshot');
-    const contextPath = path.join(cwd, CONTEXT_FILE);
-    if (fs.existsSync(contextPath)) {
-      const content = fs.readFileSync(contextPath, 'utf8');
-      const tokens = Math.ceil(content.length / 4);
-  
-      // Count modules (### headers are file paths)
-      const modules = content.split('\n').filter((l) => l.startsWith('### ')).map((l) => l.slice(4).trim());
-      lines.push(`**Token count:** ~${tokens}`);
-      lines.push(`**Modules in context:** ${modules.length}`);
-  
-      if (modules.length > 0) {
-        lines.push('');
-        lines.push('**Modules:**');
-        for (const m of modules.slice(0, 20)) lines.push(`- ${m}`);
-        if (modules.length > 20) lines.push(`- … and ${modules.length - 20} more`);
-      }
-    } else {
-      lines.push('_No context file found. Run: node gen-context.js_');
-    }
-    lines.push('');
-  
-    // ── Route summary ────────────────────────────────────────────────────────
-    const mapPath = path.join(cwd, 'PROJECT_MAP.md');
-    if (fs.existsSync(mapPath)) {
-      const mapContent = fs.readFileSync(mapPath, 'utf8');
-      const routeLines = mapContent.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---'));
-      if (routeLines.length > 0) {
-        lines.push('## Routes');
-        lines.push(`**Total routes detected:** ${routeLines.length}`);
-        lines.push('');
-        for (const r of routeLines.slice(0, 10)) lines.push(r);
-        if (routeLines.length > 10) lines.push(`| … | +${routeLines.length - 10} more | |`);
-        lines.push('');
-      }
-    }
-  
-    lines.push('---');
-    lines.push('_Generated by SigMap `create_checkpoint`_');
-  
-    return lines.join('\n');
-  }
-  
-  /**
-   * get_routing({}) → string
-   *
-   * Reads the current context file, classifies all indexed files by complexity,
-   * and returns a formatted markdown routing guide showing which files belong
-   * to the fast/balanced/powerful model tier.
-   */
-  function getRouting(args, cwd) {
-    const contextPath = path.join(cwd, CONTEXT_FILE);
-    if (!fs.existsSync(contextPath)) {
-      return (
-        '_No context file found. Run `node gen-context.js --routing` first._\n\n' +
-        'This generates routing hints that map each file to a model tier:\n' +
-        '- **fast** (haiku/gpt-4o-mini) — config, markup, trivial utilities\n' +
-        '- **balanced** (sonnet/gpt-4o) — standard application code\n' +
-        '- **powerful** (opus/gpt-4-turbo) — complex, security-critical, or large modules'
-      );
-    }
-  
-    // Parse file list from context (### headings are file paths)
-    const content = fs.readFileSync(contextPath, 'utf8');
-    const fileRels = content.split('\n')
-      .filter((l) => l.startsWith('### '))
-      .map((l) => l.slice(4).trim());
-  
-    // Build synthetic fileEntries for the classifier
-    // We don't have live sig arrays here, so rebuild from the context blocks
-    const entries = [];
-    const blocks = content.split(/^### /m).slice(1); // slice past the header
-    for (const block of blocks) {
-      const firstLine = block.split('\n')[0].trim();
-      const codeBlock = block.match(/```\n([\s\S]*?)```/);
-      const sigs = codeBlock ? codeBlock[1].trim().split('\n').filter(Boolean) : [];
-      entries.push({ filePath: path.join(cwd, firstLine), sigs });
-    }
-  
-    try {
-      const { classifyAll } = __require('./src/routing/classifier');
-      const { formatRoutingSection } = __require('./src/routing/hints');
-      const groups = classifyAll(entries, cwd);
-      return formatRoutingSection(groups);
-    } catch (err) {
-      return `_Routing classification failed: ${err.message}_`;
-    }
-  }
-  
-  function explainFile(args, cwd) {
-    if (!args || !args.path) return 'Missing required argument: path';
-  
-    const targetRel = args.path.replace(/\\/g, '/').replace(/^\//, '');
-    const targetAbs = path.resolve(cwd, targetRel);
-    const contextPath = path.join(cwd, CONTEXT_FILE);
-  
-    const lines = ['# explain_file: ' + targetRel, ''];
-  
-    lines.push('## Signatures');
-    let indexedFiles = [];
-  
-    if (fs.existsSync(contextPath)) {
-      const ctxContent = fs.readFileSync(contextPath, 'utf8');
-      const ctxLines = ctxContent.split('\n');
-      let capturing = false;
-      const sigLines = [];
-  
-      for (const line of ctxLines) {
-        if (line.startsWith('### ')) {
-          if (capturing) break;
-          const rel = line.slice(4).trim().replace(/\\/g, '/');
-          capturing = rel === targetRel || rel.endsWith('/' + targetRel) || targetRel.endsWith('/' + rel);
-          if (capturing) continue;
-        } else if (capturing) {
-          sigLines.push(line);
-        }
-      }
-  
-      const sigs = sigLines.filter((l) => l !== '```' && l.trim() !== '');
-      if (sigs.length > 0) {
-        lines.push(...sigs);
-      } else {
-        lines.push('_No signatures indexed for this file. Run: node gen-context.js_');
-      }
-  
-      indexedFiles = ctxContent
-        .split('\n')
-        .filter((l) => l.startsWith('### '))
-        .map((l) => path.resolve(cwd, l.slice(4).trim()));
-    } else {
-      lines.push('_No context file found. Run: node gen-context.js_');
-    }
-  
-    if (!fs.existsSync(targetAbs)) {
-      lines.push('');
-      lines.push('> File not found on disk: ' + targetRel);
-      return lines.join('\n');
-    }
-  
-    lines.push('');
-  
-    lines.push('## Imports (direct dependencies)');
-    try {
-      const { extractImports } = __require('./src/map/import-graph');
-      const fileContent = fs.readFileSync(targetAbs, 'utf8');
-      const fileSet = new Set(indexedFiles);
-      fileSet.add(targetAbs);
-      const imports = extractImports(targetAbs, fileContent, fileSet);
-      if (imports.length > 0) {
-        for (const imp of imports) lines.push('- ' + path.relative(cwd, imp).replace(/\\/g, '/'));
-      } else {
-        lines.push('_No resolvable relative imports found._');
-      }
-    } catch (err) {
-      lines.push('_Could not analyze imports: ' + err.message + '_');
-    }
-  
-    lines.push('');
-  
-    lines.push('## Callers (files that import this file)');
-    try {
-      const { extractImports } = __require('./src/map/import-graph');
-      const fileSet = new Set(indexedFiles);
-      fileSet.add(targetAbs);
-      const callers = [];
-      for (const f of indexedFiles) {
-        if (f === targetAbs || !fs.existsSync(f)) continue;
-        try {
-          const fc = fs.readFileSync(f, 'utf8');
-          const imps = extractImports(f, fc, fileSet);
-          if (imps.includes(targetAbs)) callers.push(path.relative(cwd, f).replace(/\\/g, '/'));
-        } catch (_) {}
-      }
-      if (callers.length > 0) {
-        for (const c of callers) lines.push('- ' + c);
-      } else {
-        lines.push('_No indexed files import this file._');
-      }
-    } catch (err) {
-      lines.push('_Could not analyze callers: ' + err.message + '_');
-    }
-  
-    return lines.join('\n');
-  }
-  
-  function listModules(args, cwd) {
-    try {
-      const { buildSigIndex } = __require('./src/retrieval/ranker');
-      const index = buildSigIndex(cwd);
-      if (index.size === 0) {
-        return 'No context file found. Run: node gen-context.js';
-      }
-
-      const groups = {};
-      for (const [rel, sigs] of index.entries()) {
-        const parts = rel.split('/');
-        const mod = parts.length > 1 ? parts[0] : '.';
-        if (!groups[mod]) groups[mod] = { fileCount: 0, tokenCount: 0 };
-        groups[mod].fileCount++;
-        groups[mod].tokenCount += Math.ceil(sigs.join('\n').length / 4);
-      }
-
-      const sorted = Object.entries(groups)
-        .map(([mod, data]) => ({ module: mod, fileCount: data.fileCount, tokenCount: data.tokenCount }))
-        .sort((a, b) => b.tokenCount - a.tokenCount);
-
-      if (sorted.length === 0) return 'No modules found in context file.';
-
-      const total = sorted.reduce((s, m) => s + m.tokenCount, 0);
-
-      return [
-        '# Modules',
-        '',
-        '| Module | Files | Tokens |',
-        '|--------|-------|--------|',
-        ...sorted.map((m) => `| ${m.module} | ${m.fileCount} | ~${m.tokenCount} |`),
-        '',
-        `**Total context tokens: ~${total}**`,
-        '',
-        '_Use `read_context({ module: "name" })` to get signatures for a specific module._',
-      ].join('\n');
-    } catch (err) {
-      return `_list_modules failed: ${err.message}_`;
-    }
-  }
-  
-  function queryContext(args, cwd) {
-    if (!args || !args.query) return 'Missing required argument: query';
-    const contextPath = path.join(cwd, CONTEXT_FILE);
-    if (!fs.existsSync(contextPath)) return 'No context file found. Run: node gen-context.js';
-    try {
-      const { rank, buildSigIndex, formatRankTable } = __require('./src/retrieval/ranker');
-      const index = buildSigIndex(cwd);
-      if (index.size === 0) return 'No signatures indexed. Run: node gen-context.js';
-      const topK = Math.min(Math.max(1, parseInt(args.topK, 10) || 10), 25);
-      const results = rank(args.query, index, { topK, cwd });
-      return formatRankTable(results, args.query);
-    } catch (err) {
-      return `_query_context failed: ${err.message}_`;
-    }
-  }
-  
-  function getImpact(args, cwd) {
-    if (!args || !args.file) return 'Missing required argument: file';
-    try {
-      const { analyzeImpact, formatImpact } = __require('./src/graph/impact');
-      const depth = Math.max(0, parseInt(args.depth, 10) || 3);
-      const results = analyzeImpact(args.file, cwd, { depth });
-      return results.map((r) => formatImpact(r.impact)).join('\n\n---\n\n');
-    } catch (err) {
-      return `_get_impact failed: ${err.message}_`;
-    }
-  }
-
-  function getLines(args, cwd) {
-    if (!args || !args.file) return 'Missing required argument: file';
-
-    const rel = String(args.file).replace(/\\/g, '/').replace(/^\//, '');
-    const abs = path.resolve(cwd, rel);
-
-    // Sandbox: refuse paths that resolve outside the project root.
-    const root = path.resolve(cwd);
-    if (abs !== root && !abs.startsWith(root + path.sep)) {
-      return `Refused: ${rel} resolves outside the project root`;
-    }
-    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
-      return `File not found: ${rel}`;
-    }
-
-    const start = parseInt(args.start, 10);
-    const end = parseInt(args.end, 10);
-    if (!Number.isFinite(start) || !Number.isFinite(end)) {
-      return 'Arguments "start" and "end" must be numbers (1-based line numbers).';
-    }
-
-    let lines;
-    try {
-      lines = fs.readFileSync(abs, 'utf8').split('\n');
-    } catch (err) {
-      return `Could not read ${rel}: ${err.message}`;
-    }
-
-    const total = lines.length;
-    const from = Math.max(1, Math.min(start, end));
-    const to = Math.min(total, Math.max(start, end));
-    if (from > total) return `${rel} has only ${total} lines; requested ${start}-${end}`;
-
-    const slice = lines.slice(from - 1, to);
-
-    let safeLines = slice;
-    try {
-      const { scan } = __require('./src/security/scanner');
-      safeLines = scan(slice, rel).safe;
-    } catch (_) {}
-
-    return [
-      `# ${rel}:${from}-${to}`,
-      '```',
-      ...safeLines,
-      '```',
-    ].join('\n');
-  }
-
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines };
+// Section header keywords in PROJECT_MAP.md
+const MAP_SECTIONS = {
+  imports: '### Import graph',
+  classes: '### Class hierarchy',
+  routes: '### Route table',
 };
 
+/**
+ * read_context({ module? }) → string
+ *
+ * Returns the full context file, or just the sections whose file paths
+ * contain the given module substring.
+ */
+function readContext(args, cwd) {
+  const content = _readContextFiles(cwd);
+  if (!content) {
+    return 'No context file found. Run: node gen-context.js';
+  }
+
+  if (!args || !args.module) return content;
+
+  const mod = args.module.replace(/\\/g, '/').replace(/\/$/, '');
+  const lines = content.split('\n');
+  const result = [];
+  let capturing = false;
+
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      const filePath = line.slice(4).trim().replace(/\\/g, '/');
+      // Match if file path starts with mod or contains /mod/ or /mod
+      capturing =
+        filePath === mod ||
+        filePath.startsWith(mod + '/') ||
+        filePath.includes('/' + mod + '/') ||
+        filePath.includes('/' + mod);
+      if (capturing) result.push(line);
+      continue;
+    }
+    if (capturing) result.push(line);
+  }
+
+  if (result.length === 0) return `No signatures found for module: ${mod}`;
+  return result.join('\n');
+}
+
+/**
+ * search_signatures({ query }) → string
+ *
+ * Case-insensitive search through all signature lines.
+ * Returns matching lines grouped by file path.
+ */
+function searchSignatures(args, cwd) {
+  if (!args || !args.query) return 'Missing required argument: query';
+
+  const query = args.query.toLowerCase();
+  try {
+    const { buildSigIndex } = __require('./src/retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) {
+      return 'No context file found. Run: node gen-context.js';
+    }
+
+    const result = [];
+    for (const [file, sigs] of index.entries()) {
+      const hits = sigs.filter((s) => s.toLowerCase().includes(query));
+      if (hits.length === 0) continue;
+      if (result.length > 0) result.push('');
+      result.push(`### ${file}`);
+      result.push(...hits);
+    }
+
+    if (result.length === 0) return `No signatures found matching: ${args.query}`;
+    return result.join('\n');
+  } catch (err) {
+    return `_search_signatures failed: ${err.message}_`;
+  }
+}
+
+/**
+ * get_map({ type }) → string
+ *
+ * Returns a section from PROJECT_MAP.md.
+ * type: 'imports' | 'classes' | 'routes'
+ */
+function getMap(args, cwd) {
+  if (!args || !args.type) return 'Missing required argument: type';
+
+  const header = MAP_SECTIONS[args.type];
+  if (!header) {
+    return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
+  }
+
+  const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+  if (!fs.existsSync(mapPath)) {
+    return 'PROJECT_MAP.md not found. Run: node gen-project-map.js';
+  }
+
+  const content = fs.readFileSync(mapPath, 'utf8');
+  const idx = content.indexOf(header);
+  if (idx === -1) {
+    return `Section "${header}" not found in PROJECT_MAP.md`;
+  }
+
+  // Extract from this header to the next ### header
+  const after = content.slice(idx);
+  const nextMatch = after.slice(header.length).search(/\n###\s/);
+  return nextMatch === -1 ? after : after.slice(0, header.length + nextMatch);
+}
+
+/**
+ * create_checkpoint({ note? }) → string
+ *
+ * Returns a markdown checkpoint summarising current project state:
+ * - Timestamp and optional user note
+ * - Active git branch + last 5 commit messages
+ * - Token count of current context file
+ * - List of modules present in the context
+ * - Route count (if PROJECT_MAP.md exists)
+ */
+function createCheckpoint(args, cwd) {
+  const note = (args && args.note) ? args.note.trim() : '';
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  const lines = [
+    '# SigMap Checkpoint',
+    `**Created:** ${now}`,
+  ];
+
+  if (note) lines.push(`**Note:** ${note}`);
+  lines.push('');
+
+  // ── Git info ────────────────────────────────────────────────────────────
+  lines.push('## Git state');
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    lines.push(`**Branch:** ${branch}`);
+  } catch (_) {
+    lines.push('**Branch:** (not a git repo)');
+  }
+
+  try {
+    const log = execSync(
+      'git log --oneline -5 --no-decorate 2>/dev/null',
+      { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    if (log) {
+      lines.push('');
+      lines.push('**Recent commits:**');
+      for (const l of log.split('\n')) lines.push(`- ${l}`);
+    }
+  } catch (_) {} // ignore — not every project uses git
+  lines.push('');
+
+  // ── Context stats ────────────────────────────────────────────────────────
+  lines.push('## Context snapshot');
+  const contextPath = path.join(cwd, CONTEXT_FILE);
+  if (fs.existsSync(contextPath)) {
+    const content = fs.readFileSync(contextPath, 'utf8');
+    const tokens = Math.ceil(content.length / 4);
+
+    // Count modules (### headers are file paths)
+    const modules = content.split('\n').filter((l) => l.startsWith('### ')).map((l) => l.slice(4).trim());
+    lines.push(`**Token count:** ~${tokens}`);
+    lines.push(`**Modules in context:** ${modules.length}`);
+
+    if (modules.length > 0) {
+      lines.push('');
+      lines.push('**Modules:**');
+      for (const m of modules.slice(0, 20)) lines.push(`- ${m}`);
+      if (modules.length > 20) lines.push(`- … and ${modules.length - 20} more`);
+    }
+  } else {
+    lines.push('_No context file found. Run: node gen-context.js_');
+  }
+  lines.push('');
+
+  // ── Route summary ────────────────────────────────────────────────────────
+  const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+  if (fs.existsSync(mapPath)) {
+    const mapContent = fs.readFileSync(mapPath, 'utf8');
+    const routeLines = mapContent.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---'));
+    if (routeLines.length > 0) {
+      lines.push('## Routes');
+      lines.push(`**Total routes detected:** ${routeLines.length}`);
+      lines.push('');
+      for (const r of routeLines.slice(0, 10)) lines.push(r);
+      if (routeLines.length > 10) lines.push(`| … | +${routeLines.length - 10} more | |`);
+      lines.push('');
+    }
+  }
+
+  lines.push('---');
+  lines.push('_Generated by SigMap `create_checkpoint`_');
+
+  return lines.join('\n');
+}
+
+/**
+ * get_routing({}) → string
+ *
+ * Reads the current context file, classifies all indexed files by complexity,
+ * and returns a formatted markdown routing guide showing which files belong
+ * to the fast/balanced/powerful model tier.
+ */
+function getRouting(args, cwd) {
+  const contextPath = path.join(cwd, CONTEXT_FILE);
+  if (!fs.existsSync(contextPath)) {
+    return (
+      '_No context file found. Run `node gen-context.js --routing` first._\n\n' +
+      'This generates routing hints that map each file to a model tier:\n' +
+      '- **fast** (haiku/gpt-4o-mini) — config, markup, trivial utilities\n' +
+      '- **balanced** (sonnet/gpt-4o) — standard application code\n' +
+      '- **powerful** (opus/gpt-4-turbo) — complex, security-critical, or large modules'
+    );
+  }
+
+  // Parse file list from context (### headings are file paths)
+  const content = fs.readFileSync(contextPath, 'utf8');
+  const fileRels = content.split('\n')
+    .filter((l) => l.startsWith('### '))
+    .map((l) => l.slice(4).trim());
+
+  // Build synthetic fileEntries for the classifier
+  // We don't have live sig arrays here, so rebuild from the context blocks
+  const entries = [];
+  const blocks = content.split(/^### /m).slice(1); // slice past the header
+  for (const block of blocks) {
+    const firstLine = block.split('\n')[0].trim();
+    const codeBlock = block.match(/```\n([\s\S]*?)```/);
+    const sigs = codeBlock ? codeBlock[1].trim().split('\n').filter(Boolean) : [];
+    entries.push({ filePath: path.join(cwd, firstLine), sigs });
+  }
+
+  try {
+    const { classifyAll } = __require('./src/routing/classifier');
+    const { formatRoutingSection } = __require('./src/routing/hints');
+    const groups = classifyAll(entries, cwd);
+    return formatRoutingSection(groups);
+  } catch (err) {
+    return `_Routing classification failed: ${err.message}_`;
+  }
+}
+
+/**
+ * explain_file({ path }) → string
+ *
+ * Returns a file's signatures, its direct imports, and files that import it.
+ * path: relative path from project root (e.g. 'src/services/auth.ts')
+ */
+function explainFile(args, cwd) {
+  if (!args || !args.path) return 'Missing required argument: path';
+
+  const targetRel = args.path.replace(/\\/g, '/').replace(/^\//, '');
+  const targetAbs = path.resolve(cwd, targetRel);
+  const contextPath = path.join(cwd, CONTEXT_FILE);
+
+  const lines = ['# explain_file: ' + targetRel, ''];
+
+  // ── Signatures (hot + cold + cache via buildSigIndex) ───────────────────
+  lines.push('## Signatures');
+  let indexedFiles = [];
+
+  try {
+    const { buildSigIndex } = __require('./src/retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    let sigs = index.get(targetRel);
+    if (!sigs) {
+      for (const [file, fileSigs] of index.entries()) {
+        if (file === targetRel || file.endsWith('/' + targetRel) || targetRel.endsWith('/' + file)) {
+          sigs = fileSigs;
+          break;
+        }
+      }
+    }
+    if (sigs && sigs.length > 0) {
+      lines.push(...sigs);
+    } else {
+      lines.push('_No signatures indexed for this file. Run: node gen-context.js_');
+    }
+    indexedFiles = [...index.keys()].map((rel) => path.resolve(cwd, rel));
+  } catch (_) {
+    lines.push('_No context file found. Run: node gen-context.js_');
+  }
+
+  if (!fs.existsSync(targetAbs)) {
+    lines.push('');
+    lines.push('> File not found on disk: ' + targetRel);
+    return lines.join('\n');
+  }
+
+  lines.push('');
+
+  // ── Direct imports ────────────────────────────────────────────────────────
+  lines.push('## Imports (direct dependencies)');
+  try {
+    const { extractImports } = __require('./src/map/import-graph');
+    const fileContent = fs.readFileSync(targetAbs, 'utf8');
+    const fileSet = new Set(indexedFiles);
+    fileSet.add(targetAbs);
+    const imports = extractImports(targetAbs, fileContent, fileSet);
+    if (imports.length > 0) {
+      for (const imp of imports) lines.push('- ' + path.relative(cwd, imp).replace(/\\/g, '/'));
+    } else {
+      lines.push('_No resolvable relative imports found._');
+    }
+  } catch (err) {
+    lines.push('_Could not analyze imports: ' + err.message + '_');
+  }
+
+  lines.push('');
+
+  // ── Callers (reverse-import lookup) ──────────────────────────────────────
+  lines.push('## Callers (files that import this file)');
+  try {
+    const { extractImports } = __require('./src/map/import-graph');
+    const fileSet = new Set(indexedFiles);
+    fileSet.add(targetAbs);
+    const callers = [];
+    for (const f of indexedFiles) {
+      if (f === targetAbs || !fs.existsSync(f)) continue;
+      try {
+        const fc = fs.readFileSync(f, 'utf8');
+        const imps = extractImports(f, fc, fileSet);
+        if (imps.includes(targetAbs)) callers.push(path.relative(cwd, f).replace(/\\/g, '/'));
+      } catch (_) {}
+    }
+    if (callers.length > 0) {
+      for (const c of callers) lines.push('- ' + c);
+    } else {
+      lines.push('_No indexed files import this file._');
+    }
+  } catch (err) {
+    lines.push('_Could not analyze callers: ' + err.message + '_');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * list_modules({}) → string
+ *
+ * Lists all srcDir modules present in the context file, sorted by token count
+ * descending. Helps agents decide which module to query with read_context.
+ */
+function listModules(args, cwd) {
+  try {
+    const { buildSigIndex } = __require('./src/retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) {
+      return 'No context file found. Run: node gen-context.js';
+    }
+
+    const groups = {};
+    for (const [rel, sigs] of index.entries()) {
+      const parts = rel.replace(/\\/g, '/').split('/');
+      const mod = parts.length > 1 ? parts[0] : '.';
+      if (!groups[mod]) groups[mod] = { fileCount: 0, tokenCount: 0 };
+      groups[mod].fileCount++;
+      groups[mod].tokenCount += Math.ceil(sigs.join('\n').length / 4);
+    }
+
+  const sorted = Object.entries(groups)
+    .map(([mod, data]) => ({ module: mod, fileCount: data.fileCount, tokenCount: data.tokenCount }))
+    .sort((a, b) => b.tokenCount - a.tokenCount);
+
+  if (sorted.length === 0) return 'No modules found in context file.';
+
+  const total = sorted.reduce((s, m) => s + m.tokenCount, 0);
+
+  return [
+    '# Modules',
+    '',
+    '| Module | Files | Tokens |',
+    '|--------|-------|--------|',
+    ...sorted.map((m) => `| ${m.module} | ${m.fileCount} | ~${m.tokenCount} |`),
+    '',
+    `**Total context tokens: ~${total}**`,
+    '',
+    '_Use `read_context({ module: "name" })` to get signatures for a specific module._',
+  ].join('\n');
+  } catch (err) {
+    return `_list_modules failed: ${err.message}_`;
+  }
+}
+
+/**
+ * query_context({ query, topK? }) → string
+ *
+ * Ranks context-file entries by relevance to the query and returns the
+ * top-K most relevant files with their signatures and scores.
+ */
+function queryContext(args, cwd) {
+  if (!args || !args.query) return 'Missing required argument: query';
+
+  try {
+    const { rank, buildSigIndex, formatRankTable } = __require('./src/retrieval/ranker');
+    const { buildFromCwd } = __require('./src/graph/builder');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) return 'No signatures indexed. Run: node gen-context.js';
+
+    const topK = Math.min(Math.max(1, parseInt(args.topK, 10) || 10), 25);
+    // Build dependency graph for neighbor boost — non-fatal if it fails
+    let graph = null;
+    try { graph = buildFromCwd(cwd); } catch (_) {}
+    const results = rank(args.query, index, { topK, cwd, graph });
+    return formatRankTable(results, args.query);
+  } catch (err) {
+    return `_query_context failed: ${err.message}_`;
+  }
+}
+
+/**
+ * get_impact({ file, depth? }) → string
+ *
+ * Returns a formatted markdown impact report for the given file:
+ * direct importers, transitive importers, affected tests, affected routes.
+ */
+function getImpact(args, cwd) {
+  if (!args || !args.file) return 'Missing required argument: file';
+
+  try {
+    const { analyzeImpact, formatImpact } = __require('./src/graph/impact');
+    const depth = Math.max(0, parseInt(args.depth, 10) || 3);
+    const results = analyzeImpact(args.file, cwd, { depth });
+    if (results.length === 0) return `No impact data for: ${args.file}`;
+    return results.map((r) => formatImpact(r.impact)).join('\n\n---\n\n');
+  } catch (err) {
+    return `_get_impact failed: ${err.message}_`;
+  }
+}
+
+/**
+ * get_lines({ file, start, end }) → string
+ *
+ * Surgical Context demand-driven fetch: returns an exact, clamped line range from a
+ * source file. The path is resolved inside the project root (no traversal escape) and
+ * the returned lines are secret-scanned via the same redactor used for signatures.
+ */
+function getLines(args, cwd) {
+  if (!args || !args.file) return 'Missing required argument: file';
+
+  const rel = String(args.file).replace(/\\/g, '/').replace(/^\//, '');
+  const abs = path.resolve(cwd, rel);
+
+  // Sandbox: refuse paths that resolve outside the project root.
+  const root = path.resolve(cwd);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    return `Refused: ${rel} resolves outside the project root`;
+  }
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+    return `File not found: ${rel}`;
+  }
+
+  const start = parseInt(args.start, 10);
+  const end = parseInt(args.end, 10);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return 'Arguments "start" and "end" must be numbers (1-based line numbers).';
+  }
+
+  let lines;
+  try {
+    lines = fs.readFileSync(abs, 'utf8').split('\n');
+  } catch (err) {
+    return `Could not read ${rel}: ${err.message}`;
+  }
+
+  const total = lines.length;
+  const from = Math.max(1, Math.min(start, end));
+  const to = Math.min(total, Math.max(start, end));
+  if (from > total) return `${rel} has only ${total} lines; requested ${start}-${end}`;
+
+  const slice = lines.slice(from - 1, to);
+
+  // Redaction scan: reuse the signature secret scanner line-by-line.
+  let safeLines = slice;
+  try {
+    const { scan } = __require('./src/security/scanner');
+    safeLines = scan(slice, rel).safe;
+  } catch (_) {} // non-fatal: fall back to raw slice
+
+  return [
+    `# ${rel}:${from}-${to}`,
+    '```',
+    ...safeLines,
+    '```',
+  ].join('\n');
+}
+
+/**
+ * read_memory({ limit? }) → string
+ *
+ * Recall the cross-session decision log (notes) plus the last ranking-session
+ * focus, formatted for an agent to consume at the start of a task.
+ */
+function readMemory(args, cwd) {
+  let limit = parseInt(args && args.limit, 10);
+  if (!Number.isFinite(limit) || limit <= 0) limit = 10;
+  limit = Math.min(limit, 50);
+
+  const out = ['# SigMap memory'];
+
+  let notes = [];
+  try {
+    const { readNotes, formatNotes } = __require('./src/session/notes');
+    notes = readNotes(cwd, limit);
+    out.push('');
+    out.push(`## Recent notes (${notes.length})`);
+    // Most recent first for quick scanning.
+    out.push(formatNotes(notes.slice().reverse()));
+  } catch (_) {
+    out.push('');
+    out.push('_No notes available._');
+  }
+
+  // Last ranking-session focus (if any) — extends src/session/memory.js.
+  try {
+    const { loadSession } = __require('./src/session/memory');
+    const s = loadSession(cwd);
+    if (s && (s.lastQuery || (s.topFiles && s.topFiles.length))) {
+      out.push('');
+      out.push('## Last session');
+      if (s.lastQuery) out.push(`**Last query:** ${s.lastQuery}`);
+      if (s.topFiles && s.topFiles.length) {
+        out.push(`**Focus files:** ${s.topFiles.map((f) => f.file).slice(0, 5).join(', ')}`);
+      }
+    }
+  } catch (_) { /* session optional */ }
+
+  return out.join('\n');
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory };
+
+};
 // ── ./src/learning/weights ──
 __factories["./src/learning/weights"] = function(module, exports) {
   'use strict';
@@ -6135,344 +6218,364 @@ __factories["./src/learning/weights"] = function(module, exports) {
 
 // ── ./src/mcp/server ──
 __factories["./src/mcp/server"] = function(module, exports) {
-  
-  /**
-   * SigMap MCP server — zero npm dependencies.
-   *
-   * Wire protocol: JSON-RPC 2.0 over stdio.
-   * One JSON object per line on both stdin and stdout.
-   *
-   * Supported methods:
-   *   initialize        → serverInfo + capabilities
-   *   tools/list        → 10 tool definitions
-   *   tools/call        → dispatch to handler, return result
-   */
+'use strict';
 
-  const readline = require('readline');
-  const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines } = __require('./src/mcp/handlers');
+/**
+ * SigMap MCP server — zero npm dependencies.
+ *
+ * Wire protocol: JSON-RPC 2.0 over stdio.
+ * One JSON object per line on both stdin and stdout.
+ *
+ * Supported methods:
+ *   initialize        → serverInfo + capabilities
+ *   tools/list        → 11 tool definitions
+ *   tools/call        → dispatch to handler, return result
+ */
 
-  const SERVER_INFO = {
-    name: 'sigmap',
+const readline = require('readline');
+const { TOOLS } = __require('./src/mcp/tools');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory } = __require('./src/mcp/handlers');
+
+const SERVER_INFO = {
+  name: 'sigmap',
   version: '6.14.0',
-    description: 'SigMap MCP server — code signatures on demand',
-  };
-  
-  // ---------------------------------------------------------------------------
-  // JSON-RPC helpers
-  // ---------------------------------------------------------------------------
-  function respond(id, result) {
-    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
-  }
-  
-  function respondError(id, code, message) {
-    process.stdout.write(
-      JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n'
-    );
-  }
-  
-  // ---------------------------------------------------------------------------
-  // Method dispatcher
-  // ---------------------------------------------------------------------------
-  function dispatch(msg, cwd) {
-    const { method, id, params } = msg;
-  
-    // Notifications (no id) need no response
-    if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
-      return;
-    }
-  
-    if (method === 'initialize') {
-      respond(id, {
-        protocolVersion: (params && params.protocolVersion) || '2024-11-05',
-        serverInfo: SERVER_INFO,
-        capabilities: { tools: {} },
-      });
-      return;
-    }
-  
-    if (method === 'tools/list') {
-      respond(id, { tools: TOOLS });
-      return;
-    }
-  
-    if (method === 'tools/call') {
-      const name = params && params.name;
-      const args = (params && params.arguments) || {};
-  
-      let text;
-      try {
-        if (name === 'read_context') text = readContext(args, cwd);
-        else if (name === 'search_signatures') text = searchSignatures(args, cwd);
-        else if (name === 'get_map') text = getMap(args, cwd);
-        else if (name === 'create_checkpoint') text = createCheckpoint(args, cwd);
-        else if (name === 'get_routing') text = getRouting(args, cwd);
-        else if (name === 'explain_file') text = explainFile(args, cwd);
-        else if (name === 'list_modules') text = listModules(args, cwd);
-        else if (name === 'query_context') text = queryContext(args, cwd);
-        else if (name === 'get_impact') text = getImpact(args, cwd);
-        else if (name === 'get_lines') text = getLines(args, cwd);
-        else {
-          respondError(id, -32601, `Unknown tool: ${name}`);
-          return;
-        }
-      } catch (err) {
-        respondError(id, -32603, `Tool error: ${err.message}`);
-        return;
-      }
-  
-      respond(id, {
-        content: [{ type: 'text', text: String(text) }],
-      });
-      return;
-    }
-  
-    // Unknown method
-    if (id !== undefined && id !== null) {
-      respondError(id, -32601, `Method not found: ${method}`);
-    }
-  }
-  
-  // ---------------------------------------------------------------------------
-  // Server entry point
-  // ---------------------------------------------------------------------------
-  function start(cwd) {
-    const rl = readline.createInterface({ input: process.stdin, terminal: false });
-  
-    rl.on('line', (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return;
-  
-      let msg;
-      try {
-        msg = JSON.parse(trimmed);
-      } catch (_) {
-        // Cannot respond without a valid id — ignore malformed input
-        return;
-      }
-  
-      try {
-        dispatch(msg, cwd);
-      } catch (err) {
-        const id = (msg && msg.id) != null ? msg.id : null;
-        respondError(id, -32603, `Internal error: ${err.message}`);
-      }
-    });
-  
-    rl.on('close', () => {
-      process.exit(0);
-    });
-  }
-  
-  module.exports = { start };
-  
+  description: 'SigMap MCP server — code signatures on demand',
 };
 
+// ---------------------------------------------------------------------------
+// JSON-RPC helpers
+// ---------------------------------------------------------------------------
+function respond(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+}
+
+function respondError(id, code, message) {
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Method dispatcher
+// ---------------------------------------------------------------------------
+function dispatch(msg, cwd) {
+  const { method, id, params } = msg;
+
+  // Notifications (no id) need no response
+  if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
+    return;
+  }
+
+  if (method === 'initialize') {
+    respond(id, {
+      protocolVersion: (params && params.protocolVersion) || '2024-11-05',
+      serverInfo: SERVER_INFO,
+      capabilities: { tools: {} },
+    });
+    return;
+  }
+
+  if (method === 'tools/list') {
+    respond(id, { tools: TOOLS });
+    return;
+  }
+
+  if (method === 'tools/call') {
+    const name = params && params.name;
+    const args = (params && params.arguments) || {};
+
+    let text;
+    try {
+      if (name === 'read_context') text = readContext(args, cwd);
+      else if (name === 'search_signatures') text = searchSignatures(args, cwd);
+      else if (name === 'get_map') text = getMap(args, cwd);
+      else if (name === 'create_checkpoint') text = createCheckpoint(args, cwd);
+      else if (name === 'get_routing') text = getRouting(args, cwd);
+      else if (name === 'explain_file') text = explainFile(args, cwd);
+      else if (name === 'list_modules') text = listModules(args, cwd);
+      else if (name === 'query_context') text = queryContext(args, cwd);
+      else if (name === 'get_impact') text = getImpact(args, cwd);
+      else if (name === 'get_lines') text = getLines(args, cwd);
+      else if (name === 'read_memory') text = readMemory(args, cwd);
+      else {
+        respondError(id, -32601, `Unknown tool: ${name}`);
+        return;
+      }
+    } catch (err) {
+      respondError(id, -32603, `Tool error: ${err.message}`);
+      return;
+    }
+
+    respond(id, {
+      content: [{ type: 'text', text: String(text) }],
+    });
+    return;
+  }
+
+  // Unknown method
+  if (id !== undefined && id !== null) {
+    respondError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server entry point
+// ---------------------------------------------------------------------------
+function start(cwd) {
+  const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+  rl.on('line', (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let msg;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch (_) {
+      // Cannot respond without a valid id — ignore malformed input
+      return;
+    }
+
+    try {
+      dispatch(msg, cwd);
+    } catch (err) {
+      const id = (msg && msg.id) != null ? msg.id : null;
+      respondError(id, -32603, `Internal error: ${err.message}`);
+    }
+  });
+
+  rl.on('close', () => {
+    process.exit(0);
+  });
+}
+
+module.exports = { start };
+
+};
 // ── ./src/mcp/tools ──
 __factories["./src/mcp/tools"] = function(module, exports) {
-  
-  /**
-   * MCP tool definitions for SigMap.
-   * Three tools: read_context, search_signatures, get_map.
-   */
-  
-  const TOOLS = [
-    {
-      name: 'read_context',
-      description:
-        'Read extracted code signatures for the project or a specific module path. ' +
-        'Returns the full copilot-instructions.md content (~500–4K tokens) or a ' +
-        'filtered subset when a module path is provided (~50–500 tokens).',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          module: {
-            type: 'string',
-            description:
-              'Optional subdirectory path to scope results (e.g. "src/services"). ' +
-              'Omit to get the full codebase context.',
-          },
-        },
-        required: [],
-      },
-    },
-    {
-      name: 'search_signatures',
-      description:
-        'Search extracted code signatures for a keyword, function name, or class name. ' +
-        'Returns matching signature lines with their file paths.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: 'Keyword to search for in signatures (case-insensitive).',
-          },
-        },
-        required: ['query'],
-      },
-    },
-    {
-      name: 'get_map',
-      description:
-        'Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. ' +
-        'Requires gen-project-map.js to have been run first.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          type: {
-            type: 'string',
-            enum: ['imports', 'classes', 'routes'],
-            description: 'Which section to retrieve: imports, classes, or routes.',
-          },
-        },
-        required: ['type'],
-      },
-    },
-    {
-      name: 'create_checkpoint',
-      description:
-        'Create a session checkpoint summarising current project state. ' +
-        'Returns recent git commits, active branch, token count, and a ' +
-        'compact snapshot of the codebase context — ideal for session handoffs ' +
-        'or periodic saves during long coding sessions.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          note: {
-            type: 'string',
-            description: 'Optional free-text note to include in the checkpoint (e.g. what you were working on).',
-          },
-        },
-        required: [],
-      },
-    },
-    {
-      name: 'get_routing',
-      description:
-        'Get model routing hints for this project — which files belong to which complexity ' +
-        'tier (fast/balanced/powerful) and which AI model to use for each type of task. ' +
-        'Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-        required: [],
-      },
-    },
-    {
-      name: 'explain_file',
-      description:
-        'Explain a specific file: returns its extracted signatures, direct imports ' +
-        '(files it depends on), and callers (files that import it). ' +
-        'Ideal for understanding a file in isolation without reading raw source. ' +
-        'Requires the context file to have been generated first.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          path: {
-            type: 'string',
-            description:
-              'Relative path from the project root (e.g. "src/services/auth.ts"). ' +
-              'Use the paths shown in read_context output.',
-          },
-        },
-        required: ['path'],
-      },
-    },
-    {
-      name: 'list_modules',
-      description:
-        'List all top-level modules (srcDirs) present in the context file, ' +
-        'sorted by token count descending. Use this to decide which module to ' +
-        'pass to read_context before querying a specific area of the codebase.',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-        required: [],
-      },
-    },
-    {
-      name: 'query_context',
-      description:
-        'Rank and return the most relevant files for a specific task or question. ' +
-        'Uses keyword + symbol + path scoring to surface only the top-K files relevant ' +
-        'to the query — much cheaper than reading all context. ' +
-        'Returns ranked file list with signatures and relevance scores.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description:
-              'Natural language task description or keyword(s) to rank files against. ' +
-              'E.g. "add a new language extractor", "fix secret scanning", "auth module".',
-          },
-          topK: {
-            type: 'number',
-            description: 'Maximum number of files to return (default: 10, max: 25).',
-          },
-        },
-        required: ['query'],
-      },
-    },
-    {
-      name: 'get_impact',
-      description:
-        'Show every file that is impacted when a given file changes — direct importers, ' +
-        'transitive importers, affected tests, and affected routes/controllers. ' +
-        'Gives agents instant blast-radius awareness before making a change. ' +
-        'Handles circular dependencies safely (no infinite loops).',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          file: {
-            type: 'string',
-            description:
-              'Relative path from the project root of the file that changed ' +
-              '(e.g. "src/extractors/python.js"). Use forward slashes.',
-          },
-          depth: {
-            type: 'number',
-            description: 'BFS traversal depth limit (default: 3). Use 0 for unlimited.',
-          },
-        },
-        required: ['file'],
-      },
-    },
-    {
-      name: 'get_lines',
-      description:
-        'Fetch an exact line range from a source file on demand — the Surgical Context ' +
-        'workhorse. Signatures carry `path:start-end` anchors; call this to read just those ' +
-        'lines instead of re-opening the whole file. Lines are clamped to the file bounds and ' +
-        'secret-scanned (redacted) before return. Path is sandboxed to the project root.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          file: {
-            type: 'string',
-            description:
-              'Relative path from the project root (e.g. "src/config/loader.js"). ' +
-              'Use the path shown in a signature anchor. Use forward slashes.',
-          },
-          start: {
-            type: 'number',
-            description: '1-based start line (inclusive). Clamped to the file bounds.',
-          },
-          end: {
-            type: 'number',
-            description: '1-based end line (inclusive). Clamped to the file bounds.',
-          },
-        },
-        required: ['file', 'start', 'end'],
-      },
-    },
-  ];
+'use strict';
 
-  module.exports = { TOOLS };
-  
+/**
+ * MCP tool definitions for SigMap (11 tools).
+ * read_context, search_signatures, get_map, create_checkpoint, get_routing,
+ * explain_file, list_modules, query_context, get_impact, get_lines, read_memory.
+ */
+
+const TOOLS = [
+  {
+    name: 'read_context',
+    description:
+      'Read extracted code signatures for the project or a specific module path. ' +
+      'Returns the full copilot-instructions.md content (~500–4K tokens) or a ' +
+      'filtered subset when a module path is provided (~50–500 tokens).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        module: {
+          type: 'string',
+          description:
+            'Optional subdirectory path to scope results (e.g. "src/services"). ' +
+            'Omit to get the full codebase context.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'search_signatures',
+    description:
+      'Search extracted code signatures for a keyword, function name, or class name. ' +
+      'Returns matching signature lines with their file paths.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Keyword to search for in signatures (case-insensitive).',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_map',
+    description:
+      'Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. ' +
+      'Requires gen-project-map.js to have been run first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['imports', 'classes', 'routes'],
+          description: 'Which section to retrieve: imports, classes, or routes.',
+        },
+      },
+      required: ['type'],
+    },
+  },
+  {
+    name: 'create_checkpoint',
+    description:
+      'Create a session checkpoint summarising current project state. ' +
+      'Returns recent git commits, active branch, token count, and a ' +
+      'compact snapshot of the codebase context — ideal for session handoffs ' +
+      'or periodic saves during long coding sessions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          description: 'Optional free-text note to include in the checkpoint (e.g. what you were working on).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_routing',
+    description:
+      'Get model routing hints for this project — which files belong to which complexity ' +
+      'tier (fast/balanced/powerful) and which AI model to use for each type of task. ' +
+      'Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'explain_file',
+    description:
+      'Explain a specific file: returns its extracted signatures, direct imports ' +
+      '(files it depends on), and callers (files that import it). ' +
+      'Ideal for understanding a file in isolation without reading raw source. ' +
+      'Requires the context file to have been generated first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description:
+            'Relative path from the project root (e.g. "src/services/auth.ts"). ' +
+            'Use the paths shown in read_context output.',
+        },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'list_modules',
+    description:
+      'List all top-level modules (srcDirs) present in the context file, ' +
+      'sorted by token count descending. Use this to decide which module to ' +
+      'pass to read_context before querying a specific area of the codebase.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'query_context',
+    description:
+      'Rank and return the most relevant files for a specific task or question. ' +
+      'Uses keyword + symbol + path scoring to surface only the top-K files relevant ' +
+      'to the query — much cheaper than reading all context. ' +
+      'Returns ranked file list with signatures and relevance scores.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Natural language task description or keyword(s) to rank files against. ' +
+            'E.g. "add a new language extractor", "fix secret scanning", "auth module".',
+        },
+        topK: {
+          type: 'number',
+          description: 'Maximum number of files to return (default: 10, max: 25).',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_impact',
+    description:
+      'Show every file that is impacted when a given file changes — direct importers, ' +
+      'transitive importers, affected tests, and affected routes/controllers. ' +
+      'Gives agents instant blast-radius awareness before making a change. ' +
+      'Handles circular dependencies safely (no infinite loops).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          description:
+            'Relative path from the project root of the file that changed ' +
+            '(e.g. "src/extractors/python.js"). Use forward slashes.',
+        },
+        depth: {
+          type: 'number',
+          description: 'BFS traversal depth limit (default: 3). Use 0 for unlimited.',
+        },
+      },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'get_lines',
+    description:
+      'Fetch an exact line range from a source file on demand — the Surgical Context ' +
+      'workhorse. Signatures carry `path:start-end` anchors; call this to read just those ' +
+      'lines instead of re-opening the whole file. Lines are clamped to the file bounds and ' +
+      'secret-scanned (redacted) before return. Path is sandboxed to the project root.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          description:
+            'Relative path from the project root (e.g. "src/config/loader.js"). ' +
+            'Use the path shown in a signature anchor. Use forward slashes.',
+        },
+        start: {
+          type: 'number',
+          description: '1-based start line (inclusive). Clamped to the file bounds.',
+        },
+        end: {
+          type: 'number',
+          description: '1-based end line (inclusive). Clamped to the file bounds.',
+        },
+      },
+      required: ['file', 'start', 'end'],
+    },
+  },
+  {
+    name: 'read_memory',
+    description:
+      'Recall the project decision log — recent notes left by humans or agents ' +
+      'across sessions (via `sigmap note`), plus the last ranking-session focus. ' +
+      'Call this at the start of a task to kill cold-start: it answers ' +
+      '"what were we doing and why" without re-reading the whole codebase.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'How many of the most recent notes to return (default: 10, max: 50).',
+        },
+      },
+      required: [],
+    },
+  },
+];
+
+module.exports = { TOOLS };
+
 };
-
 // ── ./src/routing/classifier ──
 __factories["./src/routing/classifier"] = function(module, exports) {
   
@@ -7005,6 +7108,110 @@ __factories["./src/tracking/logger"] = function(module, exports) {
   
   module.exports = { logRun, readLog, summarize };
   
+};
+
+// ── ./src/session/notes ──
+__factories["./src/session/notes"] = function(module, exports) {
+'use strict';
+
+/**
+ * Decision-log notes (Memory, v6.16.0).
+ *
+ * A tiny append-only log of human/agent notes that survives across sessions,
+ * so an agent starting cold can recall "what were we doing / why". Stored as
+ * NDJSON under `.context/` to match the project's other state logs
+ * (usage.ndjson, benchmark-history.ndjson). Zero dependencies.
+ *
+ * Consumed by the `read_memory` MCP tool and the `sigmap note` / `sigmap status`
+ * commands. Complements `src/session/memory.js` (ranking session) rather than
+ * duplicating it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const NOTES_FILE = path.join('.context', 'notes.ndjson');
+const MAX_TEXT = 2000;
+
+function notesPath(cwd) {
+  return path.join(cwd, NOTES_FILE);
+}
+
+function _currentBranch(cwd) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Append a note. Returns the stored entry.
+ * @param {string} cwd
+ * @param {string} text
+ * @param {object} [opts]
+ * @param {string|null} [opts.branch]  override branch (default: current git branch)
+ * @param {string} [opts.tag]          optional category tag
+ */
+function addNote(cwd, text, opts = {}) {
+  const clean = String(text == null ? '' : text).trim().slice(0, MAX_TEXT);
+  if (!clean) throw new Error('note text is empty');
+  const entry = {
+    ts: new Date().toISOString(),
+    text: clean,
+    branch: opts.branch !== undefined ? opts.branch : _currentBranch(cwd),
+  };
+  if (opts.tag) entry.tag = String(opts.tag).trim().slice(0, 40);
+  const p = notesPath(cwd);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.appendFileSync(p, JSON.stringify(entry) + '\n');
+  return entry;
+}
+
+/**
+ * Read notes in chronological order (oldest first).
+ * @param {string} cwd
+ * @param {number} [limit=0]  keep only the most recent N (0 = all)
+ * @returns {object[]}
+ */
+function readNotes(cwd, limit = 0) {
+  let raw;
+  try { raw = fs.readFileSync(notesPath(cwd), 'utf8'); }
+  catch (_) { return []; }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try { out.push(JSON.parse(t)); } catch (_) { /* skip corrupt line */ }
+  }
+  if (limit > 0 && out.length > limit) return out.slice(out.length - limit);
+  return out;
+}
+
+/** Format notes as a Markdown list (pass already-ordered notes). */
+function formatNotes(notes) {
+  if (!notes || !notes.length) {
+    return 'No notes recorded yet. Add one with: sigmap note "<text>"';
+  }
+  return notes.map((n) => {
+    const when = String(n.ts || '').replace('T', ' ').slice(0, 16);
+    const br = n.branch ? ` (${n.branch})` : '';
+    const tag = n.tag ? ` #${n.tag}` : '';
+    return `- [${when}${br}]${tag} ${n.text}`;
+  }).join('\n');
+}
+
+/** Delete the notes log. Returns true if a file was removed. */
+function clearNotes(cwd) {
+  try { fs.unlinkSync(notesPath(cwd)); return true; }
+  catch (_) { return false; }
+}
+
+module.exports = { notesPath, addNote, readNotes, formatNotes, clearNotes };
+
 };
 
 // ── ./src/session/memory ──
@@ -11117,6 +11324,9 @@ Usage:
   ${cmd} --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited)
   ${cmd} verify-ai-output <answer.md>      Flag fake files/imports/symbols in an AI answer
   ${cmd} verify-ai-output <answer.md> --json  Hallucination report as JSON (exits 1 if issues)
+  ${cmd} note "<text>"                     Append a note to the cross-session decision log
+  ${cmd} note                              List recent notes (also: note --list <N>)
+  ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
   ${cmd} --init                            Write example config + .contextignore scaffold
   ${cmd} --help                            Show this message
   ${cmd} --version                         Show version
@@ -12235,6 +12445,133 @@ function main() {
     });
     console.log('\nMonorepo:', result.isMonorepo ? 'yes' : 'no');
     console.log('Confidence:', result.confidence);
+    process.exit(0);
+  }
+
+  // `sigmap note "<text>"` — append to the cross-session decision log.
+  // With no text, lists recent notes (also `note --list [N]`).
+  if (args[0] === 'note') {
+    const jsonOut = args.includes('--json');
+    const { addNote, readNotes, formatNotes } = requireSourceOrBundled('./src/session/notes');
+    const listIdx = args.indexOf('--list');
+    // Build positionals, skipping value-taking flags and their values
+    // (e.g. `--cwd <dir>`, `--list <N>`) so they never leak into the note text.
+    const VALUE_FLAGS = new Set(['--cwd', '--list']);
+    const positional = [];
+    for (let i = 1; i < args.length; i++) {
+      const a = args[i];
+      if (a.startsWith('--')) { if (VALUE_FLAGS.has(a)) i++; continue; }
+      positional.push(a);
+    }
+    const wantsList = listIdx !== -1 || positional.length === 0;
+
+    if (wantsList) {
+      const limArg = listIdx !== -1 ? parseInt(args[listIdx + 1], 10) : parseInt(positional[0], 10);
+      const limit = Number.isFinite(limArg) && limArg > 0 ? limArg : 10;
+      const notes = readNotes(cwd, limit);
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify({ notes }) + '\n');
+      } else {
+        console.log(`[sigmap] ${notes.length} recent note${notes.length === 1 ? '' : 's'}`);
+        console.log(formatNotes(notes.slice().reverse()));
+      }
+      process.exit(0);
+    }
+
+    const text = positional.join(' ');
+    let entry;
+    try {
+      entry = addNote(cwd, text);
+    } catch (err) {
+      console.error(`[sigmap] ${err.message}`);
+      process.exit(1);
+    }
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify({ added: entry }) + '\n');
+    } else {
+      console.log(`[sigmap] noted${entry.branch ? ` (${entry.branch})` : ''}: ${entry.text}`);
+    }
+    process.exit(0);
+  }
+
+  // `sigmap status` — environment / repo state at a glance.
+  if (args[0] === 'status') {
+    const jsonOut = args.includes('--json');
+    const gitOpts = { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] };
+    const st = { branch: null, dirty: 0, lastIndex: null, indexVersion: null, indexFiles: null, changedSinceIndex: null, notes: 0, lastNote: null };
+
+    try { st.branch = execSync('git rev-parse --abbrev-ref HEAD', gitOpts).trim() || null; } catch (_) {}
+    // Fallback for an unborn branch (fresh repo, no commits yet).
+    if (!st.branch || st.branch === 'HEAD') {
+      try { st.branch = execSync('git symbolic-ref --short HEAD', gitOpts).trim() || st.branch; } catch (_) {}
+    }
+    try {
+      const porcelain = execSync('git status --porcelain', gitOpts).trim();
+      st.dirty = porcelain ? porcelain.split('\n').filter(Boolean).length : 0;
+    } catch (_) {}
+
+    try {
+      const { readLog } = requireSourceOrBundled('./src/tracking/logger');
+      const log = readLog(cwd);
+      if (log.length) {
+        const last = log[log.length - 1];
+        st.lastIndex = last.ts || null;
+        st.indexVersion = last.version || null;
+        st.indexFiles = last.fileCount != null ? last.fileCount : null;
+      }
+    } catch (_) {}
+
+    // Index freshness: count tracked files modified after the last index run.
+    if (st.lastIndex) {
+      try {
+        const since = Date.parse(st.lastIndex);
+        const tracked = execSync('git ls-files', gitOpts).split('\n').filter(Boolean);
+        let changed = 0;
+        for (const f of tracked.slice(0, 5000)) {
+          try { if (fs.statSync(path.join(cwd, f)).mtimeMs > since) changed++; } catch (_) {}
+        }
+        st.changedSinceIndex = changed;
+      } catch (_) {}
+    }
+
+    try {
+      const { readNotes } = requireSourceOrBundled('./src/session/notes');
+      const notes = readNotes(cwd);
+      st.notes = notes.length;
+      if (notes.length) st.lastNote = notes[notes.length - 1];
+    } catch (_) {}
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(st) + '\n');
+      process.exit(0);
+    }
+
+    const fmtAgo = (iso) => {
+      if (!iso) return 'never';
+      const ms = Date.now() - Date.parse(iso);
+      if (!Number.isFinite(ms)) return iso;
+      const m = Math.floor(ms / 60000), h = Math.floor(m / 60), d = Math.floor(h / 24);
+      if (d > 0) return `${d}d ago`;
+      if (h > 0) return `${h}h ago`;
+      if (m > 0) return `${m}m ago`;
+      return 'just now';
+    };
+
+    console.log('[sigmap] status');
+    console.log(`  Branch:        ${st.branch || '(not a git repo)'}`);
+    console.log(`  Working tree:  ${st.dirty === 0 ? 'clean' : `${st.dirty} file${st.dirty === 1 ? '' : 's'} changed`}`);
+    if (st.lastIndex) {
+      let fresh = `${fmtAgo(st.lastIndex)} (v${st.indexVersion || '?'}, ${st.indexFiles != null ? st.indexFiles + ' files' : 'n/a'})`;
+      if (st.changedSinceIndex != null && st.changedSinceIndex > 0) fresh += ` — STALE: ${st.changedSinceIndex} file${st.changedSinceIndex === 1 ? '' : 's'} changed since`;
+      console.log(`  Last index:    ${fresh}`);
+    } else {
+      console.log('  Last index:    never — run: sigmap');
+    }
+    if (st.notes > 0) {
+      console.log(`  Notes:         ${st.notes} (latest: ${st.lastNote.text.slice(0, 60)}${st.lastNote.text.length > 60 ? '…' : ''})`);
+    } else {
+      console.log('  Notes:         none — add with: sigmap note "<text>"');
+    }
     process.exit(0);
   }
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -9083,11 +9083,61 @@ function extractImports(text) {
     let r;
     while ((r = reqRe.exec(line)) !== null) push(r[1], 'js', i + 1, line);
 
+    // TS: import X = require('mod')
+    if ((m = line.match(/\bimport\s+[A-Za-z_$][\w$]*\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/))) {
+      push(m[1], 'js', i + 1, line);
+    }
+
     // Python: from x import y  |  import x
     if ((m = line.match(/^\s*from\s+([.\w]+)\s+import\b/))) {
       push(m[1], 'py', i + 1, line);
     } else if ((m = line.match(/^\s*import\s+([A-Za-z_][\w.]*)/))) {
       push(m[1], 'py', i + 1, line);
+    }
+  }
+
+  // Multi-line JS/TS imports, e.g.
+  //   import {
+  //     A as B,
+  //   } from './mod';
+  // The per-line pass above misses these because `from '…'` sits on a later
+  // line. Trigger only when the opening line has no quote and no `from` yet,
+  // then gather forward until the source string appears.
+  for (let i = 0; i < lines.length; i++) {
+    const start = lines[i];
+    if (!/^\s*(?:import|export)\b/.test(start)) continue;
+    if (/['"]/.test(start) || /\bfrom\b/.test(start)) continue; // single-line, already handled
+    let joined = start;
+    for (let j = i + 1; j < Math.min(lines.length, i + 12); j++) {
+      joined += ' ' + lines[j];
+      const fm = joined.match(/\bfrom\s*['"]([^'"]+)['"]/);
+      if (fm) { push(fm[1], 'js', i + 1, start.trim()); break; }
+      if (/['"]/.test(lines[j]) && !/\bfrom\b/.test(joined)) break; // a string that isn't a source — bail
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract npm/pnpm/yarn script invocations (`npm run <name>`).
+ * Only the explicit `run` form is matched, to avoid confusing package-manager
+ * subcommands (`yarn add`, `pnpm install`) with script names.
+ * @param {string} text
+ * @returns {{ name: string, line: number }[]}
+ */
+function extractNpmScripts(text) {
+  const lines = text.split('\n');
+  const out = [];
+  const seen = new Set();
+  const re = /\b(?:npm|pnpm|yarn)\s+run(?:-script)?\s+([A-Za-z0-9:_-]+)/g;
+  for (let i = 0; i < lines.length; i++) {
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(lines[i])) !== null) {
+      const name = m[1];
+      if (seen.has(name)) continue;
+      seen.add(name);
+      out.push({ name, line: i + 1 });
     }
   }
   return out;
@@ -9123,7 +9173,327 @@ module.exports = {
   extractFilePaths,
   extractImports,
   extractSymbols,
+  extractNpmScripts,
 };
+
+};
+
+// ── ./src/verify/closest-match ──
+__factories["./src/verify/closest-match"] = function(module, exports) {
+'use strict';
+
+/**
+ * Closest-match suggestions for the Hallucination Guard (v6.15.0).
+ *
+ * Heuristic layer (plan §5 labels this "Medium" confidence): given a name the
+ * detectors flagged as fake, find the nearest *real* candidate by Levenshtein
+ * distance so the report can say "Did you mean `loadConfig()` in
+ * src/config/loader.js:42?". Pure, deterministic, offline — no network, no LLM.
+ *
+ * All inputs are passed in (symbol/file/script candidate lists) so this module
+ * stays unit-testable without touching the filesystem or the SigMap index.
+ */
+
+/**
+ * Levenshtein edit distance with an early-exit ceiling.
+ * Returns `max + 1` as soon as the best achievable distance exceeds `max`,
+ * so callers can cheaply reject far-apart strings.
+ */
+function levenshtein(a, b, max = Infinity) {
+  if (a === b) return 0;
+  const al = a.length;
+  const bl = b.length;
+  if (al === 0) return bl;
+  if (bl === 0) return al;
+  if (Math.abs(al - bl) > max) return max + 1;
+
+  let prev = new Array(bl + 1);
+  let curr = new Array(bl + 1);
+  for (let j = 0; j <= bl; j++) prev[j] = j;
+
+  for (let i = 1; i <= al; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= bl; j++) {
+      const cost = ca === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > max) return max + 1;
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+  return prev[bl];
+}
+
+/** Bucket a normalized edit distance into a confidence label (plan §5). */
+function suggestionConfidence(distance, targetLen) {
+  const ratio = distance / Math.max(targetLen, 1);
+  if (distance === 0 || ratio <= 0.2) return 'high';
+  if (ratio <= 0.4) return 'medium';
+  return 'low';
+}
+
+/**
+ * Find the nearest candidate name to `target`.
+ *
+ * @param {string} target
+ * @param {Array<string | { name: string, file?: string, line?: number }>} candidates
+ * @param {object} [opts]
+ * @param {number} [opts.maxRatio=0.5]  reject matches farther than ratio·len edits
+ * @param {number} [opts.minLen=3]      skip very short targets (too noisy)
+ * @returns {{ name, file, line, distance, confidence } | null}
+ */
+function closestMatch(target, candidates, opts = {}) {
+  const maxRatio = opts.maxRatio != null ? opts.maxRatio : 0.5;
+  const minLen = opts.minLen != null ? opts.minLen : 3;
+  if (!target || target.length < minLen) return null;
+  if (!candidates || candidates.length === 0) return null;
+
+  const lower = target.toLowerCase();
+  const cap = Math.max(1, Math.ceil(target.length * maxRatio));
+  let best = null;
+
+  for (const c of candidates) {
+    const name = typeof c === 'string' ? c : c && c.name;
+    if (!name || name === target) continue;
+    if (Math.abs(name.length - target.length) > cap) continue;
+    const d = levenshtein(lower, name.toLowerCase(), cap);
+    if (d > cap) continue;
+    if (!best || d < best.distance ||
+        (d === best.distance && name.length < best.name.length)) {
+      best = {
+        name,
+        file: typeof c === 'object' ? c.file : undefined,
+        line: typeof c === 'object' ? c.line : undefined,
+        distance: d,
+      };
+      if (d === 0) break; // case-only difference — can't beat it
+    }
+  }
+
+  if (!best) return null;
+  best.confidence = suggestionConfidence(best.distance, target.length);
+  return best;
+}
+
+/**
+ * Build `[{ name, file, line }]` symbol candidates from a SigMap signature
+ * index (`Map<file, string[]>` whose entries may carry a `:start-end` anchor).
+ */
+function buildSymbolCandidates(sigIndex) {
+  const out = [];
+  const seen = new Set();
+  if (!sigIndex) return out;
+  for (const [file, sigs] of sigIndex) {
+    for (const sig of sigs) {
+      const s = String(sig);
+      const lineM = s.match(/:(\d+)(?:-\d+)?\s*$/);
+      const line = lineM ? parseInt(lineM[1], 10) : null;
+      const cleaned = s.replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+      const m = cleaned.match(/\b(?:async\s+function|function|class|def|interface|type|enum|const|let|var)\s+([A-Za-z_$][\w$]*)/)
+        || cleaned.match(/([A-Za-z_$][\w$]*)\s*\(/)
+        || cleaned.match(/([A-Za-z_$][\w$]*)/);
+      if (!m) continue;
+      const name = m[1];
+      const key = name + '@' + file;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ name, file, line });
+    }
+  }
+  return out;
+}
+
+/** Format a suggestion object into a human one-liner for reports/CLI. */
+function formatSuggestion(match, asCall) {
+  if (!match) return null;
+  const sym = asCall ? `${match.name}()` : match.name;
+  let where = '';
+  if (match.file) {
+    where = match.line ? ` in ${match.file}:${match.line}` : ` in ${match.file}`;
+  }
+  return `Did you mean \`${sym}\`${where}?`;
+}
+
+module.exports = {
+  levenshtein,
+  closestMatch,
+  buildSymbolCandidates,
+  suggestionConfidence,
+  formatSuggestion,
+};
+
+};
+
+// ── ./src/format/verify-report ──
+__factories["./src/format/verify-report"] = function(module, exports) {
+'use strict';
+
+/**
+ * Hallucination Guard report view (Surface A, v6.15.0).
+ *
+ * Turns the `verify-ai-output --json` result into a standalone, self-contained
+ * HTML report — red/amber/green per issue, with closest-match suggestions
+ * inline. The visual language deliberately mirrors the planned PR-comment
+ * styling so a single screenshot is reusable across docs and CI (plan proof #5).
+ *
+ * Zero dependencies, inline CSS/SVG, no external assets. Also exports a compact
+ * Markdown renderer for CI / PR comments that shares the same structure.
+ */
+
+const TYPE_META = {
+  'fake-file': { label: 'Fake file', tone: 'red', icon: '✕' },
+  'fake-test-file': { label: 'Fake test file', tone: 'red', icon: '✕' },
+  'fake-import': { label: 'Fake import', tone: 'red', icon: '✕' },
+  'fake-npm-script': { label: 'Fake npm script', tone: 'red', icon: '✕' },
+  'fake-symbol': { label: 'Fake symbol', tone: 'amber', icon: '!' },
+};
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toneFor(issue) {
+  const meta = TYPE_META[issue.type];
+  if (meta) return meta.tone;
+  return issue.confidence === 'high' ? 'red' : 'amber';
+}
+
+function labelFor(issue) {
+  return (TYPE_META[issue.type] && TYPE_META[issue.type].label) || issue.type;
+}
+
+/**
+ * Render the verify result to a full HTML document.
+ * @param {{ file?: string, issues: object[], summary: object }} result
+ * @param {object} [opts]
+ * @param {string} [opts.title]
+ * @returns {string} HTML
+ */
+function renderReportHtml(result, opts = {}) {
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  const summary = result.summary || { total: issues.length, byType: {}, clean: issues.length === 0 };
+  const file = result.file || opts.file || 'AI answer';
+  const title = opts.title || 'SigMap — Hallucination Guard report';
+  const clean = summary.clean || issues.length === 0;
+  const byType = summary.byType || {};
+
+  const chips = Object.keys(TYPE_META)
+    .filter((t) => byType[t])
+    .map((t) => `<span class="chip chip-${TYPE_META[t].tone}">${escapeHtml(TYPE_META[t].label)}: ${byType[t]}</span>`)
+    .join('');
+
+  const banner = clean
+    ? `<div class="banner banner-green"><span class="dot"></span> No hallucinations detected — ${escapeHtml(String(summary.symbolsIndexed || 0))} symbols indexed</div>`
+    : `<div class="banner banner-red"><span class="dot"></span> ${issues.length} issue${issues.length === 1 ? '' : 's'} found in <code>${escapeHtml(file)}</code></div>`;
+
+  const rows = issues.map((issue) => {
+    const tone = toneFor(issue);
+    const sugg = issue.suggestion
+      ? `<div class="suggestion">↳ ${escapeHtml(issue.suggestion)} <span class="conf">heuristic</span></div>`
+      : '';
+    return [
+      `<li class="issue issue-${tone}">`,
+      `  <div class="issue-head">`,
+      `    <span class="badge badge-${tone}">${escapeHtml(labelFor(issue))}</span>`,
+      `    <span class="loc">${escapeHtml(issue.location || ('L' + issue.line))}</span>`,
+      `    <span class="conf conf-${escapeHtml(issue.confidence || 'high')}">${escapeHtml(issue.confidence || 'high')} confidence</span>`,
+      `  </div>`,
+      `  <div class="msg">${escapeHtml(issue.message || issue.value)}</div>`,
+      `  ${sugg}`,
+      `</li>`,
+    ].join('\n');
+  }).join('\n');
+
+  const list = clean
+    ? '<p class="empty">Nothing to report — every file, import, symbol, and script in the answer resolves against the repository.</p>'
+    : `<ul class="issues">${rows}</ul>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; background: #0d1117; color: #e6edf3; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 32px 20px 64px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: #8b949e; margin: 0 0 20px; font-size: 13px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #161b22; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+  .banner { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-radius: 8px; font-weight: 600; margin-bottom: 16px; }
+  .banner-green { background: rgba(46,160,67,.15); border: 1px solid rgba(46,160,67,.4); color: #3fb950; }
+  .banner-red { background: rgba(248,81,73,.12); border: 1px solid rgba(248,81,73,.4); color: #f85149; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: currentColor; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 20px; }
+  .chip { font-size: 12px; padding: 3px 9px; border-radius: 999px; font-weight: 600; }
+  .chip-red { background: rgba(248,81,73,.15); color: #f85149; }
+  .chip-amber { background: rgba(210,153,34,.18); color: #d29922; }
+  ul.issues { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+  .issue { border: 1px solid #30363d; border-left-width: 4px; border-radius: 8px; padding: 12px 14px; background: #0f141a; }
+  .issue-red { border-left-color: #f85149; }
+  .issue-amber { border-left-color: #d29922; }
+  .issue-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .badge { font-size: 11.5px; font-weight: 700; padding: 2px 8px; border-radius: 5px; text-transform: uppercase; letter-spacing: .03em; }
+  .badge-red { background: rgba(248,81,73,.18); color: #f85149; }
+  .badge-amber { background: rgba(210,153,34,.2); color: #d29922; }
+  .loc { font-family: ui-monospace, monospace; color: #8b949e; font-size: 12px; }
+  .conf { font-size: 11px; color: #8b949e; }
+  .conf-high { color: #f85149; }
+  .conf-medium { color: #d29922; }
+  .msg { margin-top: 7px; font-family: ui-monospace, monospace; font-size: 12.5px; color: #e6edf3; }
+  .suggestion { margin-top: 6px; font-size: 12.5px; color: #3fb950; }
+  .suggestion .conf { margin-left: 6px; }
+  .empty { color: #8b949e; }
+  footer { margin-top: 28px; color: #6e7681; font-size: 12px; }
+  a { color: #58a6ff; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Hallucination Guard report</h1>
+  <p class="sub">Deterministic verification of an AI answer against the real repository — <code>sigmap verify-ai-output</code></p>
+  ${banner}
+  ${chips ? `<div class="chips">${chips}</div>` : ''}
+  ${list}
+  <footer>Generated by <a href="https://github.com/manojmallick/sigmap">SigMap</a> · offline, no LLM · suggestions are heuristic (closest-match)</footer>
+</div>
+</body>
+</html>
+`;
+}
+
+/** Compact Markdown rendering of the same result (CI / PR comments). */
+function renderReportMarkdown(result) {
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  const summary = result.summary || {};
+  const file = result.file || 'AI answer';
+  if (summary.clean || issues.length === 0) {
+    return `### ✅ Hallucination Guard — clean\n\nNo fabricated files, imports, symbols, or scripts in \`${file}\`.`;
+  }
+  const lines = [
+    `### ❌ Hallucination Guard — ${issues.length} issue${issues.length === 1 ? '' : 's'} in \`${file}\``,
+    '',
+    '| Type | Location | Detail | Suggestion |',
+    '| --- | --- | --- | --- |',
+  ];
+  for (const i of issues) {
+    const sugg = i.suggestion ? i.suggestion.replace(/\|/g, '\\|') : '—';
+    lines.push(`| ${labelFor(i)} | ${i.location || ('L' + i.line)} | \`${String(i.value).replace(/\|/g, '\\|')}\` | ${sugg} |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { renderReportHtml, renderReportMarkdown, escapeHtml };
 
 };
 
@@ -9132,21 +9502,31 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
 'use strict';
 
 /**
- * Hallucination Guard — deterministic core (Phase 1 MVP).
+ * Hallucination Guard — deterministic core (Reliable MVP, v6.15.0).
  *
  * Given the text of an AI answer, flag claims that do not match the repo:
- *   - fake-file   : a referenced path is not on disk
- *   - fake-import : a relative import does not resolve; a bare import is
- *                   absent from package.json deps (builtins allow-listed)
- *   - fake-symbol : a called function/class is absent from the symbol index
+ *   - fake-file      : a referenced path is not on disk
+ *   - fake-test-file : a referenced *test* path is not on disk (sub-type)
+ *   - fake-import    : a relative import does not resolve; a bare import is
+ *                      absent from package.json deps (builtins allow-listed)
+ *   - fake-symbol    : a called function/class is absent from the symbol index
+ *   - fake-npm-script: `npm run X` where X is not a package.json script
  *
- * No network, no LLM. Reuses SigMap primitives (buildSigIndex) but every
- * external dependency is injectable via `opts` so the core stays unit-testable.
+ * Each issue carries a `confidence` (detection certainty) and, where a near
+ * match exists, a heuristic `suggestion` ("Did you mean …?"). No network, no
+ * LLM. Reuses SigMap primitives (buildSigIndex) but every external dependency
+ * is injectable via `opts` so the core stays unit-testable.
  */
 
 const fs = require('fs');
 const path = require('path');
 const parsers = __require('./src/verify/parsers');
+const { closestMatch, buildSymbolCandidates, formatSuggestion } = __require('./src/verify/closest-match');
+
+// A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
+// a tests/__tests__ directory). Used to flag fake-test-file separately.
+const TEST_PATH_RE = /(?:\.(?:test|spec)\.[mc]?[jt]sx?$)|(?:(?:^|\/)__tests__\/)|(?:(?:^|\/)test_[^/]+\.py$)|(?:_test\.py$)|(?:(?:^|\/)tests?\/)/i;
+function isTestPath(p) { return TEST_PATH_RE.test(p); }
 
 const NODE_BUILTINS = new Set([
   'fs', 'path', 'os', 'util', 'events', 'stream', 'http', 'https', 'crypto',
@@ -9180,10 +9560,14 @@ const LANG_GLOBALS = new Set([
 const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
 const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
 
-/** Build the set of known symbol identifiers from the SigMap signature index. */
+/**
+ * Build the set of known symbol identifiers from the SigMap signature index,
+ * plus `{ name, file, line }` candidates (for closest-match suggestions).
+ */
 function buildSymbolSet(cwd) {
   const set = new Set();
   let fileKeys = [];
+  let symbolCandidates = [];
   try {
     const { buildSigIndex } = __require('./src/retrieval/ranker');
     const idx = buildSigIndex(cwd);
@@ -9195,8 +9579,9 @@ function buildSymbolSet(cwd) {
         for (const id of ids) set.add(id);
       }
     }
+    symbolCandidates = buildSymbolCandidates(idx);
   } catch (_) {}
-  return { set, fileKeys };
+  return { set, fileKeys, symbolCandidates };
 }
 
 /** Load declared dependency names from package.json. */
@@ -9213,6 +9598,18 @@ function loadDeps(cwd) {
     }
   } catch (_) {}
   return { deps, hasPkg };
+}
+
+/** Load the set of npm script names declared in package.json. */
+function loadScripts(cwd) {
+  const scripts = new Set();
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    if (pkg.scripts && typeof pkg.scripts === 'object') {
+      for (const name of Object.keys(pkg.scripts)) scripts.add(name);
+    }
+  } catch (_) {}
+  return scripts;
 }
 
 /** Default file-existence check: resolve a referenced path against cwd. */
@@ -9249,11 +9646,20 @@ function defaultRelativeResolvable(cwd, mod, fileBasenames) {
 /**
  * Verify an AI answer against the repository.
  *
+ * Each issue has the shape:
+ *   { type, value, line, location, message, confidence, suggestion }
+ * where `confidence` is the *detection* certainty ('high' for path/dep/script
+ * checks, 'medium' for symbol checks) and `suggestion` is a heuristic
+ * closest-match hint (or null).
+ *
  * @param {string} answerText
  * @param {string} cwd
  * @param {object} [opts]
  * @param {Set<string>} [opts.symbolSet]      override known symbols
+ * @param {Array}       [opts.symbolCandidates] override { name, file, line } list
+ * @param {Array<string>} [opts.fileCandidates]  override repo file paths (suggestions)
  * @param {Set<string>} [opts.deps]           override package deps
+ * @param {Set<string>} [opts.scripts]        override package.json script names
  * @param {boolean}     [opts.hasPkg]         whether a package.json exists
  * @param {(ref: string) => boolean} [opts.fileExists]          override file check
  * @param {(mod: string) => boolean} [opts.relativeResolvable]  override rel-import check
@@ -9262,12 +9668,16 @@ function defaultRelativeResolvable(cwd, mod, fileBasenames) {
 function verify(answerText, cwd, opts = {}) {
   let symbolSet = opts.symbolSet;
   let fileBasenames = opts.fileBasenames;
+  let symbolCandidates = opts.symbolCandidates || [];
+  let fileCandidates = opts.fileCandidates || [];
   if (!symbolSet) {
     const built = buildSymbolSet(cwd);
     symbolSet = built.set;
     fileBasenames = new Set(built.fileKeys.map(
       (k) => path.basename(k).replace(/\.[^.]+$/, '').toLowerCase()
     ));
+    symbolCandidates = built.symbolCandidates;
+    fileCandidates = built.fileKeys;
   }
   if (!fileBasenames) fileBasenames = new Set();
 
@@ -9278,10 +9688,15 @@ function verify(answerText, cwd, opts = {}) {
     deps = loaded.deps;
     if (hasPkg === undefined) hasPkg = loaded.hasPkg;
   }
+  const scripts = opts.scripts || (hasPkg ? loadScripts(cwd) : new Set());
 
   const fileExists = opts.fileExists || ((ref) => defaultFileExists(cwd, ref));
   const relativeResolvable = opts.relativeResolvable
     || ((mod) => defaultRelativeResolvable(cwd, mod, fileBasenames));
+
+  // Pre-derive basename candidates for file suggestions (compare on basename so
+  // a wrong directory still surfaces the right file).
+  const fileBasenameCandidates = fileCandidates.map((f) => ({ name: path.basename(f), file: f }));
 
   const issues = [];
   const dedupe = new Set();
@@ -9289,21 +9704,31 @@ function verify(answerText, cwd, opts = {}) {
     const key = `${issue.type}::${issue.value}`;
     if (dedupe.has(key)) return;
     dedupe.add(key);
+    if (!('suggestion' in issue)) issue.suggestion = null;
+    issue.location = `L${issue.line}`;
     issues.push(issue);
   };
 
-  // 1. fake-file
+  // 1. fake-file / fake-test-file
   for (const { path: p, line } of parsers.extractFilePaths(answerText)) {
-    if (!fileExists(p)) {
-      add({ type: 'fake-file', value: p, line, message: `File not found on disk: ${p}` });
-    }
+    if (fileExists(p)) continue;
+    const isTest = isTestPath(p);
+    const match = closestMatch(path.basename(p), fileBasenameCandidates, { minLen: 4 });
+    add({
+      type: isTest ? 'fake-test-file' : 'fake-file',
+      value: p,
+      line,
+      message: `${isTest ? 'Test file' : 'File'} not found on disk: ${p}`,
+      confidence: 'high',
+      suggestion: match ? formatSuggestion(match, false) : null,
+    });
   }
 
   // 2. fake-import
   for (const imp of parsers.extractImports(answerText)) {
     if (imp.relative) {
       if (!relativeResolvable(imp.module)) {
-        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}` });
+        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}`, confidence: 'high' });
       }
       continue;
     }
@@ -9318,7 +9743,15 @@ function verify(answerText, cwd, opts = {}) {
       } else if (deps.has(top) || deps.has(imp.module)) {
         continue;
       }
-      add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Package not in dependencies: ${imp.module}` });
+      const match = closestMatch(top, [...deps], { minLen: 3 });
+      add({
+        type: 'fake-import',
+        value: imp.module,
+        line: imp.line,
+        message: `Package not in dependencies: ${imp.module}`,
+        confidence: 'high',
+        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+      });
     }
     // Python bare imports: stdlib is unbounded offline — skip to keep precision.
   }
@@ -9328,13 +9761,40 @@ function verify(answerText, cwd, opts = {}) {
     for (const { name, line } of parsers.extractSymbols(answerText)) {
       if (symbolSet.has(name)) continue;
       if (LANG_GLOBALS.has(name) || NODE_BUILTINS.has(name) || PY_BUILTINS.has(name)) continue;
-      add({ type: 'fake-symbol', value: name, line, message: `Symbol not found in repo index: ${name}()` });
+      const match = closestMatch(name, symbolCandidates, { minLen: 4 });
+      add({
+        type: 'fake-symbol',
+        value: name,
+        line,
+        message: `Symbol not found in repo index: ${name}()`,
+        confidence: 'medium',
+        suggestion: match ? formatSuggestion(match, true) : null,
+      });
+    }
+  }
+
+  // 4. fake-npm-script
+  if (hasPkg && scripts.size > 0) {
+    for (const { name, line } of parsers.extractNpmScripts(answerText)) {
+      if (scripts.has(name)) continue;
+      const match = closestMatch(name, [...scripts], { minLen: 2 });
+      add({
+        type: 'fake-npm-script',
+        value: name,
+        line,
+        message: `npm script not in package.json: ${name}`,
+        confidence: 'high',
+        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+      });
     }
   }
 
   issues.sort((a, b) => a.line - b.line);
 
-  const byType = { 'fake-file': 0, 'fake-import': 0, 'fake-symbol': 0 };
+  const byType = {
+    'fake-file': 0, 'fake-test-file': 0, 'fake-import': 0,
+    'fake-symbol': 0, 'fake-npm-script': 0,
+  };
   for (const i of issues) byType[i.type] = (byType[i.type] || 0) + 1;
 
   const summary = {
@@ -9342,12 +9802,13 @@ function verify(answerText, cwd, opts = {}) {
     byType,
     clean: issues.length === 0,
     symbolsIndexed: symbolSet.size,
+    withSuggestion: issues.filter((i) => i.suggestion).length,
   };
 
   return { issues, summary };
 }
 
-module.exports = { verify, buildSymbolSet, loadDeps };
+module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath };
 
 };
 
@@ -11115,8 +11576,9 @@ Usage:
   ${cmd} --impact <file>                   Show every file impacted by changing <file>
   ${cmd} --impact <file> --json            Impact as JSON {changed, direct, transitive, tests, routes}
   ${cmd} --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited)
-  ${cmd} verify-ai-output <answer.md>      Flag fake files/imports/symbols in an AI answer
-  ${cmd} verify-ai-output <answer.md> --json  Hallucination report as JSON (exits 1 if issues)
+  ${cmd} verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
+  ${cmd} verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
+  ${cmd} verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
   ${cmd} --init                            Write example config + .contextignore scaffold
   ${cmd} --help                            Show this message
   ${cmd} --version                         Show version
@@ -12242,8 +12704,12 @@ function main() {
   if (args[0] === 'verify-ai-output') {
     const target = args[1];
     const jsonOut = args.includes('--json');
+    const reportIdx = args.indexOf('--report');
+    const reportOut = reportIdx !== -1
+      ? (args[reportIdx + 1] && !args[reportIdx + 1].startsWith('--') ? args[reportIdx + 1] : 'sigmap-verify-report.html')
+      : null;
     if (!target || target.startsWith('--')) {
-      console.error('[sigmap] Usage: sigmap verify-ai-output <answer.md> [--json]');
+      console.error('[sigmap] Usage: sigmap verify-ai-output <answer.md> [--json] [--report [out.html]]');
       process.exit(1);
     }
     const absTarget = path.resolve(cwd, target);
@@ -12255,24 +12721,39 @@ function main() {
     const answerText = fs.readFileSync(absTarget, 'utf8');
     const { verify } = requireSourceOrBundled('./src/verify/hallucination-guard');
     const { issues, summary } = verify(answerText, cwd);
+    const rel = path.relative(cwd, absTarget) || target;
+    const result = { file: rel, issues, summary };
+
+    // Optional HTML report (Surface A) — written alongside any other output.
+    if (reportOut) {
+      const { renderReportHtml } = requireSourceOrBundled('./src/format/verify-report');
+      const outAbs = path.resolve(cwd, reportOut);
+      fs.writeFileSync(outAbs, renderReportHtml(result));
+      if (!jsonOut) console.log(`[sigmap] report written: ${path.relative(cwd, outAbs) || reportOut}`);
+    }
 
     if (jsonOut) {
-      process.stdout.write(JSON.stringify({ file: path.relative(cwd, absTarget) || target, issues, summary }) + '\n');
+      process.stdout.write(JSON.stringify(result) + '\n');
       process.exit(summary.total > 0 ? 1 : 0);
     }
 
-    const rel = path.relative(cwd, absTarget) || target;
     if (summary.total === 0) {
       console.log(`[sigmap] ✓ ${rel} — no hallucinations detected (${summary.symbolsIndexed} symbols indexed)`);
       process.exit(0);
     }
 
-    const labels = { 'fake-file': 'Fake file', 'fake-import': 'Fake import', 'fake-symbol': 'Fake symbol' };
+    const labels = {
+      'fake-file': 'Fake file', 'fake-test-file': 'Fake test file',
+      'fake-import': 'Fake import', 'fake-symbol': 'Fake symbol',
+      'fake-npm-script': 'Fake npm script',
+    };
+    const bt = summary.byType;
     console.log(`[sigmap] ✗ ${rel} — ${summary.total} issue${summary.total === 1 ? '' : 's'} found`);
-    console.log(`  fake-file: ${summary.byType['fake-file']}  fake-import: ${summary.byType['fake-import']}  fake-symbol: ${summary.byType['fake-symbol']}`);
+    console.log(`  fake-file: ${bt['fake-file']}  fake-test-file: ${bt['fake-test-file']}  fake-import: ${bt['fake-import']}  fake-symbol: ${bt['fake-symbol']}  fake-npm-script: ${bt['fake-npm-script']}`);
     console.log('');
     for (const issue of issues) {
       console.log(`  L${issue.line}  [${labels[issue.type] || issue.type}]  ${issue.message}`);
+      if (issue.suggestion) console.log(`         ↳ ${issue.suggestion}`);
     }
     process.exit(1);
   }

--- a/gen-context.js
+++ b/gen-context.js
@@ -6238,7 +6238,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.14.0',
+  version: '6.15.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 
@@ -7115,7 +7115,7 @@ __factories["./src/session/notes"] = function(module, exports) {
 'use strict';
 
 /**
- * Decision-log notes (Memory, v6.16.0).
+ * Decision-log notes (Memory, v6.15.0).
  *
  * A tiny append-only log of human/agent notes that survives across sessions,
  * so an agent starting cold can recall "what were we doing / why". Stored as
@@ -10024,7 +10024,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = '6.14.0';
+const VERSION = '6.15.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node test/run.js && node test/r-language.test.js",
-    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp-server.test.js",
+    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/memory-tools.test.js",
     "test:integration:all": "node test/integration/all.js",
     "test:all": "node test/run.js && node test/r-language.test.js && node test/integration/strategy.test.js && node test/integration/secret-scan.test.js",
     "generate": "node gen-context.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node test/run.js && node test/r-language.test.js",
-    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp-server.test.js",
+    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js",
     "test:integration:all": "node test/integration/all.js",
     "test:all": "node test/run.js && node test/r-language.test.js && node test/integration/strategy.test.js && node test/integration/secret-scan.test.js",
     "generate": "node gen-context.js",
@@ -25,6 +25,7 @@
     "report": "node gen-context.js --report",
     "audit:strategies": "node scripts/run-strategy-audit.mjs",
     "benchmark:matrix": "node scripts/run-benchmark-matrix.mjs --save --skip-clone",
+    "benchmark:verify": "node scripts/run-verify-benchmark.mjs",
     "health": "node gen-context.js --health",
     "map": "node gen-project-map.js",
     "mcp": "node gen-context.js --mcp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
   "main": "gen-context.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/scripts/run-verify-benchmark.mjs
+++ b/scripts/run-verify-benchmark.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Hallucination Guard proof harness (Reliable MVP, v6.15.0).
+ *
+ * Runs `verify-ai-output` against a set of labeled cases and emits a
+ * per-detector precision/recall CSV (plan §2 proof requirements, §7 targets).
+ *
+ *   node scripts/run-verify-benchmark.mjs                 # offline synthetic self-test
+ *   node scripts/run-verify-benchmark.mjs --manifest cases.json
+ *   node scripts/run-verify-benchmark.mjs --out benchmarks/reports/verify-precision.csv
+ *
+ * Manifest format (JSON array) — point this at 5 real repos
+ * (small / medium / large / monorepo / framework):
+ *   [
+ *     {
+ *       "name": "axios",
+ *       "repo": "/abs/path/to/axios",
+ *       "answer": "/abs/path/to/seeded-answer.md",
+ *       "expected": {                      // ground truth
+ *         "fake":  ["src/ghost.js", "ghost-pkg", "phantomFn"],
+ *         "real":  ["src/index.js", "chalk", "isAxiosError"]  // must NOT be flagged
+ *       }
+ *     }
+ *   ]
+ *
+ * Precision = TP / (TP + FP)   (FP = a real reference wrongly flagged)
+ * Recall    = TP / (TP + FN)   (FN = a seeded fake that slipped through)
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+const args = process.argv.slice(2);
+function flag(name, def) {
+  const i = args.indexOf(name);
+  return i !== -1 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : def;
+}
+const manifestPath = flag('--manifest', null);
+const outPath = flag('--out', path.join(ROOT, 'benchmarks', 'reports', 'verify-precision.csv'));
+
+// Plan §7 precision targets per detector group.
+const TARGETS = { file: 0.95, import: 0.85, symbol: 0.75, script: 0.95 };
+const GROUP = {
+  'fake-file': 'file', 'fake-test-file': 'file',
+  'fake-import': 'import', 'fake-symbol': 'symbol', 'fake-npm-script': 'script',
+};
+
+function runVerify(repo, answer) {
+  const res = spawnSync('node', [SCRIPT, 'verify-ai-output', answer, '--cwd', repo, '--json'], {
+    cwd: ROOT, encoding: 'utf8',
+  });
+  try { return JSON.parse(res.stdout.trim()); }
+  catch { return { issues: [], summary: { total: 0 } }; }
+}
+
+/** Build an offline synthetic case so the harness runs with zero network. */
+function makeSyntheticCase() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-proof-'));
+  fs.mkdirSync(path.join(repo, 'src'));
+  fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({
+    name: 'proof', version: '1.0.0',
+    scripts: { build: 'x', test: 'x', lint: 'x' },
+    dependencies: { chalk: '^5.0.0' },
+  }, null, 2));
+  fs.writeFileSync(path.join(repo, 'src', 'index.js'),
+    'function loadConfig(p){return p;}\nfunction rankFiles(q){return q;}\nmodule.exports={loadConfig,rankFiles};\n');
+  fs.writeFileSync(path.join(repo, 'src', 'util.js'),
+    'function helper(){return 1;}\nmodule.exports={helper};\n');
+  // Seed an index so buildSigIndex has symbols.
+  spawnSync('node', [SCRIPT, '--cwd', repo], { cwd: ROOT, encoding: 'utf8' });
+
+  const answer = path.join(repo, 'answer.md');
+  fs.writeFileSync(answer, [
+    '# Implementation',
+    'Edit `src/index.js` which exposes `loadConfig()` and `rankFiles()`.',     // real (negatives)
+    'Also see `src/ghost.js` and the test `src/ghost.test.js`.',               // fake-file + fake-test-file
+    'Call `loadConfg()` (typo) and `phantomFn()`.',                            // fake-symbol ×2
+    '',
+    '```js',
+    "import { helper } from './src/util';",                                    // real
+    "import chalk from 'chalk';",                                              // real
+    "import ghost from 'ghost-pkg-9000';",                                     // fake-import
+    '```',
+    'Run `npm run build` then `npm run nope`.',                                // real script + fake-npm-script
+  ].join('\n'));
+
+  return {
+    name: 'synthetic',
+    repo, answer,
+    expected: {
+      fake: ['src/ghost.js', 'src/ghost.test.js', 'loadConfg', 'phantomFn', 'ghost-pkg-9000', 'nope'],
+      real: ['src/index.js', 'src/util.js', 'loadConfig', 'rankFiles', 'helper', 'chalk', 'build'],
+    },
+    _cleanup: () => { try { fs.rmSync(repo, { recursive: true, force: true }); } catch {} },
+  };
+}
+
+function scoreCase(c) {
+  const result = runVerify(c.repo, c.answer);
+  const flagged = new Map(); // value -> group
+  for (const issue of result.issues) flagged.set(issue.value, GROUP[issue.type] || 'other');
+
+  const fake = new Set(c.expected.fake || []);
+  const real = new Set(c.expected.real || []);
+
+  // Per-group tallies.
+  const groups = {};
+  const ensure = (g) => (groups[g] = groups[g] || { tp: 0, fp: 0, fn: 0 });
+
+  for (const [val, g] of flagged) {
+    if (fake.has(val)) ensure(g).tp++;
+    else if (real.has(val)) ensure(g).fp++;
+    // values neither labeled fake nor real are ignored (not part of ground truth)
+  }
+  // False negatives: seeded fakes that were not flagged. We can't know the
+  // group of an un-flagged value from output, so bucket by a label map if
+  // present, else attribute to a catch-all using a heuristic.
+  const fakeGroupHint = c.expected.fakeGroups || {};
+  for (const val of fake) {
+    if (!flagged.has(val)) ensure(fakeGroupHint[val] || guessGroup(val)).fn++;
+  }
+  return { name: c.name, groups, result };
+}
+
+function guessGroup(val) {
+  if (/\.(test|spec)\./.test(val)) return 'file';
+  if (/[./]/.test(val) && /\.[a-z]+$/i.test(val)) return 'file';
+  if (/^[a-z0-9@][\w@/-]*$/i.test(val) && /-/.test(val)) return 'import';
+  if (/^[a-z][\w]*$/i.test(val)) return 'symbol';
+  return 'other';
+}
+
+function pct(n) { return Number.isFinite(n) ? (n * 100).toFixed(1) + '%' : 'n/a'; }
+
+function main() {
+  let cases;
+  let synthetic = null;
+  if (manifestPath) {
+    cases = JSON.parse(fs.readFileSync(path.resolve(manifestPath), 'utf8'));
+  } else {
+    synthetic = makeSyntheticCase();
+    cases = [synthetic];
+    console.log('[proof] no --manifest given — running offline synthetic self-test\n');
+  }
+
+  const rows = [['repo', 'group', 'TP', 'FP', 'FN', 'precision', 'recall', 'target', 'meets']];
+  const agg = {};
+  let allMeet = true;
+
+  for (const c of cases) {
+    const { name, groups } = scoreCase(c);
+    for (const [g, t] of Object.entries(groups)) {
+      const precision = t.tp + t.fp ? t.tp / (t.tp + t.fp) : 1;
+      const recall = t.tp + t.fn ? t.tp / (t.tp + t.fn) : 1;
+      const target = TARGETS[g];
+      const meets = target == null ? '' : (precision >= target ? 'yes' : 'NO');
+      if (meets === 'NO') allMeet = false;
+      rows.push([name, g, t.tp, t.fp, t.fn, pct(precision), pct(recall), target != null ? pct(target) : '', meets]);
+      const a = agg[g] = agg[g] || { tp: 0, fp: 0, fn: 0 };
+      a.tp += t.tp; a.fp += t.fp; a.fn += t.fn;
+    }
+  }
+
+  for (const [g, t] of Object.entries(agg)) {
+    const precision = t.tp + t.fp ? t.tp / (t.tp + t.fp) : 1;
+    const recall = t.tp + t.fn ? t.tp / (t.tp + t.fn) : 1;
+    const target = TARGETS[g];
+    rows.push(['ALL', g, t.tp, t.fp, t.fn, pct(precision), pct(recall), target != null ? pct(target) : '', target == null ? '' : (precision >= target ? 'yes' : 'NO')]);
+  }
+
+  // Console table
+  const w = rows[0].map((_, i) => Math.max(...rows.map((r) => String(r[i]).length)));
+  for (const r of rows) console.log(r.map((v, i) => String(v).padEnd(w[i])).join('  '));
+
+  // CSV
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, rows.map((r) => r.join(',')).join('\n') + '\n');
+  console.log(`\n[proof] CSV written: ${path.relative(ROOT, outPath)}`);
+
+  if (synthetic) synthetic._cleanup();
+  if (!allMeet) {
+    console.error('\n[proof] FAIL — one or more detector groups missed its precision target');
+    process.exit(1);
+  }
+  console.log('[proof] OK — all detector groups met their precision targets');
+}
+
+main();

--- a/src/format/verify-report.js
+++ b/src/format/verify-report.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * Hallucination Guard report view (Surface A, v6.15.0).
+ *
+ * Turns the `verify-ai-output --json` result into a standalone, self-contained
+ * HTML report — red/amber/green per issue, with closest-match suggestions
+ * inline. The visual language deliberately mirrors the planned PR-comment
+ * styling so a single screenshot is reusable across docs and CI (plan proof #5).
+ *
+ * Zero dependencies, inline CSS/SVG, no external assets. Also exports a compact
+ * Markdown renderer for CI / PR comments that shares the same structure.
+ */
+
+const TYPE_META = {
+  'fake-file': { label: 'Fake file', tone: 'red', icon: '✕' },
+  'fake-test-file': { label: 'Fake test file', tone: 'red', icon: '✕' },
+  'fake-import': { label: 'Fake import', tone: 'red', icon: '✕' },
+  'fake-npm-script': { label: 'Fake npm script', tone: 'red', icon: '✕' },
+  'fake-symbol': { label: 'Fake symbol', tone: 'amber', icon: '!' },
+};
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toneFor(issue) {
+  const meta = TYPE_META[issue.type];
+  if (meta) return meta.tone;
+  return issue.confidence === 'high' ? 'red' : 'amber';
+}
+
+function labelFor(issue) {
+  return (TYPE_META[issue.type] && TYPE_META[issue.type].label) || issue.type;
+}
+
+/**
+ * Render the verify result to a full HTML document.
+ * @param {{ file?: string, issues: object[], summary: object }} result
+ * @param {object} [opts]
+ * @param {string} [opts.title]
+ * @returns {string} HTML
+ */
+function renderReportHtml(result, opts = {}) {
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  const summary = result.summary || { total: issues.length, byType: {}, clean: issues.length === 0 };
+  const file = result.file || opts.file || 'AI answer';
+  const title = opts.title || 'SigMap — Hallucination Guard report';
+  const clean = summary.clean || issues.length === 0;
+  const byType = summary.byType || {};
+
+  const chips = Object.keys(TYPE_META)
+    .filter((t) => byType[t])
+    .map((t) => `<span class="chip chip-${TYPE_META[t].tone}">${escapeHtml(TYPE_META[t].label)}: ${byType[t]}</span>`)
+    .join('');
+
+  const banner = clean
+    ? `<div class="banner banner-green"><span class="dot"></span> No hallucinations detected — ${escapeHtml(String(summary.symbolsIndexed || 0))} symbols indexed</div>`
+    : `<div class="banner banner-red"><span class="dot"></span> ${issues.length} issue${issues.length === 1 ? '' : 's'} found in <code>${escapeHtml(file)}</code></div>`;
+
+  const rows = issues.map((issue) => {
+    const tone = toneFor(issue);
+    const sugg = issue.suggestion
+      ? `<div class="suggestion">↳ ${escapeHtml(issue.suggestion)} <span class="conf">heuristic</span></div>`
+      : '';
+    return [
+      `<li class="issue issue-${tone}">`,
+      `  <div class="issue-head">`,
+      `    <span class="badge badge-${tone}">${escapeHtml(labelFor(issue))}</span>`,
+      `    <span class="loc">${escapeHtml(issue.location || ('L' + issue.line))}</span>`,
+      `    <span class="conf conf-${escapeHtml(issue.confidence || 'high')}">${escapeHtml(issue.confidence || 'high')} confidence</span>`,
+      `  </div>`,
+      `  <div class="msg">${escapeHtml(issue.message || issue.value)}</div>`,
+      `  ${sugg}`,
+      `</li>`,
+    ].join('\n');
+  }).join('\n');
+
+  const list = clean
+    ? '<p class="empty">Nothing to report — every file, import, symbol, and script in the answer resolves against the repository.</p>'
+    : `<ul class="issues">${rows}</ul>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; background: #0d1117; color: #e6edf3; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 32px 20px 64px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: #8b949e; margin: 0 0 20px; font-size: 13px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #161b22; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+  .banner { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-radius: 8px; font-weight: 600; margin-bottom: 16px; }
+  .banner-green { background: rgba(46,160,67,.15); border: 1px solid rgba(46,160,67,.4); color: #3fb950; }
+  .banner-red { background: rgba(248,81,73,.12); border: 1px solid rgba(248,81,73,.4); color: #f85149; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: currentColor; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 20px; }
+  .chip { font-size: 12px; padding: 3px 9px; border-radius: 999px; font-weight: 600; }
+  .chip-red { background: rgba(248,81,73,.15); color: #f85149; }
+  .chip-amber { background: rgba(210,153,34,.18); color: #d29922; }
+  ul.issues { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+  .issue { border: 1px solid #30363d; border-left-width: 4px; border-radius: 8px; padding: 12px 14px; background: #0f141a; }
+  .issue-red { border-left-color: #f85149; }
+  .issue-amber { border-left-color: #d29922; }
+  .issue-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .badge { font-size: 11.5px; font-weight: 700; padding: 2px 8px; border-radius: 5px; text-transform: uppercase; letter-spacing: .03em; }
+  .badge-red { background: rgba(248,81,73,.18); color: #f85149; }
+  .badge-amber { background: rgba(210,153,34,.2); color: #d29922; }
+  .loc { font-family: ui-monospace, monospace; color: #8b949e; font-size: 12px; }
+  .conf { font-size: 11px; color: #8b949e; }
+  .conf-high { color: #f85149; }
+  .conf-medium { color: #d29922; }
+  .msg { margin-top: 7px; font-family: ui-monospace, monospace; font-size: 12.5px; color: #e6edf3; }
+  .suggestion { margin-top: 6px; font-size: 12.5px; color: #3fb950; }
+  .suggestion .conf { margin-left: 6px; }
+  .empty { color: #8b949e; }
+  footer { margin-top: 28px; color: #6e7681; font-size: 12px; }
+  a { color: #58a6ff; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Hallucination Guard report</h1>
+  <p class="sub">Deterministic verification of an AI answer against the real repository — <code>sigmap verify-ai-output</code></p>
+  ${banner}
+  ${chips ? `<div class="chips">${chips}</div>` : ''}
+  ${list}
+  <footer>Generated by <a href="https://github.com/manojmallick/sigmap">SigMap</a> · offline, no LLM · suggestions are heuristic (closest-match)</footer>
+</div>
+</body>
+</html>
+`;
+}
+
+/** Compact Markdown rendering of the same result (CI / PR comments). */
+function renderReportMarkdown(result) {
+  const issues = Array.isArray(result.issues) ? result.issues : [];
+  const summary = result.summary || {};
+  const file = result.file || 'AI answer';
+  if (summary.clean || issues.length === 0) {
+    return `### ✅ Hallucination Guard — clean\n\nNo fabricated files, imports, symbols, or scripts in \`${file}\`.`;
+  }
+  const lines = [
+    `### ❌ Hallucination Guard — ${issues.length} issue${issues.length === 1 ? '' : 's'} in \`${file}\``,
+    '',
+    '| Type | Location | Detail | Suggestion |',
+    '| --- | --- | --- | --- |',
+  ];
+  for (const i of issues) {
+    const sugg = i.suggestion ? i.suggestion.replace(/\|/g, '\\|') : '—';
+    lines.push(`| ${labelFor(i)} | ${i.location || ('L' + i.line)} | \`${String(i.value).replace(/\|/g, '\\|')}\` | ${sugg} |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { renderReportHtml, renderReportMarkdown, escapeHtml };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -505,4 +505,47 @@ function getLines(args, cwd) {
   ].join('\n');
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines };
+/**
+ * read_memory({ limit? }) → string
+ *
+ * Recall the cross-session decision log (notes) plus the last ranking-session
+ * focus, formatted for an agent to consume at the start of a task.
+ */
+function readMemory(args, cwd) {
+  let limit = parseInt(args && args.limit, 10);
+  if (!Number.isFinite(limit) || limit <= 0) limit = 10;
+  limit = Math.min(limit, 50);
+
+  const out = ['# SigMap memory'];
+
+  let notes = [];
+  try {
+    const { readNotes, formatNotes } = require('../session/notes');
+    notes = readNotes(cwd, limit);
+    out.push('');
+    out.push(`## Recent notes (${notes.length})`);
+    // Most recent first for quick scanning.
+    out.push(formatNotes(notes.slice().reverse()));
+  } catch (_) {
+    out.push('');
+    out.push('_No notes available._');
+  }
+
+  // Last ranking-session focus (if any) — extends src/session/memory.js.
+  try {
+    const { loadSession } = require('../session/memory');
+    const s = loadSession(cwd);
+    if (s && (s.lastQuery || (s.topFiles && s.topFiles.length))) {
+      out.push('');
+      out.push('## Last session');
+      if (s.lastQuery) out.push(`**Last query:** ${s.lastQuery}`);
+      if (s.topFiles && s.topFiles.length) {
+        out.push(`**Focus files:** ${s.topFiles.map((f) => f.file).slice(0, 5).join(', ')}`);
+      }
+    }
+  } catch (_) { /* session optional */ }
+
+  return out.join('\n');
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -8,13 +8,13 @@
  *
  * Supported methods:
  *   initialize        → serverInfo + capabilities
- *   tools/list        → 10 tool definitions
+ *   tools/list        → 11 tool definitions
  *   tools/call        → dispatch to handler, return result
  */
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -76,6 +76,7 @@ function dispatch(msg, cwd) {
       else if (name === 'query_context') text = queryContext(args, cwd);
       else if (name === 'get_impact') text = getImpact(args, cwd);
       else if (name === 'get_lines') text = getLines(args, cwd);
+      else if (name === 'read_memory') text = readMemory(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '6.14.0',
+  version: '6.15.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,9 +1,9 @@
 'use strict';
 
 /**
- * MCP tool definitions for SigMap (10 tools).
+ * MCP tool definitions for SigMap (11 tools).
  * read_context, search_signatures, get_map, create_checkpoint, get_routing,
- * explain_file, list_modules, query_context, get_impact, get_lines.
+ * explain_file, list_modules, query_context, get_impact, get_lines, read_memory.
  */
 
 const TOOLS = [
@@ -195,6 +195,24 @@ const TOOLS = [
         },
       },
       required: ['file', 'start', 'end'],
+    },
+  },
+  {
+    name: 'read_memory',
+    description:
+      'Recall the project decision log — recent notes left by humans or agents ' +
+      'across sessions (via `sigmap note`), plus the last ranking-session focus. ' +
+      'Call this at the start of a task to kill cold-start: it answers ' +
+      '"what were we doing and why" without re-reading the whole codebase.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'How many of the most recent notes to return (default: 10, max: 50).',
+        },
+      },
+      required: [],
     },
   },
 ];

--- a/src/session/notes.js
+++ b/src/session/notes.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * Decision-log notes (Memory, v6.16.0).
+ *
+ * A tiny append-only log of human/agent notes that survives across sessions,
+ * so an agent starting cold can recall "what were we doing / why". Stored as
+ * NDJSON under `.context/` to match the project's other state logs
+ * (usage.ndjson, benchmark-history.ndjson). Zero dependencies.
+ *
+ * Consumed by the `read_memory` MCP tool and the `sigmap note` / `sigmap status`
+ * commands. Complements `src/session/memory.js` (ranking session) rather than
+ * duplicating it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const NOTES_FILE = path.join('.context', 'notes.ndjson');
+const MAX_TEXT = 2000;
+
+function notesPath(cwd) {
+  return path.join(cwd, NOTES_FILE);
+}
+
+function _currentBranch(cwd) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Append a note. Returns the stored entry.
+ * @param {string} cwd
+ * @param {string} text
+ * @param {object} [opts]
+ * @param {string|null} [opts.branch]  override branch (default: current git branch)
+ * @param {string} [opts.tag]          optional category tag
+ */
+function addNote(cwd, text, opts = {}) {
+  const clean = String(text == null ? '' : text).trim().slice(0, MAX_TEXT);
+  if (!clean) throw new Error('note text is empty');
+  const entry = {
+    ts: new Date().toISOString(),
+    text: clean,
+    branch: opts.branch !== undefined ? opts.branch : _currentBranch(cwd),
+  };
+  if (opts.tag) entry.tag = String(opts.tag).trim().slice(0, 40);
+  const p = notesPath(cwd);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.appendFileSync(p, JSON.stringify(entry) + '\n');
+  return entry;
+}
+
+/**
+ * Read notes in chronological order (oldest first).
+ * @param {string} cwd
+ * @param {number} [limit=0]  keep only the most recent N (0 = all)
+ * @returns {object[]}
+ */
+function readNotes(cwd, limit = 0) {
+  let raw;
+  try { raw = fs.readFileSync(notesPath(cwd), 'utf8'); }
+  catch (_) { return []; }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try { out.push(JSON.parse(t)); } catch (_) { /* skip corrupt line */ }
+  }
+  if (limit > 0 && out.length > limit) return out.slice(out.length - limit);
+  return out;
+}
+
+/** Format notes as a Markdown list (pass already-ordered notes). */
+function formatNotes(notes) {
+  if (!notes || !notes.length) {
+    return 'No notes recorded yet. Add one with: sigmap note "<text>"';
+  }
+  return notes.map((n) => {
+    const when = String(n.ts || '').replace('T', ' ').slice(0, 16);
+    const br = n.branch ? ` (${n.branch})` : '';
+    const tag = n.tag ? ` #${n.tag}` : '';
+    return `- [${when}${br}]${tag} ${n.text}`;
+  }).join('\n');
+}
+
+/** Delete the notes log. Returns true if a file was removed. */
+function clearNotes(cwd) {
+  try { fs.unlinkSync(notesPath(cwd)); return true; }
+  catch (_) { return false; }
+}
+
+module.exports = { notesPath, addNote, readNotes, formatNotes, clearNotes };

--- a/src/session/notes.js
+++ b/src/session/notes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Decision-log notes (Memory, v6.16.0).
+ * Decision-log notes (Memory, v6.15.0).
  *
  * A tiny append-only log of human/agent notes that survives across sessions,
  * so an agent starting cold can recall "what were we doing / why". Stored as

--- a/src/verify/closest-match.js
+++ b/src/verify/closest-match.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * Closest-match suggestions for the Hallucination Guard (v6.15.0).
+ *
+ * Heuristic layer (plan §5 labels this "Medium" confidence): given a name the
+ * detectors flagged as fake, find the nearest *real* candidate by Levenshtein
+ * distance so the report can say "Did you mean `loadConfig()` in
+ * src/config/loader.js:42?". Pure, deterministic, offline — no network, no LLM.
+ *
+ * All inputs are passed in (symbol/file/script candidate lists) so this module
+ * stays unit-testable without touching the filesystem or the SigMap index.
+ */
+
+/**
+ * Levenshtein edit distance with an early-exit ceiling.
+ * Returns `max + 1` as soon as the best achievable distance exceeds `max`,
+ * so callers can cheaply reject far-apart strings.
+ */
+function levenshtein(a, b, max = Infinity) {
+  if (a === b) return 0;
+  const al = a.length;
+  const bl = b.length;
+  if (al === 0) return bl;
+  if (bl === 0) return al;
+  if (Math.abs(al - bl) > max) return max + 1;
+
+  let prev = new Array(bl + 1);
+  let curr = new Array(bl + 1);
+  for (let j = 0; j <= bl; j++) prev[j] = j;
+
+  for (let i = 1; i <= al; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= bl; j++) {
+      const cost = ca === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > max) return max + 1;
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+  return prev[bl];
+}
+
+/** Bucket a normalized edit distance into a confidence label (plan §5). */
+function suggestionConfidence(distance, targetLen) {
+  const ratio = distance / Math.max(targetLen, 1);
+  if (distance === 0 || ratio <= 0.2) return 'high';
+  if (ratio <= 0.4) return 'medium';
+  return 'low';
+}
+
+/**
+ * Find the nearest candidate name to `target`.
+ *
+ * @param {string} target
+ * @param {Array<string | { name: string, file?: string, line?: number }>} candidates
+ * @param {object} [opts]
+ * @param {number} [opts.maxRatio=0.5]  reject matches farther than ratio·len edits
+ * @param {number} [opts.minLen=3]      skip very short targets (too noisy)
+ * @returns {{ name, file, line, distance, confidence } | null}
+ */
+function closestMatch(target, candidates, opts = {}) {
+  const maxRatio = opts.maxRatio != null ? opts.maxRatio : 0.5;
+  const minLen = opts.minLen != null ? opts.minLen : 3;
+  if (!target || target.length < minLen) return null;
+  if (!candidates || candidates.length === 0) return null;
+
+  const lower = target.toLowerCase();
+  const cap = Math.max(1, Math.ceil(target.length * maxRatio));
+  let best = null;
+
+  for (const c of candidates) {
+    const name = typeof c === 'string' ? c : c && c.name;
+    if (!name || name === target) continue;
+    if (Math.abs(name.length - target.length) > cap) continue;
+    const d = levenshtein(lower, name.toLowerCase(), cap);
+    if (d > cap) continue;
+    if (!best || d < best.distance ||
+        (d === best.distance && name.length < best.name.length)) {
+      best = {
+        name,
+        file: typeof c === 'object' ? c.file : undefined,
+        line: typeof c === 'object' ? c.line : undefined,
+        distance: d,
+      };
+      if (d === 0) break; // case-only difference — can't beat it
+    }
+  }
+
+  if (!best) return null;
+  best.confidence = suggestionConfidence(best.distance, target.length);
+  return best;
+}
+
+/**
+ * Build `[{ name, file, line }]` symbol candidates from a SigMap signature
+ * index (`Map<file, string[]>` whose entries may carry a `:start-end` anchor).
+ */
+function buildSymbolCandidates(sigIndex) {
+  const out = [];
+  const seen = new Set();
+  if (!sigIndex) return out;
+  for (const [file, sigs] of sigIndex) {
+    for (const sig of sigs) {
+      const s = String(sig);
+      const lineM = s.match(/:(\d+)(?:-\d+)?\s*$/);
+      const line = lineM ? parseInt(lineM[1], 10) : null;
+      const cleaned = s.replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+      const m = cleaned.match(/\b(?:async\s+function|function|class|def|interface|type|enum|const|let|var)\s+([A-Za-z_$][\w$]*)/)
+        || cleaned.match(/([A-Za-z_$][\w$]*)\s*\(/)
+        || cleaned.match(/([A-Za-z_$][\w$]*)/);
+      if (!m) continue;
+      const name = m[1];
+      const key = name + '@' + file;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ name, file, line });
+    }
+  }
+  return out;
+}
+
+/** Format a suggestion object into a human one-liner for reports/CLI. */
+function formatSuggestion(match, asCall) {
+  if (!match) return null;
+  const sym = asCall ? `${match.name}()` : match.name;
+  let where = '';
+  if (match.file) {
+    where = match.line ? ` in ${match.file}:${match.line}` : ` in ${match.file}`;
+  }
+  return `Did you mean \`${sym}\`${where}?`;
+}
+
+module.exports = {
+  levenshtein,
+  closestMatch,
+  buildSymbolCandidates,
+  suggestionConfidence,
+  formatSuggestion,
+};

--- a/src/verify/hallucination-guard.js
+++ b/src/verify/hallucination-guard.js
@@ -1,21 +1,31 @@
 'use strict';
 
 /**
- * Hallucination Guard — deterministic core (Phase 1 MVP).
+ * Hallucination Guard — deterministic core (Reliable MVP, v6.15.0).
  *
  * Given the text of an AI answer, flag claims that do not match the repo:
- *   - fake-file   : a referenced path is not on disk
- *   - fake-import : a relative import does not resolve; a bare import is
- *                   absent from package.json deps (builtins allow-listed)
- *   - fake-symbol : a called function/class is absent from the symbol index
+ *   - fake-file      : a referenced path is not on disk
+ *   - fake-test-file : a referenced *test* path is not on disk (sub-type)
+ *   - fake-import    : a relative import does not resolve; a bare import is
+ *                      absent from package.json deps (builtins allow-listed)
+ *   - fake-symbol    : a called function/class is absent from the symbol index
+ *   - fake-npm-script: `npm run X` where X is not a package.json script
  *
- * No network, no LLM. Reuses SigMap primitives (buildSigIndex) but every
- * external dependency is injectable via `opts` so the core stays unit-testable.
+ * Each issue carries a `confidence` (detection certainty) and, where a near
+ * match exists, a heuristic `suggestion` ("Did you mean …?"). No network, no
+ * LLM. Reuses SigMap primitives (buildSigIndex) but every external dependency
+ * is injectable via `opts` so the core stays unit-testable.
  */
 
 const fs = require('fs');
 const path = require('path');
 const parsers = require('./parsers');
+const { closestMatch, buildSymbolCandidates, formatSuggestion } = require('./closest-match');
+
+// A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
+// a tests/__tests__ directory). Used to flag fake-test-file separately.
+const TEST_PATH_RE = /(?:\.(?:test|spec)\.[mc]?[jt]sx?$)|(?:(?:^|\/)__tests__\/)|(?:(?:^|\/)test_[^/]+\.py$)|(?:_test\.py$)|(?:(?:^|\/)tests?\/)/i;
+function isTestPath(p) { return TEST_PATH_RE.test(p); }
 
 const NODE_BUILTINS = new Set([
   'fs', 'path', 'os', 'util', 'events', 'stream', 'http', 'https', 'crypto',
@@ -49,10 +59,14 @@ const LANG_GLOBALS = new Set([
 const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
 const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
 
-/** Build the set of known symbol identifiers from the SigMap signature index. */
+/**
+ * Build the set of known symbol identifiers from the SigMap signature index,
+ * plus `{ name, file, line }` candidates (for closest-match suggestions).
+ */
 function buildSymbolSet(cwd) {
   const set = new Set();
   let fileKeys = [];
+  let symbolCandidates = [];
   try {
     const { buildSigIndex } = require('../retrieval/ranker');
     const idx = buildSigIndex(cwd);
@@ -64,8 +78,9 @@ function buildSymbolSet(cwd) {
         for (const id of ids) set.add(id);
       }
     }
+    symbolCandidates = buildSymbolCandidates(idx);
   } catch (_) {}
-  return { set, fileKeys };
+  return { set, fileKeys, symbolCandidates };
 }
 
 /** Load declared dependency names from package.json. */
@@ -82,6 +97,18 @@ function loadDeps(cwd) {
     }
   } catch (_) {}
   return { deps, hasPkg };
+}
+
+/** Load the set of npm script names declared in package.json. */
+function loadScripts(cwd) {
+  const scripts = new Set();
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    if (pkg.scripts && typeof pkg.scripts === 'object') {
+      for (const name of Object.keys(pkg.scripts)) scripts.add(name);
+    }
+  } catch (_) {}
+  return scripts;
 }
 
 /** Default file-existence check: resolve a referenced path against cwd. */
@@ -118,11 +145,20 @@ function defaultRelativeResolvable(cwd, mod, fileBasenames) {
 /**
  * Verify an AI answer against the repository.
  *
+ * Each issue has the shape:
+ *   { type, value, line, location, message, confidence, suggestion }
+ * where `confidence` is the *detection* certainty ('high' for path/dep/script
+ * checks, 'medium' for symbol checks) and `suggestion` is a heuristic
+ * closest-match hint (or null).
+ *
  * @param {string} answerText
  * @param {string} cwd
  * @param {object} [opts]
  * @param {Set<string>} [opts.symbolSet]      override known symbols
+ * @param {Array}       [opts.symbolCandidates] override { name, file, line } list
+ * @param {Array<string>} [opts.fileCandidates]  override repo file paths (suggestions)
  * @param {Set<string>} [opts.deps]           override package deps
+ * @param {Set<string>} [opts.scripts]        override package.json script names
  * @param {boolean}     [opts.hasPkg]         whether a package.json exists
  * @param {(ref: string) => boolean} [opts.fileExists]          override file check
  * @param {(mod: string) => boolean} [opts.relativeResolvable]  override rel-import check
@@ -131,12 +167,16 @@ function defaultRelativeResolvable(cwd, mod, fileBasenames) {
 function verify(answerText, cwd, opts = {}) {
   let symbolSet = opts.symbolSet;
   let fileBasenames = opts.fileBasenames;
+  let symbolCandidates = opts.symbolCandidates || [];
+  let fileCandidates = opts.fileCandidates || [];
   if (!symbolSet) {
     const built = buildSymbolSet(cwd);
     symbolSet = built.set;
     fileBasenames = new Set(built.fileKeys.map(
       (k) => path.basename(k).replace(/\.[^.]+$/, '').toLowerCase()
     ));
+    symbolCandidates = built.symbolCandidates;
+    fileCandidates = built.fileKeys;
   }
   if (!fileBasenames) fileBasenames = new Set();
 
@@ -147,10 +187,15 @@ function verify(answerText, cwd, opts = {}) {
     deps = loaded.deps;
     if (hasPkg === undefined) hasPkg = loaded.hasPkg;
   }
+  const scripts = opts.scripts || (hasPkg ? loadScripts(cwd) : new Set());
 
   const fileExists = opts.fileExists || ((ref) => defaultFileExists(cwd, ref));
   const relativeResolvable = opts.relativeResolvable
     || ((mod) => defaultRelativeResolvable(cwd, mod, fileBasenames));
+
+  // Pre-derive basename candidates for file suggestions (compare on basename so
+  // a wrong directory still surfaces the right file).
+  const fileBasenameCandidates = fileCandidates.map((f) => ({ name: path.basename(f), file: f }));
 
   const issues = [];
   const dedupe = new Set();
@@ -158,21 +203,31 @@ function verify(answerText, cwd, opts = {}) {
     const key = `${issue.type}::${issue.value}`;
     if (dedupe.has(key)) return;
     dedupe.add(key);
+    if (!('suggestion' in issue)) issue.suggestion = null;
+    issue.location = `L${issue.line}`;
     issues.push(issue);
   };
 
-  // 1. fake-file
+  // 1. fake-file / fake-test-file
   for (const { path: p, line } of parsers.extractFilePaths(answerText)) {
-    if (!fileExists(p)) {
-      add({ type: 'fake-file', value: p, line, message: `File not found on disk: ${p}` });
-    }
+    if (fileExists(p)) continue;
+    const isTest = isTestPath(p);
+    const match = closestMatch(path.basename(p), fileBasenameCandidates, { minLen: 4 });
+    add({
+      type: isTest ? 'fake-test-file' : 'fake-file',
+      value: p,
+      line,
+      message: `${isTest ? 'Test file' : 'File'} not found on disk: ${p}`,
+      confidence: 'high',
+      suggestion: match ? formatSuggestion(match, false) : null,
+    });
   }
 
   // 2. fake-import
   for (const imp of parsers.extractImports(answerText)) {
     if (imp.relative) {
       if (!relativeResolvable(imp.module)) {
-        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}` });
+        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}`, confidence: 'high' });
       }
       continue;
     }
@@ -187,7 +242,15 @@ function verify(answerText, cwd, opts = {}) {
       } else if (deps.has(top) || deps.has(imp.module)) {
         continue;
       }
-      add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Package not in dependencies: ${imp.module}` });
+      const match = closestMatch(top, [...deps], { minLen: 3 });
+      add({
+        type: 'fake-import',
+        value: imp.module,
+        line: imp.line,
+        message: `Package not in dependencies: ${imp.module}`,
+        confidence: 'high',
+        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+      });
     }
     // Python bare imports: stdlib is unbounded offline — skip to keep precision.
   }
@@ -197,13 +260,40 @@ function verify(answerText, cwd, opts = {}) {
     for (const { name, line } of parsers.extractSymbols(answerText)) {
       if (symbolSet.has(name)) continue;
       if (LANG_GLOBALS.has(name) || NODE_BUILTINS.has(name) || PY_BUILTINS.has(name)) continue;
-      add({ type: 'fake-symbol', value: name, line, message: `Symbol not found in repo index: ${name}()` });
+      const match = closestMatch(name, symbolCandidates, { minLen: 4 });
+      add({
+        type: 'fake-symbol',
+        value: name,
+        line,
+        message: `Symbol not found in repo index: ${name}()`,
+        confidence: 'medium',
+        suggestion: match ? formatSuggestion(match, true) : null,
+      });
+    }
+  }
+
+  // 4. fake-npm-script
+  if (hasPkg && scripts.size > 0) {
+    for (const { name, line } of parsers.extractNpmScripts(answerText)) {
+      if (scripts.has(name)) continue;
+      const match = closestMatch(name, [...scripts], { minLen: 2 });
+      add({
+        type: 'fake-npm-script',
+        value: name,
+        line,
+        message: `npm script not in package.json: ${name}`,
+        confidence: 'high',
+        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+      });
     }
   }
 
   issues.sort((a, b) => a.line - b.line);
 
-  const byType = { 'fake-file': 0, 'fake-import': 0, 'fake-symbol': 0 };
+  const byType = {
+    'fake-file': 0, 'fake-test-file': 0, 'fake-import': 0,
+    'fake-symbol': 0, 'fake-npm-script': 0,
+  };
   for (const i of issues) byType[i.type] = (byType[i.type] || 0) + 1;
 
   const summary = {
@@ -211,9 +301,10 @@ function verify(answerText, cwd, opts = {}) {
     byType,
     clean: issues.length === 0,
     symbolsIndexed: symbolSet.size,
+    withSuggestion: issues.filter((i) => i.suggestion).length,
   };
 
   return { issues, summary };
 }
 
-module.exports = { verify, buildSymbolSet, loadDeps };
+module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath };

--- a/src/verify/parsers.js
+++ b/src/verify/parsers.js
@@ -106,11 +106,61 @@ function extractImports(text) {
     let r;
     while ((r = reqRe.exec(line)) !== null) push(r[1], 'js', i + 1, line);
 
+    // TS: import X = require('mod')
+    if ((m = line.match(/\bimport\s+[A-Za-z_$][\w$]*\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/))) {
+      push(m[1], 'js', i + 1, line);
+    }
+
     // Python: from x import y  |  import x
     if ((m = line.match(/^\s*from\s+([.\w]+)\s+import\b/))) {
       push(m[1], 'py', i + 1, line);
     } else if ((m = line.match(/^\s*import\s+([A-Za-z_][\w.]*)/))) {
       push(m[1], 'py', i + 1, line);
+    }
+  }
+
+  // Multi-line JS/TS imports, e.g.
+  //   import {
+  //     A as B,
+  //   } from './mod';
+  // The per-line pass above misses these because `from '…'` sits on a later
+  // line. Trigger only when the opening line has no quote and no `from` yet,
+  // then gather forward until the source string appears.
+  for (let i = 0; i < lines.length; i++) {
+    const start = lines[i];
+    if (!/^\s*(?:import|export)\b/.test(start)) continue;
+    if (/['"]/.test(start) || /\bfrom\b/.test(start)) continue; // single-line, already handled
+    let joined = start;
+    for (let j = i + 1; j < Math.min(lines.length, i + 12); j++) {
+      joined += ' ' + lines[j];
+      const fm = joined.match(/\bfrom\s*['"]([^'"]+)['"]/);
+      if (fm) { push(fm[1], 'js', i + 1, start.trim()); break; }
+      if (/['"]/.test(lines[j]) && !/\bfrom\b/.test(joined)) break; // a string that isn't a source — bail
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract npm/pnpm/yarn script invocations (`npm run <name>`).
+ * Only the explicit `run` form is matched, to avoid confusing package-manager
+ * subcommands (`yarn add`, `pnpm install`) with script names.
+ * @param {string} text
+ * @returns {{ name: string, line: number }[]}
+ */
+function extractNpmScripts(text) {
+  const lines = text.split('\n');
+  const out = [];
+  const seen = new Set();
+  const re = /\b(?:npm|pnpm|yarn)\s+run(?:-script)?\s+([A-Za-z0-9:_-]+)/g;
+  for (let i = 0; i < lines.length; i++) {
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(lines[i])) !== null) {
+      const name = m[1];
+      if (seen.has(name)) continue;
+      seen.add(name);
+      out.push({ name, line: i + 1 });
     }
   }
   return out;
@@ -146,4 +196,5 @@ module.exports = {
   extractFilePaths,
   extractImports,
   extractSymbols,
+  extractNpmScripts,
 };

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 10 tools (not 9)', () => {
+test('mcp.md: description mentions 11 tools (not 10)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('10 tools'), 'missing "10 tools" in mcp.md');
+  assert.ok(src.includes('11 tools'), 'missing "11 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -80,9 +80,9 @@ test('quality-benchmark: latest saved run is v5.7.0 or later', () => {
 
 // ── Benchmark metric accuracy ─────────────────────────────────────────────────
 
-test('generalization: uses 81.1% hit@5 (current v6.11.1 benchmark)', () => {
+test('generalization: uses 75.6% hit@5 (current v6.11.1 benchmark)', () => {
   const src = readGuide('generalization.md');
-  assert.ok(src.includes('81.1%'), 'missing 81.1% hit@5 in generalization.md');
+  assert.ok(src.includes('75.6%'), 'missing 75.6% hit@5 in generalization.md');
   assert.ok(!src.includes('80.0% hit@5'), 'found stale 80.0% in generalization.md');
   assert.ok(!src.includes('78.9%'), 'found stale 78.9% in generalization.md');
 });

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -68,16 +68,16 @@ test('what-it-is: short explanation present', () => {
 
 // ── Section 4: Why SigMap ─────────────────────────────────────────────────────
 
-test('why: 81.1% hit@5 mentioned', () => {
-  assert.ok(src.includes('81.1%'), 'missing 81.1% hit@5');
+test('why: 75.6% hit@5 mentioned', () => {
+  assert.ok(src.includes('75.6%'), 'missing 75.6% hit@5');
 });
 
 test('why: 13.6% baseline mentioned', () => {
   assert.ok(src.includes('13.6%'), 'missing 13.6% baseline');
 });
 
-test('why: token reduction 96.5% mentioned', () => {
-  assert.ok(src.includes('96.5%'), 'missing 96.5% token reduction');
+test('why: token reduction 97.1% mentioned', () => {
+  assert.ok(src.includes('97.1%'), 'missing 97.1% token reduction');
 });
 
 // ── Section 5: Replace section ────────────────────────────────────────────────
@@ -122,28 +122,28 @@ test('workflow: Ask → Rank → Context → Validate → Judge → Learn', () =
 
 // ── Section 7: Benchmark ─────────────────────────────────────────────────────
 
-test('benchmark: sigmap-v6.13-main ID present', () => {
-  assert.ok(src.includes('sigmap-v6.13-main'), 'missing sigmap-v6.13-main benchmark ID');
+test('benchmark: sigmap-v6.15-main ID present', () => {
+  assert.ok(src.includes('sigmap-v6.15-main'), 'missing sigmap-v6.15-main benchmark ID');
 });
 
-test('benchmark: date 2026-06-05 present', () => {
-  assert.ok(src.includes('2026-06-05'), 'missing benchmark date 2026-06-05');
+test('benchmark: date 2026-06-09 present', () => {
+  assert.ok(src.includes('2026-06-09'), 'missing benchmark date 2026-06-09');
 });
 
-test('benchmark: Hit@5 81.1% present', () => {
-  assert.ok(src.includes('81.1%'), 'missing Hit@5 81.1%');
+test('benchmark: Hit@5 75.6% present', () => {
+  assert.ok(src.includes('75.6%'), 'missing Hit@5 75.6%');
 });
 
 test('benchmark: baseline 13.6% present', () => {
   assert.ok(src.includes('13.6%'), 'missing baseline 13.6%');
 });
 
-test('benchmark: prompt reduction 41.8% present', () => {
-  assert.ok(src.includes('41.8%'), 'missing prompt reduction 41.8%');
+test('benchmark: prompt reduction 39.0% present', () => {
+  assert.ok(src.includes('39.0%'), 'missing prompt reduction 39.0%');
 });
 
-test('benchmark: task success 53.3% present', () => {
-  assert.ok(src.includes('53.3%'), 'missing task success 53.3%');
+test('benchmark: task success 51.1% present', () => {
+  assert.ok(src.includes('51.1%'), 'missing task success 51.1%');
 });
 
 // ── Section 8: Install ────────────────────────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -69,9 +69,9 @@ test('version.json: languages is 31', () => {
   assert.strictEqual(v.languages, 31);
 });
 
-test('version.json: mcp_tools is 10', () => {
+test('version.json: mcp_tools is 11', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 10);
+  assert.strictEqual(v.mcp_tools, 11);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -174,7 +174,7 @@ test('compare-alternatives.md: covers SigMap vs Copilot', () => {
 
 test('compare-alternatives.md: contains correct hit@5 figure', () => {
   const src = readGuide('compare-alternatives.md');
-  assert.ok(src.includes('81.1%'), 'missing 81.1% hit@5 in compare-alternatives');
+  assert.ok(src.includes('75.6%'), 'missing 75.6% hit@5 in compare-alternatives');
   assert.ok(!src.includes('80.0%'), 'found stale 80.0% hit@5 in compare-alternatives');
 });
 
@@ -215,21 +215,21 @@ test('docs/impact-banner.svg: no stale 80.0% hit@5', () => {
   assert.ok(!src.includes('80.0%'), 'found stale 80.0% in impact-banner.svg');
 });
 
-test('docs/impact-banner.svg: uses 81.1% hit@5', () => {
+test('docs/impact-banner.svg: uses 75.6% hit@5', () => {
   const src = readDocs('impact-banner.svg');
-  assert.ok(src.includes('81.1%'), 'missing 81.1% in impact-banner.svg');
+  assert.ok(src.includes('75.6%'), 'missing 75.6% in impact-banner.svg');
 });
 
-test('docs/impact-banner.svg: uses 1.66 prompts (not 1.68)', () => {
+test('docs/impact-banner.svg: uses 1.73 prompts (not 1.68)', () => {
   const src = readDocs('impact-banner.svg');
   assert.ok(!src.includes('1.68'), 'found stale 1.68 in impact-banner.svg');
-  assert.ok(src.includes('1.66'), 'missing 1.66 in impact-banner.svg');
+  assert.ok(src.includes('1.73'), 'missing 1.73 in impact-banner.svg');
 });
 
-test('docs/comparison-chart.svg: uses 81.1% (not 80.0%)', () => {
+test('docs/comparison-chart.svg: uses 75.6% (not 80.0%)', () => {
   const src = readDocs('comparison-chart.svg');
   assert.ok(!src.includes('80.0%'), 'found stale 80.0% in comparison-chart.svg');
-  assert.ok(src.includes('81.1%'), 'missing 81.1% in comparison-chart.svg');
+  assert.ok(src.includes('75.6%'), 'missing 75.6% in comparison-chart.svg');
 });
 
 test('docs/index.html: softwareVersion is 5.8.0', () => {

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 10 tools including get_impact', () => {
+test('MCP tools/list: returns 11 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 10, `expected 10 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 11, `expected 11 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (10 tools total)', () => {
+test('get_lines is registered (11 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 10, `expected 10 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 11, `expected 11 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -99,14 +99,14 @@ test('initialize returns serverInfo', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
-// Gate 2: tools/list returns 10 tools (v6.12+)
+// Gate 2: tools/list returns 11 tools (v6.16+)
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 10 tools', () => {
+test('tools/list returns exactly 11 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 10);
+    assert.strictEqual(res.result.tools.length, 11);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -78,21 +78,22 @@ function seedContextFile(dir) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Gate: tools/list now returns 10 tools including v6.12 get_lines
+// Gate: tools/list now returns 11 tools including v6.16 read_memory
 // ─────────────────────────────────────────────────────────────
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 10 tools', () => {
+test('tools/list returns exactly 11 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 10, `Expected 10 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 11, `Expected 11 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');
     assert.ok(names.includes('query_context'), 'Should have query_context');
+    assert.ok(names.includes('read_memory'), 'Should have read_memory');
   });
 });
 

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+/**
+ * Integration tests for the Memory tools (v6.16.0):
+ *   - src/session/notes.js  — addNote / readNotes / formatNotes / clearNotes
+ *   - CLI `sigmap note "<text>"` / `note --list` (+ --json)
+ *   - CLI `sigmap status` (+ --json)
+ *   - read_memory MCP handler + tools/list registration (11th tool)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const notes = require(path.join(ROOT, 'src', 'session', 'notes'));
+const handlers = require(path.join(ROOT, 'src', 'mcp', 'handlers'));
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function tmpRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-mem-'));
+  spawnSync('git', ['init', '-q'], { cwd: dir });
+  spawnSync('git', ['config', 'user.email', 't@t.co'], { cwd: dir });
+  spawnSync('git', ['config', 'user.name', 't'], { cwd: dir });
+  return dir;
+}
+function run(dir, args) {
+  return spawnSync('node', [SCRIPT, ...args, '--cwd', dir], { cwd: ROOT, encoding: 'utf8' });
+}
+
+// --------------------------------------------------------------------------
+// notes module
+// --------------------------------------------------------------------------
+test('addNote appends and readNotes returns chronological order', () => {
+  const dir = tmpRepo();
+  notes.addNote(dir, 'first', { branch: 'main' });
+  notes.addNote(dir, 'second', { branch: 'main' });
+  const all = notes.readNotes(dir);
+  assert.strictEqual(all.length, 2);
+  assert.strictEqual(all[0].text, 'first');
+  assert.strictEqual(all[1].text, 'second');
+  assert.ok(all[0].ts && all[0].branch === 'main');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('readNotes limit keeps the most recent N', () => {
+  const dir = tmpRepo();
+  for (let i = 0; i < 5; i++) notes.addNote(dir, `n${i}`, { branch: null });
+  const last2 = notes.readNotes(dir, 2);
+  assert.deepStrictEqual(last2.map((n) => n.text), ['n3', 'n4']);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('addNote rejects empty text; clearNotes removes the log', () => {
+  const dir = tmpRepo();
+  assert.throws(() => notes.addNote(dir, '   '), /empty/);
+  notes.addNote(dir, 'keep', {});
+  assert.ok(fs.existsSync(notes.notesPath(dir)));
+  assert.strictEqual(notes.clearNotes(dir), true);
+  assert.strictEqual(notes.readNotes(dir).length, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('formatNotes renders a markdown list and an empty hint', () => {
+  assert.ok(/sigmap note/.test(notes.formatNotes([])));
+  const md = notes.formatNotes([{ ts: '2026-06-08T10:00:00Z', text: 'hi', branch: 'dev' }]);
+  assert.ok(/- \[2026-06-08 10:00 \(dev\)\] hi/.test(md));
+});
+
+test('readNotes tolerates a corrupt line', () => {
+  const dir = tmpRepo();
+  fs.mkdirSync(path.dirname(notes.notesPath(dir)), { recursive: true });
+  fs.writeFileSync(notes.notesPath(dir), '{bad json}\n' + JSON.stringify({ ts: 'x', text: 'ok' }) + '\n');
+  const all = notes.readNotes(dir);
+  assert.strictEqual(all.length, 1);
+  assert.strictEqual(all[0].text, 'ok');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// --------------------------------------------------------------------------
+// CLI: note
+// --------------------------------------------------------------------------
+test('CLI note adds a note; --cwd value never leaks into the text', () => {
+  const dir = tmpRepo();
+  const res = run(dir, ['note', 'refactor the auth flow']);
+  assert.strictEqual(res.status, 0, res.stderr);
+  const all = notes.readNotes(dir);
+  assert.strictEqual(all.length, 1);
+  assert.strictEqual(all[0].text, 'refactor the auth flow'); // not "... <tmpdir>"
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI note --json lists recent notes', () => {
+  const dir = tmpRepo();
+  run(dir, ['note', 'alpha']);
+  run(dir, ['note', 'beta']);
+  const res = run(dir, ['note', '--json']);
+  const obj = JSON.parse(res.stdout.trim());
+  assert.ok(Array.isArray(obj.notes) && obj.notes.length === 2);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI note with no log lists nothing gracefully', () => {
+  const dir = tmpRepo();
+  const res = run(dir, ['note']);
+  assert.strictEqual(res.status, 0);
+  assert.ok(/0 recent notes/.test(res.stdout));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// --------------------------------------------------------------------------
+// CLI: status
+// --------------------------------------------------------------------------
+test('CLI status --json reports branch, dirty count, notes', () => {
+  const dir = tmpRepo();
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'x'); // untracked → dirty
+  notes.addNote(dir, 'a note', { branch: 'main' });
+  const res = run(dir, ['status', '--json']);
+  const st = JSON.parse(res.stdout.trim());
+  // Branch name varies with git's init.defaultBranch — assert it resolved at all
+  // (symbolic-ref fallback works even on an unborn branch with no commits).
+  assert.ok(typeof st.branch === 'string' && st.branch.length > 0, `branch was ${st.branch}`);
+  assert.ok(st.dirty >= 1);
+  assert.strictEqual(st.notes, 1);
+  assert.ok(st.lastNote && st.lastNote.text === 'a note');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI status human output renders the expected lines', () => {
+  const dir = tmpRepo();
+  const res = run(dir, ['status']);
+  assert.strictEqual(res.status, 0);
+  assert.ok(/Branch:/.test(res.stdout));
+  assert.ok(/Working tree:/.test(res.stdout));
+  assert.ok(/Last index:/.test(res.stdout));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// --------------------------------------------------------------------------
+// read_memory handler + MCP registration
+// --------------------------------------------------------------------------
+test('readMemory handler returns recent notes, most-recent first', () => {
+  const dir = tmpRepo();
+  notes.addNote(dir, 'older', { branch: 'main' });
+  notes.addNote(dir, 'newer', { branch: 'main' });
+  const out = handlers.readMemory({ limit: 5 }, dir);
+  assert.ok(/Recent notes \(2\)/.test(out));
+  const iOlder = out.indexOf('older');
+  const iNewer = out.indexOf('newer');
+  assert.ok(iNewer < iOlder && iNewer !== -1, 'most recent first');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('readMemory handles an empty repo without throwing', () => {
+  const dir = tmpRepo();
+  const out = handlers.readMemory({}, dir);
+  assert.ok(/SigMap memory/.test(out));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
+  const dir = tmpRepo();
+  notes.addNote(dir, 'seed note', { branch: 'main' });
+  const reqs = [
+    { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+    { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'read_memory', arguments: { limit: 3 } } },
+  ].map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
+  const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
+  const tools = lines.find((l) => l.id === 1).result.tools;
+  assert.strictEqual(tools.length, 11);
+  assert.ok(tools.some((t) => t.name === 'read_memory'));
+  const text = lines.find((l) => l.id === 2).result.content[0].text;
+  assert.ok(/seed note/.test(text));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+console.log(`\nmemory-tools: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 8 tools including query_context', () => {
+test('MCP tools/list: returns 11 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 10, `expected 10 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 11, `expected 11 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/test/integration/verify-ai-output.test.js
+++ b/test/integration/verify-ai-output.test.js
@@ -30,7 +30,9 @@ const { spawnSync } = require('child_process');
 const ROOT = path.resolve(__dirname, '../..');
 const SCRIPT = path.join(ROOT, 'gen-context.js');
 const parsers = require(path.join(ROOT, 'src', 'verify', 'parsers'));
-const { verify } = require(path.join(ROOT, 'src', 'verify', 'hallucination-guard'));
+const { verify, isTestPath } = require(path.join(ROOT, 'src', 'verify', 'hallucination-guard'));
+const closest = require(path.join(ROOT, 'src', 'verify', 'closest-match'));
+const report = require(path.join(ROOT, 'src', 'format', 'verify-report'));
 
 let passed = 0;
 let failed = 0;
@@ -139,6 +141,139 @@ test('builtins + scoped/real deps are not flagged', () => {
 });
 
 // --------------------------------------------------------------------------
+// New detectors + schema (Reliable MVP, v6.15.0)
+// --------------------------------------------------------------------------
+test('fake-test-file is a distinct type from fake-file', () => {
+  const opts = { ...baseOpts, fileExists: () => false };
+  const { issues } = verify('See `src/foo.test.js` and `src/foo.js` and `__tests__/x.js`.', '/x', opts);
+  const byType = Object.fromEntries(issues.map((i) => [i.value, i.type]));
+  assert.strictEqual(byType['src/foo.test.js'], 'fake-test-file');
+  assert.strictEqual(byType['__tests__/x.js'], 'fake-test-file');
+  assert.strictEqual(byType['src/foo.js'], 'fake-file');
+});
+
+test('isTestPath recognises spec/test/python conventions', () => {
+  assert.ok(isTestPath('a/b.spec.ts'));
+  assert.ok(isTestPath('test_thing.py'));
+  assert.ok(isTestPath('thing_test.py'));
+  assert.ok(isTestPath('tests/x.js'));
+  assert.ok(!isTestPath('src/loader.js'));
+});
+
+test('fake-npm-script flags unknown script, passes known', () => {
+  const opts = { ...baseOpts, hasPkg: true, scripts: new Set(['build', 'test']) };
+  const text = 'Run `npm run build` then `pnpm run nope` and `yarn run other`.';
+  const { issues } = verify(text, '/x', opts);
+  const scripts = issues.filter((i) => i.type === 'fake-npm-script').map((i) => i.value).sort();
+  assert.deepStrictEqual(scripts, ['nope', 'other']);
+});
+
+test('issues carry confidence + location; symbol detection is medium', () => {
+  const opts = { ...baseOpts };
+  const { issues, summary } = verify('Missing `src/ghost.js` and `phantomFn()`.', '/x', opts);
+  const file = issues.find((i) => i.type === 'fake-file');
+  const sym = issues.find((i) => i.type === 'fake-symbol');
+  assert.strictEqual(file.confidence, 'high');
+  assert.strictEqual(sym.confidence, 'medium');
+  assert.ok(/^L\d+$/.test(file.location));
+  assert.ok('withSuggestion' in summary);
+});
+
+test('closest-match suggestion attached for a near-miss symbol', () => {
+  const opts = {
+    ...baseOpts,
+    symbolCandidates: [{ name: 'loadConfig', file: 'src/config/loader.js', line: 42 }],
+  };
+  const { issues } = verify('Call `loadConfg()`.', '/x', opts);
+  const sym = issues.find((i) => i.type === 'fake-symbol');
+  assert.ok(sym.suggestion && /loadConfig/.test(sym.suggestion), sym.suggestion);
+  assert.ok(/loader\.js:42/.test(sym.suggestion));
+});
+
+// --------------------------------------------------------------------------
+// closest-match module
+// --------------------------------------------------------------------------
+test('levenshtein basic + ceiling early-exit', () => {
+  assert.strictEqual(closest.levenshtein('kitten', 'sitting'), 3);
+  assert.strictEqual(closest.levenshtein('abc', 'abc'), 0);
+  assert.ok(closest.levenshtein('abcdef', 'zzzzzz', 2) > 2); // exceeds cap
+});
+
+test('closestMatch finds nearest and skips far/short targets', () => {
+  const cands = [{ name: 'loadConfig' }, { name: 'saveConfig' }, { name: 'rank' }];
+  assert.strictEqual(closest.closestMatch('loadConfg', cands).name, 'loadConfig');
+  assert.strictEqual(closest.closestMatch('xy', cands), null, 'too short');
+  assert.strictEqual(closest.closestMatch('totallyDifferentNameHere', cands), null, 'too far');
+});
+
+test('buildSymbolCandidates parses name + anchor line from sig index', () => {
+  const idx = new Map([['src/a.js', ['function loadConfig(p)  :42-58', 'class Foo  :3-9']]]);
+  const cands = closest.buildSymbolCandidates(idx);
+  const load = cands.find((c) => c.name === 'loadConfig');
+  assert.ok(load);
+  assert.strictEqual(load.line, 42);
+  assert.strictEqual(load.file, 'src/a.js');
+});
+
+// --------------------------------------------------------------------------
+// Parsers — edge cases (Reliable MVP)
+// --------------------------------------------------------------------------
+test('extractImports handles multi-line import and TS import=require', () => {
+  const text = [
+    'import {',
+    '  A as B,',
+    '  C,',
+    "} from './multi';",
+    "import fs = require('fs-extra');",
+  ].join('\n');
+  const mods = parsers.extractImports(text).map((i) => i.module);
+  assert.ok(mods.includes('./multi'), 'multi-line import found');
+  assert.ok(mods.includes('fs-extra'), 'TS import=require found');
+});
+
+test('extractNpmScripts finds explicit run forms only', () => {
+  const text = 'Run `npm run build`, `pnpm run lint`, `yarn run dev`; ignore `npm install` and `yarn add x`.';
+  const names = parsers.extractNpmScripts(text).map((s) => s.name).sort();
+  assert.deepStrictEqual(names, ['build', 'dev', 'lint']);
+});
+
+// --------------------------------------------------------------------------
+// verify-report renderer
+// --------------------------------------------------------------------------
+test('renderReportHtml produces a self-contained doc with issue rows', () => {
+  const result = {
+    file: 'ans.md',
+    issues: [
+      { type: 'fake-symbol', value: 'phantomFn', line: 3, location: 'L3', confidence: 'medium', message: 'Symbol not found', suggestion: 'Did you mean `realFn()`?' },
+    ],
+    summary: { total: 1, byType: { 'fake-symbol': 1 }, clean: false },
+  };
+  const html = report.renderReportHtml(result);
+  assert.ok(/<!DOCTYPE html>/.test(html));
+  assert.ok(/Fake symbol/.test(html));
+  assert.ok(/Did you mean/.test(html));
+  assert.ok(!/<script/i.test(html), 'no scripts — static report');
+});
+
+test('renderReportMarkdown clean vs dirty', () => {
+  assert.ok(/clean/.test(report.renderReportMarkdown({ issues: [], summary: { clean: true } })));
+  const md = report.renderReportMarkdown({
+    file: 'a.md',
+    issues: [{ type: 'fake-file', value: 'x.js', line: 1, location: 'L1', suggestion: null }],
+    summary: { total: 1, clean: false },
+  });
+  assert.ok(/\| Type \| Location/.test(md));
+  assert.ok(/Fake file/.test(md));
+});
+
+test('renderReportHtml escapes html in values', () => {
+  const html = report.renderReportHtml({
+    file: '<x>&"', issues: [], summary: { clean: true, symbolsIndexed: 0 },
+  });
+  assert.ok(!/<x>/.test(html), 'file name escaped');
+});
+
+// --------------------------------------------------------------------------
 // CLI dispatch against a generated fixture repo
 // --------------------------------------------------------------------------
 function makeFixtureRepo() {
@@ -146,7 +281,7 @@ function makeFixtureRepo() {
   fs.mkdirSync(path.join(dir, 'src'));
   fs.writeFileSync(
     path.join(dir, 'package.json'),
-    JSON.stringify({ name: 'fx', version: '1.0.0', dependencies: { chalk: '^5.0.0' } }, null, 2)
+    JSON.stringify({ name: 'fx', version: '1.0.0', scripts: { build: 'echo b' }, dependencies: { chalk: '^5.0.0' } }, null, 2)
   );
   fs.writeFileSync(
     path.join(dir, 'src', 'index.js'),
@@ -228,6 +363,37 @@ test('CLI: missing arg → exit 1 with usage', () => {
   const res = spawnSync('node', [SCRIPT, 'verify-ai-output', '--cwd', fixtureDir], { cwd: ROOT, encoding: 'utf8' });
   assert.strictEqual(res.status, 1);
   assert.ok(/Usage: sigmap verify-ai-output/.test(res.stderr));
+});
+
+const mvpAnswer = path.join(fixtureDir, 'mvp.md');
+fs.writeFileSync(mvpAnswer, [
+  '# Answer',
+  'Add `src/ghost.test.js` and call `realFun()`. Run `npm run buidl`.',
+].join('\n'));
+
+test('CLI: detects fake-test-file, fake-symbol w/ suggestion, fake-npm-script', () => {
+  const res = runVerify(fixtureDir, mvpAnswer);
+  assert.strictEqual(res.status, 1, res.stdout + res.stderr);
+  assert.ok(/Fake test file/.test(res.stdout), 'test-file detector');
+  assert.ok(/Fake npm script/.test(res.stdout), 'npm-script detector');
+  assert.ok(/Did you mean `build`/.test(res.stdout), 'script suggestion');
+  assert.ok(/Did you mean `realFunc\(\)`/.test(res.stdout), 'symbol suggestion');
+});
+
+test('CLI: --report writes a standalone HTML file', () => {
+  const out = path.join(fixtureDir, 'report.html');
+  const res = runVerify(fixtureDir, mvpAnswer, ['--report', out]);
+  assert.strictEqual(res.status, 1);
+  assert.ok(fs.existsSync(out), 'report file written');
+  const html = fs.readFileSync(out, 'utf8');
+  assert.ok(/<!DOCTYPE html>/.test(html) && /Hallucination Guard report/.test(html));
+});
+
+test('CLI: --json issues include confidence + suggestion fields', () => {
+  const res = runVerify(fixtureDir, mvpAnswer, ['--json']);
+  const obj = JSON.parse(res.stdout.trim());
+  assert.ok(obj.issues.every((i) => i.confidence && 'suggestion' in i && i.location));
+  assert.ok(obj.summary.byType['fake-test-file'] >= 1);
 });
 
 // Cleanup

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
   "benchmark_date": "2026-06-05",
   "benchmark_id": "sigmap-v6.13-main",
   "languages": 31,
-  "mcp_tools": 10,
+  "mcp_tools": 11,
   "tests": 60,
   "metrics": {
     "hit_at_5": 0.811,

--- a/version.json
+++ b/version.json
@@ -1,19 +1,19 @@
 {
-  "version": "6.14.0",
-  "benchmark_date": "2026-06-05",
-  "benchmark_id": "sigmap-v6.13-main",
+  "version": "6.15.0",
+  "benchmark_date": "2026-06-09",
+  "benchmark_id": "sigmap-v6.15-main",
   "languages": 31,
   "mcp_tools": 11,
   "tests": 60,
   "metrics": {
-    "hit_at_5": 0.811,
+    "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,
-    "prompt_reduction_pct": 41.8,
-    "task_success_proxy_pct": 53.3,
-    "prompts_per_task": 1.66,
+    "prompt_reduction_pct": 39.0,
+    "task_success_proxy_pct": 51.1,
+    "prompts_per_task": 1.73,
     "baseline_prompts_per_task": 2.84,
-    "overall_token_reduction_pct": 96.5,
-    "retrieval_lift": 6.0,
-    "graph_boosted_hit_at_5": 0.811
+    "overall_token_reduction_pct": 97.1,
+    "retrieval_lift": 5.6,
+    "graph_boosted_hit_at_5": 0.756
   }
 }


### PR DESCRIPTION
## Summary
- Promotes **v6.15.0** from develop to main for tagging + release.
- Two feature milestones + full release prep, all already merged + CI-green on develop.

## Changes
- **verify-ai-output Reliable MVP** (#232): 5 detectors (adds fake-test-file, fake-npm-script), closest-match suggestions, finalized JSON schema, standalone HTML report (`--report`), and a precision proof harness.
- **Memory tools** (#233): `sigmap note`, `sigmap status`, and the `read_memory` MCP tool (11th) — kills agent cold-start.
- **Release prep** (#234, /update-docs): version 6.14.0 → 6.15.0 synced across all version files; CHANGELOG [6.15.0]; fresh benchmarks (sigmap-v6.15-main) propagated to README/index/guides/SVGs; CLI + MCP + roadmap + memory docs; content-consistency test gates updated.

## Test plan
- [x] `node test/integration/all.js` — 66 files pass
- [x] `npm test` — pass
- [x] VitePress docs build — pass
- [x] CI on #232/#233/#234 — green (Node 18/20/22 + docs + security)

After merge: tag `v6.15.0` on the main merge commit to trigger Release Binaries + npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)