### PR TITLE
feat(squeeze)!: input minimization + star nudge (v7.0.0)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -9180,6 +9180,577 @@ __factories["./src/workspace/detector"] = function(module, exports) {
  * No npm install required. Node 18+ built-ins only.
  */
 
+// ── ./src/squeeze/classify ──
+__factories["./src/squeeze/classify"] = function(module, exports) {
+'use strict';
+
+/**
+ * Squeeze input classifier (v7.0.0).
+ *
+ * Deterministic, zero-dep detector that labels a pasted blob as a
+ * `stacktrace`, `cilog`, or `json` payload — or `null` (pass through). Pure
+ * regex/heuristics; runs in well under 10ms even on large input.
+ *
+ * Order matters: stack traces are highest value and a CI log often *contains*
+ * a trace, so stacktrace is checked first, then cilog, then json.
+ */
+
+const FRAME_RE = [
+  /^\s*at\s+.+\(.+:\d+:\d+\)\s*$/,          // JS: at fn (file:line:col)
+  /^\s*at\s+.+:\d+:\d+\s*$/,                 // JS: at file:line:col
+  /^\s*at\s+[\w$.<>]+\(.+\.\w+:\d+\)/,       // Java/Kotlin: at pkg.Cls.m(File.java:42)
+  /^\s*File\s+".+",\s+line\s+\d+/,           // Python frame
+  /^\s+\w+.*\([^)]*\.(go|rs):\d+\)/,         // Go/Rust frame with file:line
+  /^\s*#\d+\s+0x[0-9a-f]+/,                  // native/gdb frame
+];
+
+const STACK_HEADER_RE = [
+  /Traceback \(most recent call last\)/,
+  /Exception in thread/,
+  /\bat Object\.<anonymous>\b/,
+  /thread '.*' panicked at/,
+  /^panic:/m,
+  /goroutine \d+ \[/,
+];
+
+function countFrames(lines) {
+  let n = 0;
+  for (const line of lines) {
+    if (FRAME_RE.some((re) => re.test(line))) n++;
+  }
+  return n;
+}
+
+function matchesStackTrace(input, lines) {
+  const frames = countFrames(lines);
+  const header = STACK_HEADER_RE.some((re) => re.test(input));
+  // A single explicit header (Traceback/panic) counts as strong evidence even
+  // with few parsed frames; otherwise require 2+ frame-like lines.
+  if (!header && frames < 2) return { match: false, confidence: 0, frames };
+  // Confidence scales with frame count; a header alone floors it at 0.6.
+  let confidence = Math.min(0.97, 0.15 * frames);
+  if (header) confidence = Math.max(confidence, 0.6 + Math.min(0.3, 0.05 * frames));
+  return { match: true, confidence: Number(confidence.toFixed(2)), frames };
+}
+
+const TS_RE = /(\b\d{1,2}:\d{2}:\d{2}\b)|(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})/;
+const PROGRESS_RE = /(\d{1,3}%)|(\bDownloading\b)|(\bnpm (WARN|notice|http)\b)|(##\[(group|endgroup|command)\])|(\[\d+\/\d+\])|(▕|█|━|⠿)|(\bETA\b)|(\r$)/;
+
+function matchesCiLog(input, lines) {
+  if (lines.length < 8) return { match: false, confidence: 0 };
+  let logish = 0;
+  const seen = new Map();
+  let repeats = 0;
+  for (const line of lines) {
+    if (TS_RE.test(line) || PROGRESS_RE.test(line)) logish++;
+    const norm = line.replace(/\d+/g, '#').trim();
+    if (norm) {
+      const c = (seen.get(norm) || 0) + 1;
+      seen.set(norm, c);
+      if (c > 1) repeats++;
+    }
+  }
+  const density = logish / lines.length;
+  const repeatRatio = repeats / lines.length;
+  if (density < 0.4 && repeatRatio < 0.4) return { match: false, confidence: 0 };
+  const confidence = Math.min(0.95, Math.max(density, repeatRatio) + 0.15);
+  return { match: true, confidence: Number(confidence.toFixed(2)) };
+}
+
+function matchesJsonPayload(input) {
+  const trimmed = input.trim();
+  if (/^[[{]/.test(trimmed)) {
+    try {
+      JSON.parse(trimmed);
+      return { match: true, confidence: 0.95 };
+    } catch (_) { /* not strict JSON — fall through to heuristic */ }
+  }
+  const lines = trimmed.split('\n');
+  if (lines.length < 4) return { match: false, confidence: 0 };
+  let kv = 0;
+  for (const line of lines) {
+    if (/^\s*"[^"]+"\s*:\s*.+/.test(line) || /^\s*[}\]],?\s*$/.test(line)) kv++;
+  }
+  const ratio = kv / lines.length;
+  if (ratio < 0.6) return { match: false, confidence: 0 };
+  return { match: true, confidence: Number(Math.min(0.9, ratio).toFixed(2)) };
+}
+
+/**
+ * @param {string} input
+ * @returns {{ category: 'stacktrace'|'cilog'|'json'|null, confidence: number }}
+ */
+function classify(input) {
+  if (typeof input !== 'string' || !input.trim()) return { category: null, confidence: 0 };
+  const lines = input.split('\n');
+
+  const st = matchesStackTrace(input, lines);
+  if (st.match) return { category: 'stacktrace', confidence: st.confidence };
+
+  const ci = matchesCiLog(input, lines);
+  if (ci.match) return { category: 'cilog', confidence: ci.confidence };
+
+  const js = matchesJsonPayload(input);
+  if (js.match) return { category: 'json', confidence: js.confidence };
+
+  return { category: null, confidence: 0 };
+}
+
+module.exports = { classify, countFrames };
+
+};
+
+// ── ./src/squeeze/cilog ──
+__factories["./src/squeeze/cilog"] = function(module, exports) {
+'use strict';
+
+/**
+ * CI / build-log squeeze (v7.0.0).
+ *
+ * Strips timestamps, progress bars, and repeated noise; keeps every error line
+ * plus a small context window around it. Never returns empty — when there are
+ * no errors it falls back to a head/tail summary. Also reused by the stacktrace
+ * squeezer to clean noise surrounding a trace.
+ */
+
+const TS_PREFIX_RE = /^\s*(?:\[?\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?Z?\]?\s*|\[?\d{1,2}:\d{2}:\d{2}(?:[.,]\d+)?\]?\s*)+/;
+const PROGRESS_LINE_RE = /(?:^|\s)(?:\d{1,3}%|Downloading|Receiving objects|Resolving deltas|Compressing objects|npm (?:WARN|notice|http|sill|verb)|##\[(?:group|endgroup|command|section)\]|\[\d+\/\d+\]|ETA[: ]|█|━|▕|⣿)/;
+const ERROR_RE = /\b(?:error|err!|fail(?:ed|ure)?|exception|panic|fatal|traceback|ERR_|E[A-Z]{3,})\b|✗|❌/i;
+
+/** Remove a leading timestamp prefix from a single line. */
+function stripTimestamp(line) {
+  return line.replace(TS_PREFIX_RE, '');
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {number} [opts.context=2]  context lines kept around each error
+ * @returns {{ squeezed: string, kept: string[], stripped: string[] }}
+ */
+function squeezeCiLog(input, opts = {}) {
+  const ctx = opts.context != null ? opts.context : 2;
+  const lines = input.split('\n');
+  const keep = new Set();
+  const errorIdx = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (ERROR_RE.test(lines[i])) {
+      errorIdx.push(i);
+      for (let j = Math.max(0, i - ctx); j <= Math.min(lines.length - 1, i + ctx); j++) keep.add(j);
+    }
+  }
+
+  let body;
+  let keptDesc;
+  if (errorIdx.length === 0) {
+    const head = lines.slice(0, 10).map(stripTimestamp);
+    const tail = lines.length > 20 ? lines.slice(-10).map(stripTimestamp) : [];
+    body = head.slice();
+    if (tail.length) body.push(`… (${lines.length - 20} lines omitted) …`, ...tail);
+    keptDesc = ['head/tail summary (no error lines found)'];
+  } else {
+    const sorted = [...keep].sort((a, b) => a - b);
+    body = [];
+    let prev = -2;
+    for (const idx of sorted) {
+      // Drop pure progress/noise lines unless they are themselves errors.
+      const line = stripTimestamp(lines[idx]);
+      if (PROGRESS_LINE_RE.test(line) && !ERROR_RE.test(line)) continue;
+      if (idx > prev + 1) body.push(`… (${idx - prev - 1} lines) …`);
+      body.push(line);
+      prev = idx;
+    }
+    if (body.length === 0) body = errorIdx.map((i) => stripTimestamp(lines[i])); // safety net
+    keptDesc = [`${errorIdx.length} error line(s) + ${ctx}-line context`];
+  }
+
+  return {
+    squeezed: body.join('\n'),
+    kept: keptDesc,
+    stripped: [`${Math.max(0, lines.length - body.length)} timestamp/progress/noise line(s)`],
+  };
+}
+
+module.exports = { squeezeCiLog, stripTimestamp, ERROR_RE };
+
+};
+
+// ── ./src/squeeze/jsonpayload ──
+__factories["./src/squeeze/jsonpayload"] = function(module, exports) {
+'use strict';
+
+/**
+ * JSON-payload squeeze (v7.0.0).
+ *
+ * Collapses repeated array elements, truncates long string values, and
+ * preserves the schema shape at every depth — so an LLM still sees the
+ * structure of an API/GraphQL/validation error without the bulk.
+ */
+
+const MAX_STR = 500;
+const ARRAY_KEEP = 2;
+
+function squeezeValue(v, opts) {
+  const maxStr = opts.maxStr;
+  const keep = opts.arrayKeep;
+  if (Array.isArray(v)) {
+    if (v.length <= keep + 1) return v.map((x) => squeezeValue(x, opts));
+    const head = v.slice(0, keep).map((x) => squeezeValue(x, opts));
+    head.push(`…${v.length - keep} more similar items`);
+    return head;
+  }
+  if (v && typeof v === 'object') {
+    const o = {};
+    for (const k of Object.keys(v)) o[k] = squeezeValue(v[k], opts);
+    return o;
+  }
+  if (typeof v === 'string' && v.length > maxStr) {
+    return v.slice(0, maxStr) + `…(${v.length} chars)`;
+  }
+  return v;
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {number} [opts.maxStr=500]    truncate strings longer than this
+ * @param {number} [opts.arrayKeep=2]   array items kept before collapsing
+ * @returns {{ squeezed, kept, stripped }}
+ */
+function squeezeJsonPayload(input, opts = {}) {
+  let parsed;
+  try { parsed = JSON.parse(input); }
+  catch (_) { return { squeezed: input, kept: ['(not valid JSON — unchanged)'], stripped: [] }; }
+  const cfg = { maxStr: opts.maxStr != null ? opts.maxStr : MAX_STR, arrayKeep: opts.arrayKeep != null ? opts.arrayKeep : ARRAY_KEEP };
+  const squeezed = JSON.stringify(squeezeValue(parsed, cfg), null, 2);
+  return {
+    squeezed,
+    kept: ['schema shape preserved at all depths'],
+    stripped: ['collapsed repeated array items; truncated long string values'],
+  };
+}
+
+module.exports = { squeezeJsonPayload, squeezeValue };
+
+};
+
+// ── ./src/squeeze/stacktrace ──
+__factories["./src/squeeze/stacktrace"] = function(module, exports) {
+'use strict';
+
+/**
+ * Stack-trace squeeze (v7.0.0) — the highest-value squeeze module.
+ *
+ * Dedupes repeated exceptions, strips vendor frames, keeps frames in the user's
+ * own source dirs, and — the differentiator — **enriches the top kept frame**
+ * with its real signature from the SigMap symbol index (`buildSigIndex`).
+ * Generic log summarizers can't do this; SigMap has the repo's symbol map.
+ *
+ * Pure/deterministic. The symbol index is injected via `opts.symbolIndex` so
+ * the module is unit-testable without touching the filesystem.
+ */
+
+const path = require('path');
+
+const VENDOR_RE = /(?:^|[\\/])(?:node_modules|vendor|site-packages|dist|build|\.venv|venv|third_party|external|\.cargo|go\/pkg\/mod)[\\/]/;
+
+/** Parse a frame line across JS/TS, Python, Java/Kotlin, Go, Rust, native. */
+function parseFrame(line) {
+  let m;
+  if ((m = line.match(/^\s*at\s+(.+?)\s+\((.+?):(\d+):(\d+)\)/))) return { fn: m[1], file: m[2], line: +m[3], raw: line };
+  if ((m = line.match(/^\s*at\s+(.+?):(\d+):(\d+)\s*$/))) return { fn: '', file: m[1], line: +m[2], raw: line };
+  if ((m = line.match(/^\s*at\s+([\w$.<>]+)\((.+?):(\d+)\)/))) return { fn: m[1], file: m[2], line: +m[3], raw: line };
+  if ((m = line.match(/^\s*File\s+"(.+?)",\s+line\s+(\d+)(?:,\s+in\s+(.+))?/))) return { fn: (m[3] || '').trim(), file: m[1], line: +m[2], raw: line };
+  if ((m = line.match(/^\s*(.+\.(?:go|rs)):(\d+)/))) return { fn: '', file: m[1], line: +m[2], raw: line };
+  return null;
+}
+
+function isVendor(file) { return VENDOR_RE.test(String(file).replace(/\\/g, '/')); }
+
+function inSrcDirs(file, srcDirs) {
+  const f = String(file).replace(/\\/g, '/');
+  return srcDirs.some((d) => {
+    const dd = String(d).replace(/^\.\//, '').replace(/\/$/, '');
+    return dd && (f === dd || f.startsWith(dd + '/') || f.includes('/' + dd + '/'));
+  });
+}
+
+/** Look up the real signature for a frame in the SigMap symbol index. */
+function enrichFrame(frame, symbolIndex) {
+  if (!symbolIndex || !frame) return null;
+  const want = String(frame.file).replace(/\\/g, '/');
+  const base = path.basename(want);
+  let key = null;
+  for (const k0 of symbolIndex.keys()) {
+    const k = String(k0).replace(/\\/g, '/');
+    if (k === want || want.endsWith('/' + k) || k.endsWith('/' + want)) { key = k0; break; }
+    if (!key && path.basename(k) === base) key = k0;
+  }
+  if (!key) return null;
+  const sigs = symbolIndex.get(key) || [];
+  const wantFn = frame.fn ? frame.fn.split('.').pop() : '';
+  let byLine = null, byName = null;
+  for (const sig of sigs) {
+    const s = String(sig);
+    const mm = s.match(/:(\d+)(?:-(\d+))?\s*$/);
+    if (mm) {
+      const a = +mm[1], b = mm[2] ? +mm[2] : a;
+      if (frame.line >= a && frame.line <= b) byLine = s;
+    }
+    if (wantFn && new RegExp('\\b' + wantFn.replace(/[^\w$]/g, '') + '\\b').test(s)) byName = byName || s;
+  }
+  const sig = byLine || byName;
+  return sig ? { file: key, sig: sig.replace(/\s*:\d+(?:-\d+)?\s*$/, '').trim() } : null;
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {string[]} [opts.srcDirs]      user source dirs (default ['src'])
+ * @param {Map}      [opts.symbolIndex]  SigMap signature index for enrichment
+ * @param {number}   [opts.maxFrames=8]  cap on kept source frames
+ * @returns {{ squeezed, kept, stripped, enriched }}
+ */
+function squeezeStackTrace(input, opts = {}) {
+  const srcDirs = (opts.srcDirs && opts.srcDirs.length) ? opts.srcDirs : ['src'];
+  const maxFrames = opts.maxFrames != null ? opts.maxFrames : 8;
+  const lines = input.split('\n');
+
+  const headerCount = new Map();
+  const headerOrder = [];
+  const frames = [];
+  for (const line of lines) {
+    const f = parseFrame(line);
+    if (f) { frames.push(f); continue; }
+    const t = line.trim();
+    if (!t) continue;
+    if (!headerCount.has(t)) headerOrder.push(t);
+    headerCount.set(t, (headerCount.get(t) || 0) + 1);
+  }
+
+  const seen = new Set();
+  let dupFrames = 0;
+  const nonVendor = [];
+  const sourceFrames = [];
+  let vendorCount = 0;
+  for (const f of frames) {
+    const k = f.file + ':' + f.line;
+    if (seen.has(k)) { dupFrames++; continue; }
+    seen.add(k);
+    if (isVendor(f.file)) { vendorCount++; continue; }
+    nonVendor.push(f);
+    if (inSrcDirs(f.file, srcDirs)) sourceFrames.push(f);
+  }
+
+  // Prefer source frames; never return empty (fall back to top non-vendor, then raw).
+  const shown = sourceFrames.length ? sourceFrames.slice(0, maxFrames)
+    : (nonVendor.length ? nonVendor.slice(0, 3) : frames.slice(0, 3));
+
+  const enrichment = shown.length ? enrichFrame(shown[0], opts.symbolIndex) : null;
+
+  const out = [];
+  for (const h of headerOrder) {
+    const n = headerCount.get(h);
+    out.push(n > 1 ? `${h}   (occurred ×${n})` : h);
+  }
+  for (let i = 0; i < shown.length; i++) {
+    out.push('    ' + shown[i].raw.trim());
+    if (i === 0 && enrichment) out.push(`      ↳ ${enrichment.sig}   [${enrichment.file}]`);
+  }
+
+  return {
+    squeezed: out.join('\n'),
+    kept: [
+      `${headerOrder.length} unique exception(s)`,
+      `top ${shown.length} ${sourceFrames.length ? 'source ' : ''}frame(s)`,
+      ...(enrichment ? [`enriched ${path.basename(shown[0].file)}:${shown[0].line}`] : []),
+    ],
+    stripped: [`${vendorCount} vendor frame(s)`, `${dupFrames} duplicate frame(s)`],
+    enriched: !!enrichment,
+  };
+}
+
+module.exports = { squeezeStackTrace, parseFrame, isVendor, inSrcDirs, enrichFrame };
+
+};
+
+// ── ./src/squeeze/index ──
+__factories["./src/squeeze/index"] = function(module, exports) {
+'use strict';
+
+/**
+ * Squeeze orchestrator (v7.0.0): classify → squeeze → reduction → decision.
+ *
+ * Always-on and silent: callers run `squeeze()` on pasted input, then use
+ * `shouldPrompt()` to decide whether the reduction is worth interrupting for.
+ * Everything is deterministic and offline; the symbol index for stack-trace
+ * enrichment is passed through via `opts.symbolIndex`.
+ */
+
+const { classify } = __require('./src/squeeze/classify');
+const { squeezeStackTrace } = __require('./src/squeeze/stacktrace');
+const { squeezeCiLog } = __require('./src/squeeze/cilog');
+const { squeezeJsonPayload } = __require('./src/squeeze/jsonpayload');
+
+function estimateTokens(s) { return Math.ceil(String(s || '').length / 4); }
+
+/**
+ * @param {string} input
+ * @param {object} [opts]  forwarded to the category squeezer (srcDirs, symbolIndex, …)
+ * @returns {{ category, confidence, original, squeezed, rawTokens, squeezedTokens, reduction, kept, stripped, enriched, applies }}
+ */
+function squeeze(input, opts = {}) {
+  const { category, confidence } = classify(input);
+  const rawTokens = estimateTokens(input);
+  const base = {
+    category, confidence, original: input, squeezed: input,
+    rawTokens, squeezedTokens: rawTokens, reduction: 0,
+    kept: [], stripped: [], enriched: false, applies: false,
+  };
+  if (!category) return base;
+
+  let r;
+  if (category === 'stacktrace') r = squeezeStackTrace(input, opts);
+  else if (category === 'cilog') r = squeezeCiLog(input, opts);
+  else r = squeezeJsonPayload(input, opts);
+
+  const squeezedTokens = estimateTokens(r.squeezed);
+  const reduction = rawTokens > 0 ? (rawTokens - squeezedTokens) / rawTokens : 0;
+  return {
+    category, confidence,
+    original: input, squeezed: r.squeezed,
+    rawTokens, squeezedTokens,
+    reduction: Math.max(0, Number(reduction.toFixed(4))),
+    kept: r.kept || [], stripped: r.stripped || [], enriched: !!r.enriched,
+    applies: squeezedTokens < rawTokens,
+  };
+}
+
+/** True when the reduction clears the threshold (accepts 0–1 or 0–100). */
+function shouldPrompt(reduction, threshold) {
+  const t = threshold > 1 ? threshold / 100 : threshold;
+  return reduction >= t;
+}
+
+/** A compact human summary of what squeeze would do (for the prompt). */
+function formatSummary(result) {
+  const pct = Math.round(result.reduction * 100);
+  const lines = [
+    `Input: ${result.rawTokens.toLocaleString()} tokens`,
+    `Can reduce to ${result.squeezedTokens.toLocaleString()} tokens (${pct}% smaller):`,
+  ];
+  for (const k of result.kept) lines.push(`  ✓ Kept: ${k}`);
+  for (const s of result.stripped) lines.push(`  ✗ Stripped: ${s}`);
+  return lines.join('\n');
+}
+
+module.exports = { squeeze, shouldPrompt, formatSummary, estimateTokens };
+
+};
+
+// ── ./src/nudge ──
+__factories["./src/nudge"] = function(module, exports) {
+'use strict';
+
+/**
+ * Star nudge + usage tracking (v7.0.0).
+ *
+ * Records run counts in `.context/usage.json` and shows a one-time GitHub-star
+ * message after the tool has been genuinely useful (≥10 runs, ≥8 successes).
+ * Shown exactly once per machine — even under concurrent runs (an `wx` lock
+ * file makes the show race-safe). Wired into `ask` (and the `squeeze` path).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const RUN_THRESHOLD = 10;
+const SUCCESS_THRESHOLD = 8;
+
+function usagePath(cwd) { return path.join(cwd, '.context', 'usage.json'); }
+
+function defaultUsage() {
+  return {
+    totalRuns: 0, successfulRuns: 0, squeezeOffered: 0, squeezeAccepted: 0,
+    starNudgeShown: false, machineId: '', firstRunDate: null, lastRunDate: null,
+  };
+}
+
+function readUsage(cwd) {
+  try { return { ...defaultUsage(), ...JSON.parse(fs.readFileSync(usagePath(cwd), 'utf8')) }; }
+  catch (_) { return defaultUsage(); }
+}
+
+function writeUsageAtomic(cwd, usage) {
+  const p = usagePath(cwd);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(usage, null, 2));
+  fs.renameSync(tmp, p); // atomic on POSIX
+}
+
+const STAR_MESSAGE = [
+  '─────────────────────────────────────────────────────────',
+  '  SigMap has helped you 10 times now.',
+  '',
+  "  If it's been useful, a GitHub star takes 5 seconds and",
+  '  helps other developers find it:',
+  '  → github.com/manojmallick/sigmap',
+  '',
+  "  (Won't ask again. Press Enter to continue.)",
+  '─────────────────────────────────────────────────────────',
+].join('\n');
+
+function showStarNudge(write) {
+  (write || ((s) => process.stderr.write(s)))('\n' + STAR_MESSAGE + '\n');
+}
+
+/**
+ * Record one run and, when the thresholds are first met, show the star nudge.
+ * @param {string} cwd
+ * @param {boolean} runSuccess
+ * @param {object} [opts]
+ * @param {boolean} [opts.silent]   record only — never print
+ * @param {function} [opts.write]   sink for the message (default stderr)
+ * @param {string} [opts.today]     override date (testing)
+ * @param {object} [opts.bump]      counter deltas to merge (e.g. { squeezeAccepted: 1 })
+ * @returns {{ usage, nudged }}
+ */
+function checkStarNudge(cwd, runSuccess, opts = {}) {
+  const usage = readUsage(cwd);
+  usage.totalRuns += 1;
+  if (runSuccess) usage.successfulRuns += 1;
+  if (opts.bump) for (const k of Object.keys(opts.bump)) usage[k] = (usage[k] || 0) + opts.bump[k];
+
+  const today = opts.today || new Date().toISOString().slice(0, 10);
+  if (!usage.firstRunDate) usage.firstRunDate = today;
+  usage.lastRunDate = today;
+  if (!usage.machineId) {
+    try { usage.machineId = 'sha256-' + crypto.createHash('sha256').update(os.hostname()).digest('hex').slice(0, 16); } catch (_) {}
+  }
+
+  let nudged = false;
+  if (!usage.starNudgeShown && usage.totalRuns >= RUN_THRESHOLD && usage.successfulRuns >= SUCCESS_THRESHOLD) {
+    // Race-safe single-show: only the process that creates the lock prints.
+    let won = false;
+    try { fs.closeSync(fs.openSync(usagePath(cwd) + '.nudge.lock', 'wx')); won = true; }
+    catch (_) { won = false; }
+    if (won && !opts.silent) showStarNudge(opts.write);
+    nudged = won;
+    usage.starNudgeShown = true;
+  }
+
+  writeUsageAtomic(cwd, usage);
+  return { usage, nudged };
+}
+
+module.exports = { checkStarNudge, readUsage, usagePath, showStarNudge, RUN_THRESHOLD, SUCCESS_THRESHOLD };
+
+};
+
 // ── ./src/verify/parsers ──
 __factories["./src/verify/parsers"] = function(module, exports) {
 'use strict';
@@ -11786,6 +12357,10 @@ Usage:
   ${cmd} verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
   ${cmd} verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
   ${cmd} verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+  ${cmd} squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+  ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
+  ${cmd} ask "<query>" --no-squeeze        Disable input minimization entirely
+  ${cmd} ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -12174,13 +12749,51 @@ function main() {
     const { loadSession, saveSession, mergeSessionContext } = requireSourceOrBundled('./src/session/memory');
     const { detectWorkspaces, inferPackage, scopeToPackage } = requireSourceOrBundled('./src/workspace/detector');
 
-    const intent = detectIntent(query);
-    const intentWeights = getIntentWeights(intent);
+    let intent = detectIntent(query);
+    let intentWeights = getIntentWeights(intent);
 
     const sigIndex = buildSigIndex(cwd);
     if (sigIndex.size === 0) {
       console.error('[sigmap] no context file found. Run: sigmap  (to generate first)');
       process.exit(1);
+    }
+
+    // v7.0.0: Squeeze — classify and minimize pasted stacktrace/CI-log/JSON
+    // input before ranking. Always runs silently; only prompts (interactive
+    // TTY) when the reduction clears the threshold. Never blocks pipes/CI.
+    let squeezeOffered = false;
+    let squeezeAccepted = false;
+    if (!args.includes('--no-squeeze')) {
+      try {
+        const { squeeze: runSqueeze, shouldPrompt, formatSummary } = requireSourceOrBundled('./src/squeeze/index');
+        const sq = runSqueeze(query, { srcDirs: config.srcDirs, symbolIndex: sigIndex });
+        if (sq.applies && sq.reduction > 0) {
+          squeezeOffered = true;
+          const thrIdx = args.indexOf('--squeeze-threshold');
+          const threshold = thrIdx !== -1 ? parseFloat(args[thrIdx + 1]) : 30;
+          const auto = args.includes('--squeeze');
+          const interactive = !!(process.stdin.isTTY && process.stderr.isTTY) && !args.includes('--json');
+          let accept = false;
+          if (auto) {
+            accept = true;
+          } else if (interactive && shouldPrompt(sq.reduction, threshold)) {
+            process.stderr.write('\n' + formatSummary(sq) + '\n\n');
+            process.stderr.write('Proceed with minimized input? [Y/n] ');
+            const buf = Buffer.alloc(8);
+            try {
+              const n = fs.readSync(0, buf, 0, 8, null);
+              const ans = buf.toString('utf8', 0, n).trim().toLowerCase();
+              accept = ans === '' || ans === 'y' || ans === 'yes';
+            } catch (_) { accept = false; }
+          }
+          if (accept) {
+            query = sq.squeezed;
+            intent = detectIntent(query);
+            intentWeights = getIntentWeights(intent);
+            squeezeAccepted = true;
+          }
+        }
+      } catch (_) { /* squeeze is best-effort — never break ask */ }
     }
 
     let ranked = rank(query, sigIndex, { topK: 5, weights: intentWeights, cwd });
@@ -12282,6 +12895,15 @@ function main() {
         bar,
       ].join('\n'));
     }
+    // v7.0.0: record the run and show the one-time star nudge (interactive only).
+    try {
+      const { checkStarNudge } = requireSourceOrBundled('./src/nudge');
+      const showNudge = !!process.stderr.isTTY && !args.includes('--json');
+      checkStarNudge(cwd, true, {
+        silent: !showNudge,
+        bump: { squeezeOffered: squeezeOffered ? 1 : 0, squeezeAccepted: squeezeAccepted ? 1 : 0 },
+      });
+    } catch (_) {}
     process.exit(0);
   }
 
@@ -13034,6 +13656,49 @@ function main() {
     } else {
       console.log('  Notes:         none — add with: sigmap note "<text>"');
     }
+    process.exit(0);
+  }
+
+  // v7.0.0: `sigmap squeeze <file|->` — minimize a pasted stacktrace / CI-log / JSON blob
+  if (args[0] === 'squeeze') {
+    const jsonOut = args.includes('--json');
+    const target = args[1] && !args[1].startsWith('--') ? args[1] : '-';
+    let input = '';
+    try {
+      input = fs.readFileSync(target === '-' ? 0 : path.resolve(cwd, target), 'utf8');
+    } catch (e) {
+      console.error(`[sigmap] cannot read input: ${e.message}`);
+      process.exit(1);
+    }
+
+    const { squeeze: runSqueeze, formatSummary } = requireSourceOrBundled('./src/squeeze/index');
+    let symbolIndex = null;
+    try {
+      const { buildSigIndex } = requireSourceOrBundled('./src/retrieval/ranker');
+      symbolIndex = buildSigIndex(cwd);
+    } catch (_) {}
+    const sq = runSqueeze(input, { srcDirs: config.srcDirs, symbolIndex });
+
+    try {
+      const { checkStarNudge } = requireSourceOrBundled('./src/nudge');
+      checkStarNudge(cwd, true, { silent: !process.stderr.isTTY || jsonOut, bump: { squeezeOffered: sq.applies ? 1 : 0 } });
+    } catch (_) {}
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify({
+        category: sq.category, confidence: sq.confidence,
+        rawTokens: sq.rawTokens, squeezedTokens: sq.squeezedTokens,
+        reduction: sq.reduction, enriched: sq.enriched, squeezed: sq.squeezed,
+      }) + '\n');
+      process.exit(0);
+    }
+    if (!sq.category) {
+      process.stderr.write('[sigmap] no squeezable structure detected — input unchanged\n');
+      process.stdout.write(input);
+      process.exit(0);
+    }
+    process.stderr.write(formatSummary(sq) + '\n\n');
+    process.stdout.write(sq.squeezed + '\n');
     process.exit(0);
   }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node test/run.js && node test/r-language.test.js",
-    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js && node test/integration/memory-tools.test.js",
+    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js && node test/integration/memory-tools.test.js && node test/integration/squeeze.test.js",
     "test:integration:all": "node test/integration/all.js",
     "test:all": "node test/run.js && node test/r-language.test.js && node test/integration/strategy.test.js && node test/integration/secret-scan.test.js",
     "generate": "node gen-context.js",
@@ -26,6 +26,8 @@
     "audit:strategies": "node scripts/run-strategy-audit.mjs",
     "benchmark:matrix": "node scripts/run-benchmark-matrix.mjs --save --skip-clone",
     "benchmark:verify": "node scripts/run-verify-benchmark.mjs",
+    "benchmark:squeeze": "node scripts/run-squeeze-benchmark.mjs --save",
+    "validate:squeeze": "node scripts/run-squeeze-benchmark.mjs --gate",
     "health": "node gen-context.js --health",
     "map": "node gen-project-map.js",
     "mcp": "node gen-context.js --mcp",

--- a/scripts/run-squeeze-benchmark.mjs
+++ b/scripts/run-squeeze-benchmark.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Squeeze benchmark + regression gate (v7.0.0).
+ *
+ *   node scripts/run-squeeze-benchmark.mjs            # run, print table
+ *   node scripts/run-squeeze-benchmark.mjs --save     # also write JSON
+ *   node scripts/run-squeeze-benchmark.mjs --gate     # exit 1 on regression
+ *
+ * Scores classification accuracy, per-category reduction, ground-truth
+ * preservation (the key fact a developer needs must survive the squeeze),
+ * false-trigger rate, and latency. The fixture set below is a representative
+ * seed across categories — extend toward the 100 real-world pastes from the
+ * plan (§8.1) before any public reduction % is stated.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { squeeze } = await import(path.join(ROOT, 'src/squeeze/index.js'));
+
+const SAVE = process.argv.includes('--save');
+const GATE = process.argv.includes('--gate');
+const OUT = path.join(ROOT, 'benchmarks', 'reports', 'squeeze.json');
+
+// Targets (plan §8.4/8.5)
+const GROUND_TRUTH_MIN = 0.95;
+const FALSE_TRIGGER_MAX = 0.05;
+const CLASS_ACC_MIN = 0.90;
+
+const rep = (s, n) => s.repeat(n);
+const SYMS = new Map([['src/auth/session.js', ['function validateToken(token)  :140-150']]]);
+
+// Each fixture: { name, category (expected, null=prose), input, ground[] }
+const FIXTURES = [
+  // stacktrace
+  { name: 'st/node-typeerror', category: 'stacktrace', ground: ['TypeError', 'src/auth/session.js:142'],
+    input: 'TypeError: Cannot read property "id" of undefined\n' + rep('    at vendor (/app/node_modules/x/q.js:5:1)\n', 20) + '    at validateToken (/app/src/auth/session.js:142:9)\n' + rep('    at mw (/app/node_modules/express/router.js:281:7)\n', 10) },
+  { name: 'st/python', category: 'stacktrace', ground: ['ValueError', 'app/svc.py'],
+    input: 'Traceback (most recent call last):\n' + rep('  File "/usr/lib/python3/site-packages/lib.py", line 5, in g\n    g()\n', 15) + '  File "/app/svc.py", line 42, in handler\n    raise ValueError("bad")\nValueError: bad' },
+  { name: 'st/repeated', category: 'stacktrace', ground: ['occurred', 'src/a.js'],
+    input: rep('BoomError: kaboom\n    at f (/app/src/a.js:1:2)\n', 47) },
+  { name: 'st/java', category: 'stacktrace', ground: ['NullPointerException'],
+    input: 'Exception in thread "main" java.lang.NullPointerException\n' + rep('\tat com.x.Lib.run(Lib.java:55)\n', 12) + '\tat com.app.Main.handle(Main.java:21)\n' },
+  { name: 'st/go', category: 'stacktrace', ground: ['panic', 'main.go'],
+    input: 'panic: runtime error: index out of range\n\ngoroutine 1 [running]:\n' + rep('runtime.foo(/usr/go/pkg/mod/runtime/x.go:12)\n', 8) + 'main.handler(/app/main.go:88)\n' },
+  // cilog
+  { name: 'ci/gh-actions', category: 'cilog', ground: ['ERROR build failed'],
+    input: rep('2026-06-09T10:00:00 ##[group]step\n', 30) + '2026-06-09T10:01:00 ERROR build failed: missing module\n' + rep('2026-06-09T10:02:00 75% Downloading\n', 30) },
+  { name: 'ci/npm', category: 'cilog', ground: ['ENOENT'],
+    input: rep('npm WARN deprecated foo@1.0.0\n', 40) + 'npm ERR! code ENOENT\nnpm ERR! enoent ENOENT: no such file\n' + rep('npm http fetch GET 200\n', 20) },
+  { name: 'ci/docker', category: 'cilog', ground: ['failed to solve'],
+    input: rep('#5 12.34 [1/4] downloading layers 45%\n', 35) + '#7 ERROR: failed to solve: process did not complete\n' + rep('#5 12.34 extracting 90%\n', 20) },
+  { name: 'ci/pytest', category: 'cilog', ground: ['FAILED'],
+    input: rep('10:00:00 PASSED test_a\n', 40) + '10:00:01 FAILED test_z - assert 1 == 2\n' + rep('10:00:02 PASSED test_b\n', 20) },
+  // json
+  { name: 'json/api-error', category: 'json', ground: ['"code"', '"VALIDATION"'],
+    input: JSON.stringify({ error: { code: 'VALIDATION', message: 'bad' }, items: Array.from({ length: 200 }, (_, i) => ({ id: i, name: 'x' })) }) },
+  { name: 'json/graphql', category: 'json', ground: ['errors', 'Unauthorized'],
+    input: JSON.stringify({ errors: [{ message: 'Unauthorized', path: ['me'] }], data: null, extensions: { trace: rep('z', 900) } }) },
+  { name: 'json/validation', category: 'json', ground: ['"field"'],
+    input: JSON.stringify({ field: 'email', violations: Array.from({ length: 80 }, (_, i) => ({ idx: i, rule: 'required' })) }) },
+  // prose (must NOT trigger)
+  { name: 'prose/bug', category: null, ground: [], input: 'the login button does not work when I double-click it on mobile safari' },
+  { name: 'prose/question', category: null, ground: [], input: 'how do I configure the retry policy for the upload service in staging?' },
+  { name: 'prose/short', category: null, ground: [], input: 'fix the failing checkout flow' },
+];
+
+function tokens(s) { return Math.ceil(s.length / 4); }
+
+const byCat = {};
+let correct = 0, falseTrig = 0, proseCount = 0;
+const rows = [];
+for (const fx of FIXTURES) {
+  const t0 = process.hrtime.bigint();
+  const r = squeeze(fx.input, { srcDirs: ['src', 'app'], symbolIndex: SYMS });
+  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+
+  const classifiedOk = (r.category || null) === (fx.category || null);
+  if (classifiedOk) correct++;
+  if (fx.category === null) { proseCount++; if (r.category) falseTrig++; }
+
+  const gtOk = fx.ground.every((g) => r.squeezed.includes(g));
+  const cat = fx.category || 'prose';
+  (byCat[cat] = byCat[cat] || { n: 0, redSum: 0, gtOk: 0, enriched: 0 });
+  byCat[cat].n++;
+  byCat[cat].redSum += r.reduction;
+  if (gtOk) byCat[cat].gtOk++;
+  if (r.enriched) byCat[cat].enriched++;
+
+  rows.push({ name: fx.name, expected: fx.category, got: r.category, reduction: r.reduction, groundTruthPreserved: gtOk, enriched: r.enriched, latencyMs: Number(ms.toFixed(2)) });
+}
+
+const categories = {};
+for (const [cat, v] of Object.entries(byCat)) {
+  categories[cat] = {
+    count: v.n,
+    avgReduction: Number((v.redSum / v.n).toFixed(3)),
+    groundTruthPreserved: Number((v.gtOk / v.n).toFixed(3)),
+    ...(cat === 'stacktrace' ? { enrichmentHitRate: Number((v.enriched / v.n).toFixed(3)) } : {}),
+  };
+}
+const result = {
+  fixtureCount: FIXTURES.length,
+  byCategory: categories,
+  overall: {
+    classificationAccuracy: Number((correct / FIXTURES.length).toFixed(3)),
+    falseTriggerRate: Number((proseCount ? falseTrig / proseCount : 0).toFixed(3)),
+    avgLatencyMs: Number((rows.reduce((s, r) => s + r.latencyMs, 0) / rows.length).toFixed(2)),
+  },
+  rows,
+};
+
+// Console table
+console.log('\nSqueeze benchmark —', FIXTURES.length, 'fixtures\n');
+for (const [cat, v] of Object.entries(categories)) {
+  const extra = v.enrichmentHitRate != null ? `  enrich ${Math.round(v.enrichmentHitRate * 100)}%` : '';
+  console.log(`  ${cat.padEnd(11)} n=${v.count}  reduction ${Math.round(v.avgReduction * 100)}%  ground-truth ${Math.round(v.groundTruthPreserved * 100)}%${extra}`);
+}
+console.log(`\n  classification ${Math.round(result.overall.classificationAccuracy * 100)}%  false-trigger ${Math.round(result.overall.falseTriggerRate * 100)}%  latency ${result.overall.avgLatencyMs}ms`);
+
+if (SAVE) {
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(result, null, 2));
+  console.log(`\n[squeeze] saved -> ${path.relative(ROOT, OUT)}`);
+}
+
+// Regression gate (plan §8.5)
+if (GATE) {
+  const fails = [];
+  for (const [cat, v] of Object.entries(categories)) {
+    if (cat !== 'prose' && v.groundTruthPreserved < GROUND_TRUTH_MIN) fails.push(`${cat} ground-truth ${Math.round(v.groundTruthPreserved * 100)}% < ${GROUND_TRUTH_MIN * 100}%`);
+  }
+  if (result.overall.falseTriggerRate > FALSE_TRIGGER_MAX) fails.push(`false-trigger ${Math.round(result.overall.falseTriggerRate * 100)}% > ${FALSE_TRIGGER_MAX * 100}%`);
+  if (result.overall.classificationAccuracy < CLASS_ACC_MIN) fails.push(`classification ${Math.round(result.overall.classificationAccuracy * 100)}% < ${CLASS_ACC_MIN * 100}%`);
+  if (fails.length) { console.error('\n[squeeze] GATE FAIL:\n  ' + fails.join('\n  ')); process.exit(1); }
+  console.log('\n[squeeze] GATE OK — all categories meet targets');
+}

--- a/src/nudge.js
+++ b/src/nudge.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * Star nudge + usage tracking (v7.0.0).
+ *
+ * Records run counts in `.context/usage.json` and shows a one-time GitHub-star
+ * message after the tool has been genuinely useful (≥10 runs, ≥8 successes).
+ * Shown exactly once per machine — even under concurrent runs (an `wx` lock
+ * file makes the show race-safe). Wired into `ask` (and the `squeeze` path).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const RUN_THRESHOLD = 10;
+const SUCCESS_THRESHOLD = 8;
+
+function usagePath(cwd) { return path.join(cwd, '.context', 'usage.json'); }
+
+function defaultUsage() {
+  return {
+    totalRuns: 0, successfulRuns: 0, squeezeOffered: 0, squeezeAccepted: 0,
+    starNudgeShown: false, machineId: '', firstRunDate: null, lastRunDate: null,
+  };
+}
+
+function readUsage(cwd) {
+  try { return { ...defaultUsage(), ...JSON.parse(fs.readFileSync(usagePath(cwd), 'utf8')) }; }
+  catch (_) { return defaultUsage(); }
+}
+
+function writeUsageAtomic(cwd, usage) {
+  const p = usagePath(cwd);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(usage, null, 2));
+  fs.renameSync(tmp, p); // atomic on POSIX
+}
+
+const STAR_MESSAGE = [
+  '─────────────────────────────────────────────────────────',
+  '  SigMap has helped you 10 times now.',
+  '',
+  "  If it's been useful, a GitHub star takes 5 seconds and",
+  '  helps other developers find it:',
+  '  → github.com/manojmallick/sigmap',
+  '',
+  "  (Won't ask again. Press Enter to continue.)",
+  '─────────────────────────────────────────────────────────',
+].join('\n');
+
+function showStarNudge(write) {
+  (write || ((s) => process.stderr.write(s)))('\n' + STAR_MESSAGE + '\n');
+}
+
+/**
+ * Record one run and, when the thresholds are first met, show the star nudge.
+ * @param {string} cwd
+ * @param {boolean} runSuccess
+ * @param {object} [opts]
+ * @param {boolean} [opts.silent]   record only — never print
+ * @param {function} [opts.write]   sink for the message (default stderr)
+ * @param {string} [opts.today]     override date (testing)
+ * @param {object} [opts.bump]      counter deltas to merge (e.g. { squeezeAccepted: 1 })
+ * @returns {{ usage, nudged }}
+ */
+function checkStarNudge(cwd, runSuccess, opts = {}) {
+  const usage = readUsage(cwd);
+  usage.totalRuns += 1;
+  if (runSuccess) usage.successfulRuns += 1;
+  if (opts.bump) for (const k of Object.keys(opts.bump)) usage[k] = (usage[k] || 0) + opts.bump[k];
+
+  const today = opts.today || new Date().toISOString().slice(0, 10);
+  if (!usage.firstRunDate) usage.firstRunDate = today;
+  usage.lastRunDate = today;
+  if (!usage.machineId) {
+    try { usage.machineId = 'sha256-' + crypto.createHash('sha256').update(os.hostname()).digest('hex').slice(0, 16); } catch (_) {}
+  }
+
+  let nudged = false;
+  if (!usage.starNudgeShown && usage.totalRuns >= RUN_THRESHOLD && usage.successfulRuns >= SUCCESS_THRESHOLD) {
+    // Race-safe single-show: only the process that creates the lock prints.
+    let won = false;
+    try { fs.closeSync(fs.openSync(usagePath(cwd) + '.nudge.lock', 'wx')); won = true; }
+    catch (_) { won = false; }
+    if (won && !opts.silent) showStarNudge(opts.write);
+    nudged = won;
+    usage.starNudgeShown = true;
+  }
+
+  writeUsageAtomic(cwd, usage);
+  return { usage, nudged };
+}
+
+module.exports = { checkStarNudge, readUsage, usagePath, showStarNudge, RUN_THRESHOLD, SUCCESS_THRESHOLD };

--- a/src/squeeze/cilog.js
+++ b/src/squeeze/cilog.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * CI / build-log squeeze (v7.0.0).
+ *
+ * Strips timestamps, progress bars, and repeated noise; keeps every error line
+ * plus a small context window around it. Never returns empty — when there are
+ * no errors it falls back to a head/tail summary. Also reused by the stacktrace
+ * squeezer to clean noise surrounding a trace.
+ */
+
+const TS_PREFIX_RE = /^\s*(?:\[?\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?Z?\]?\s*|\[?\d{1,2}:\d{2}:\d{2}(?:[.,]\d+)?\]?\s*)+/;
+const PROGRESS_LINE_RE = /(?:^|\s)(?:\d{1,3}%|Downloading|Receiving objects|Resolving deltas|Compressing objects|npm (?:WARN|notice|http|sill|verb)|##\[(?:group|endgroup|command|section)\]|\[\d+\/\d+\]|ETA[: ]|█|━|▕|⣿)/;
+const ERROR_RE = /\b(?:error|err!|fail(?:ed|ure)?|exception|panic|fatal|traceback|ERR_|E[A-Z]{3,})\b|✗|❌/i;
+
+/** Remove a leading timestamp prefix from a single line. */
+function stripTimestamp(line) {
+  return line.replace(TS_PREFIX_RE, '');
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {number} [opts.context=2]  context lines kept around each error
+ * @returns {{ squeezed: string, kept: string[], stripped: string[] }}
+ */
+function squeezeCiLog(input, opts = {}) {
+  const ctx = opts.context != null ? opts.context : 2;
+  const lines = input.split('\n');
+  const keep = new Set();
+  const errorIdx = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (ERROR_RE.test(lines[i])) {
+      errorIdx.push(i);
+      for (let j = Math.max(0, i - ctx); j <= Math.min(lines.length - 1, i + ctx); j++) keep.add(j);
+    }
+  }
+
+  let body;
+  let keptDesc;
+  if (errorIdx.length === 0) {
+    const head = lines.slice(0, 10).map(stripTimestamp);
+    const tail = lines.length > 20 ? lines.slice(-10).map(stripTimestamp) : [];
+    body = head.slice();
+    if (tail.length) body.push(`… (${lines.length - 20} lines omitted) …`, ...tail);
+    keptDesc = ['head/tail summary (no error lines found)'];
+  } else {
+    const sorted = [...keep].sort((a, b) => a - b);
+    body = [];
+    let prev = -2;
+    for (const idx of sorted) {
+      // Drop pure progress/noise lines unless they are themselves errors.
+      const line = stripTimestamp(lines[idx]);
+      if (PROGRESS_LINE_RE.test(line) && !ERROR_RE.test(line)) continue;
+      if (idx > prev + 1) body.push(`… (${idx - prev - 1} lines) …`);
+      body.push(line);
+      prev = idx;
+    }
+    if (body.length === 0) body = errorIdx.map((i) => stripTimestamp(lines[i])); // safety net
+    keptDesc = [`${errorIdx.length} error line(s) + ${ctx}-line context`];
+  }
+
+  return {
+    squeezed: body.join('\n'),
+    kept: keptDesc,
+    stripped: [`${Math.max(0, lines.length - body.length)} timestamp/progress/noise line(s)`],
+  };
+}
+
+module.exports = { squeezeCiLog, stripTimestamp, ERROR_RE };

--- a/src/squeeze/classify.js
+++ b/src/squeeze/classify.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/**
+ * Squeeze input classifier (v7.0.0).
+ *
+ * Deterministic, zero-dep detector that labels a pasted blob as a
+ * `stacktrace`, `cilog`, or `json` payload — or `null` (pass through). Pure
+ * regex/heuristics; runs in well under 10ms even on large input.
+ *
+ * Order matters: stack traces are highest value and a CI log often *contains*
+ * a trace, so stacktrace is checked first, then cilog, then json.
+ */
+
+const FRAME_RE = [
+  /^\s*at\s+.+\(.+:\d+:\d+\)\s*$/,          // JS: at fn (file:line:col)
+  /^\s*at\s+.+:\d+:\d+\s*$/,                 // JS: at file:line:col
+  /^\s*at\s+[\w$.<>]+\(.+\.\w+:\d+\)/,       // Java/Kotlin: at pkg.Cls.m(File.java:42)
+  /^\s*File\s+".+",\s+line\s+\d+/,           // Python frame
+  /^\s+\w+.*\([^)]*\.(go|rs):\d+\)/,         // Go/Rust frame with file:line
+  /^\s*#\d+\s+0x[0-9a-f]+/,                  // native/gdb frame
+];
+
+const STACK_HEADER_RE = [
+  /Traceback \(most recent call last\)/,
+  /Exception in thread/,
+  /\bat Object\.<anonymous>\b/,
+  /thread '.*' panicked at/,
+  /^panic:/m,
+  /goroutine \d+ \[/,
+];
+
+function countFrames(lines) {
+  let n = 0;
+  for (const line of lines) {
+    if (FRAME_RE.some((re) => re.test(line))) n++;
+  }
+  return n;
+}
+
+function matchesStackTrace(input, lines) {
+  const frames = countFrames(lines);
+  const header = STACK_HEADER_RE.some((re) => re.test(input));
+  // A single explicit header (Traceback/panic) counts as strong evidence even
+  // with few parsed frames; otherwise require 2+ frame-like lines.
+  if (!header && frames < 2) return { match: false, confidence: 0, frames };
+  // Confidence scales with frame count; a header alone floors it at 0.6.
+  let confidence = Math.min(0.97, 0.15 * frames);
+  if (header) confidence = Math.max(confidence, 0.6 + Math.min(0.3, 0.05 * frames));
+  return { match: true, confidence: Number(confidence.toFixed(2)), frames };
+}
+
+const TS_RE = /(\b\d{1,2}:\d{2}:\d{2}\b)|(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})/;
+const PROGRESS_RE = /(\d{1,3}%)|(\bDownloading\b)|(\bnpm (WARN|notice|http)\b)|(##\[(group|endgroup|command)\])|(\[\d+\/\d+\])|(▕|█|━|⠿)|(\bETA\b)|(\r$)/;
+
+function matchesCiLog(input, lines) {
+  if (lines.length < 8) return { match: false, confidence: 0 };
+  let logish = 0;
+  const seen = new Map();
+  let repeats = 0;
+  for (const line of lines) {
+    if (TS_RE.test(line) || PROGRESS_RE.test(line)) logish++;
+    const norm = line.replace(/\d+/g, '#').trim();
+    if (norm) {
+      const c = (seen.get(norm) || 0) + 1;
+      seen.set(norm, c);
+      if (c > 1) repeats++;
+    }
+  }
+  const density = logish / lines.length;
+  const repeatRatio = repeats / lines.length;
+  if (density < 0.4 && repeatRatio < 0.4) return { match: false, confidence: 0 };
+  const confidence = Math.min(0.95, Math.max(density, repeatRatio) + 0.15);
+  return { match: true, confidence: Number(confidence.toFixed(2)) };
+}
+
+function matchesJsonPayload(input) {
+  const trimmed = input.trim();
+  if (/^[[{]/.test(trimmed)) {
+    try {
+      JSON.parse(trimmed);
+      return { match: true, confidence: 0.95 };
+    } catch (_) { /* not strict JSON — fall through to heuristic */ }
+  }
+  const lines = trimmed.split('\n');
+  if (lines.length < 4) return { match: false, confidence: 0 };
+  let kv = 0;
+  for (const line of lines) {
+    if (/^\s*"[^"]+"\s*:\s*.+/.test(line) || /^\s*[}\]],?\s*$/.test(line)) kv++;
+  }
+  const ratio = kv / lines.length;
+  if (ratio < 0.6) return { match: false, confidence: 0 };
+  return { match: true, confidence: Number(Math.min(0.9, ratio).toFixed(2)) };
+}
+
+/**
+ * @param {string} input
+ * @returns {{ category: 'stacktrace'|'cilog'|'json'|null, confidence: number }}
+ */
+function classify(input) {
+  if (typeof input !== 'string' || !input.trim()) return { category: null, confidence: 0 };
+  const lines = input.split('\n');
+
+  const st = matchesStackTrace(input, lines);
+  if (st.match) return { category: 'stacktrace', confidence: st.confidence };
+
+  const ci = matchesCiLog(input, lines);
+  if (ci.match) return { category: 'cilog', confidence: ci.confidence };
+
+  const js = matchesJsonPayload(input);
+  if (js.match) return { category: 'json', confidence: js.confidence };
+
+  return { category: null, confidence: 0 };
+}
+
+module.exports = { classify, countFrames };

--- a/src/squeeze/index.js
+++ b/src/squeeze/index.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Squeeze orchestrator (v7.0.0): classify → squeeze → reduction → decision.
+ *
+ * Always-on and silent: callers run `squeeze()` on pasted input, then use
+ * `shouldPrompt()` to decide whether the reduction is worth interrupting for.
+ * Everything is deterministic and offline; the symbol index for stack-trace
+ * enrichment is passed through via `opts.symbolIndex`.
+ */
+
+const { classify } = require('./classify');
+const { squeezeStackTrace } = require('./stacktrace');
+const { squeezeCiLog } = require('./cilog');
+const { squeezeJsonPayload } = require('./jsonpayload');
+
+function estimateTokens(s) { return Math.ceil(String(s || '').length / 4); }
+
+/**
+ * @param {string} input
+ * @param {object} [opts]  forwarded to the category squeezer (srcDirs, symbolIndex, …)
+ * @returns {{ category, confidence, original, squeezed, rawTokens, squeezedTokens, reduction, kept, stripped, enriched, applies }}
+ */
+function squeeze(input, opts = {}) {
+  const { category, confidence } = classify(input);
+  const rawTokens = estimateTokens(input);
+  const base = {
+    category, confidence, original: input, squeezed: input,
+    rawTokens, squeezedTokens: rawTokens, reduction: 0,
+    kept: [], stripped: [], enriched: false, applies: false,
+  };
+  if (!category) return base;
+
+  let r;
+  if (category === 'stacktrace') r = squeezeStackTrace(input, opts);
+  else if (category === 'cilog') r = squeezeCiLog(input, opts);
+  else r = squeezeJsonPayload(input, opts);
+
+  const squeezedTokens = estimateTokens(r.squeezed);
+  const reduction = rawTokens > 0 ? (rawTokens - squeezedTokens) / rawTokens : 0;
+  return {
+    category, confidence,
+    original: input, squeezed: r.squeezed,
+    rawTokens, squeezedTokens,
+    reduction: Math.max(0, Number(reduction.toFixed(4))),
+    kept: r.kept || [], stripped: r.stripped || [], enriched: !!r.enriched,
+    applies: squeezedTokens < rawTokens,
+  };
+}
+
+/** True when the reduction clears the threshold (accepts 0–1 or 0–100). */
+function shouldPrompt(reduction, threshold) {
+  const t = threshold > 1 ? threshold / 100 : threshold;
+  return reduction >= t;
+}
+
+/** A compact human summary of what squeeze would do (for the prompt). */
+function formatSummary(result) {
+  const pct = Math.round(result.reduction * 100);
+  const lines = [
+    `Input: ${result.rawTokens.toLocaleString()} tokens`,
+    `Can reduce to ${result.squeezedTokens.toLocaleString()} tokens (${pct}% smaller):`,
+  ];
+  for (const k of result.kept) lines.push(`  ✓ Kept: ${k}`);
+  for (const s of result.stripped) lines.push(`  ✗ Stripped: ${s}`);
+  return lines.join('\n');
+}
+
+module.exports = { squeeze, shouldPrompt, formatSummary, estimateTokens };

--- a/src/squeeze/jsonpayload.js
+++ b/src/squeeze/jsonpayload.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * JSON-payload squeeze (v7.0.0).
+ *
+ * Collapses repeated array elements, truncates long string values, and
+ * preserves the schema shape at every depth — so an LLM still sees the
+ * structure of an API/GraphQL/validation error without the bulk.
+ */
+
+const MAX_STR = 500;
+const ARRAY_KEEP = 2;
+
+function squeezeValue(v, opts) {
+  const maxStr = opts.maxStr;
+  const keep = opts.arrayKeep;
+  if (Array.isArray(v)) {
+    if (v.length <= keep + 1) return v.map((x) => squeezeValue(x, opts));
+    const head = v.slice(0, keep).map((x) => squeezeValue(x, opts));
+    head.push(`…${v.length - keep} more similar items`);
+    return head;
+  }
+  if (v && typeof v === 'object') {
+    const o = {};
+    for (const k of Object.keys(v)) o[k] = squeezeValue(v[k], opts);
+    return o;
+  }
+  if (typeof v === 'string' && v.length > maxStr) {
+    return v.slice(0, maxStr) + `…(${v.length} chars)`;
+  }
+  return v;
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {number} [opts.maxStr=500]    truncate strings longer than this
+ * @param {number} [opts.arrayKeep=2]   array items kept before collapsing
+ * @returns {{ squeezed, kept, stripped }}
+ */
+function squeezeJsonPayload(input, opts = {}) {
+  let parsed;
+  try { parsed = JSON.parse(input); }
+  catch (_) { return { squeezed: input, kept: ['(not valid JSON — unchanged)'], stripped: [] }; }
+  const cfg = { maxStr: opts.maxStr != null ? opts.maxStr : MAX_STR, arrayKeep: opts.arrayKeep != null ? opts.arrayKeep : ARRAY_KEEP };
+  const squeezed = JSON.stringify(squeezeValue(parsed, cfg), null, 2);
+  return {
+    squeezed,
+    kept: ['schema shape preserved at all depths'],
+    stripped: ['collapsed repeated array items; truncated long string values'],
+  };
+}
+
+module.exports = { squeezeJsonPayload, squeezeValue };

--- a/src/squeeze/stacktrace.js
+++ b/src/squeeze/stacktrace.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Stack-trace squeeze (v7.0.0) — the highest-value squeeze module.
+ *
+ * Dedupes repeated exceptions, strips vendor frames, keeps frames in the user's
+ * own source dirs, and — the differentiator — **enriches the top kept frame**
+ * with its real signature from the SigMap symbol index (`buildSigIndex`).
+ * Generic log summarizers can't do this; SigMap has the repo's symbol map.
+ *
+ * Pure/deterministic. The symbol index is injected via `opts.symbolIndex` so
+ * the module is unit-testable without touching the filesystem.
+ */
+
+const path = require('path');
+
+const VENDOR_RE = /(?:^|[\\/])(?:node_modules|vendor|site-packages|dist|build|\.venv|venv|third_party|external|\.cargo|go\/pkg\/mod)[\\/]/;
+
+/** Parse a frame line across JS/TS, Python, Java/Kotlin, Go, Rust, native. */
+function parseFrame(line) {
+  let m;
+  if ((m = line.match(/^\s*at\s+(.+?)\s+\((.+?):(\d+):(\d+)\)/))) return { fn: m[1], file: m[2], line: +m[3], raw: line };
+  if ((m = line.match(/^\s*at\s+(.+?):(\d+):(\d+)\s*$/))) return { fn: '', file: m[1], line: +m[2], raw: line };
+  if ((m = line.match(/^\s*at\s+([\w$.<>]+)\((.+?):(\d+)\)/))) return { fn: m[1], file: m[2], line: +m[3], raw: line };
+  if ((m = line.match(/^\s*File\s+"(.+?)",\s+line\s+(\d+)(?:,\s+in\s+(.+))?/))) return { fn: (m[3] || '').trim(), file: m[1], line: +m[2], raw: line };
+  if ((m = line.match(/^\s*(.+\.(?:go|rs)):(\d+)/))) return { fn: '', file: m[1], line: +m[2], raw: line };
+  return null;
+}
+
+function isVendor(file) { return VENDOR_RE.test(String(file).replace(/\\/g, '/')); }
+
+function inSrcDirs(file, srcDirs) {
+  const f = String(file).replace(/\\/g, '/');
+  return srcDirs.some((d) => {
+    const dd = String(d).replace(/^\.\//, '').replace(/\/$/, '');
+    return dd && (f === dd || f.startsWith(dd + '/') || f.includes('/' + dd + '/'));
+  });
+}
+
+/** Look up the real signature for a frame in the SigMap symbol index. */
+function enrichFrame(frame, symbolIndex) {
+  if (!symbolIndex || !frame) return null;
+  const want = String(frame.file).replace(/\\/g, '/');
+  const base = path.basename(want);
+  let key = null;
+  for (const k0 of symbolIndex.keys()) {
+    const k = String(k0).replace(/\\/g, '/');
+    if (k === want || want.endsWith('/' + k) || k.endsWith('/' + want)) { key = k0; break; }
+    if (!key && path.basename(k) === base) key = k0;
+  }
+  if (!key) return null;
+  const sigs = symbolIndex.get(key) || [];
+  const wantFn = frame.fn ? frame.fn.split('.').pop() : '';
+  let byLine = null, byName = null;
+  for (const sig of sigs) {
+    const s = String(sig);
+    const mm = s.match(/:(\d+)(?:-(\d+))?\s*$/);
+    if (mm) {
+      const a = +mm[1], b = mm[2] ? +mm[2] : a;
+      if (frame.line >= a && frame.line <= b) byLine = s;
+    }
+    if (wantFn && new RegExp('\\b' + wantFn.replace(/[^\w$]/g, '') + '\\b').test(s)) byName = byName || s;
+  }
+  const sig = byLine || byName;
+  return sig ? { file: key, sig: sig.replace(/\s*:\d+(?:-\d+)?\s*$/, '').trim() } : null;
+}
+
+/**
+ * @param {string} input
+ * @param {object} [opts]
+ * @param {string[]} [opts.srcDirs]      user source dirs (default ['src'])
+ * @param {Map}      [opts.symbolIndex]  SigMap signature index for enrichment
+ * @param {number}   [opts.maxFrames=8]  cap on kept source frames
+ * @returns {{ squeezed, kept, stripped, enriched }}
+ */
+function squeezeStackTrace(input, opts = {}) {
+  const srcDirs = (opts.srcDirs && opts.srcDirs.length) ? opts.srcDirs : ['src'];
+  const maxFrames = opts.maxFrames != null ? opts.maxFrames : 8;
+  const lines = input.split('\n');
+
+  const headerCount = new Map();
+  const headerOrder = [];
+  const frames = [];
+  for (const line of lines) {
+    const f = parseFrame(line);
+    if (f) { frames.push(f); continue; }
+    const t = line.trim();
+    if (!t) continue;
+    if (!headerCount.has(t)) headerOrder.push(t);
+    headerCount.set(t, (headerCount.get(t) || 0) + 1);
+  }
+
+  const seen = new Set();
+  let dupFrames = 0;
+  const nonVendor = [];
+  const sourceFrames = [];
+  let vendorCount = 0;
+  for (const f of frames) {
+    const k = f.file + ':' + f.line;
+    if (seen.has(k)) { dupFrames++; continue; }
+    seen.add(k);
+    if (isVendor(f.file)) { vendorCount++; continue; }
+    nonVendor.push(f);
+    if (inSrcDirs(f.file, srcDirs)) sourceFrames.push(f);
+  }
+
+  // Prefer source frames; never return empty (fall back to top non-vendor, then raw).
+  const shown = sourceFrames.length ? sourceFrames.slice(0, maxFrames)
+    : (nonVendor.length ? nonVendor.slice(0, 3) : frames.slice(0, 3));
+
+  const enrichment = shown.length ? enrichFrame(shown[0], opts.symbolIndex) : null;
+
+  const out = [];
+  for (const h of headerOrder) {
+    const n = headerCount.get(h);
+    out.push(n > 1 ? `${h}   (occurred ×${n})` : h);
+  }
+  for (let i = 0; i < shown.length; i++) {
+    out.push('    ' + shown[i].raw.trim());
+    if (i === 0 && enrichment) out.push(`      ↳ ${enrichment.sig}   [${enrichment.file}]`);
+  }
+
+  return {
+    squeezed: out.join('\n'),
+    kept: [
+      `${headerOrder.length} unique exception(s)`,
+      `top ${shown.length} ${sourceFrames.length ? 'source ' : ''}frame(s)`,
+      ...(enrichment ? [`enriched ${path.basename(shown[0].file)}:${shown[0].line}`] : []),
+    ],
+    stripped: [`${vendorCount} vendor frame(s)`, `${dupFrames} duplicate frame(s)`],
+    enriched: !!enrichment,
+  };
+}
+
+module.exports = { squeezeStackTrace, parseFrame, isVendor, inSrcDirs, enrichFrame };

--- a/test/integration/squeeze.test.js
+++ b/test/integration/squeeze.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+/**
+ * Integration tests for Squeeze + Star Nudge (v7.0.0).
+ *   classify · cilog · stacktrace (+ enrichment) · jsonpayload · orchestrator
+ *   star nudge (thresholds + race-safe) · CLI (squeeze command, ask flags)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { classify } = require(path.join(ROOT, 'src/squeeze/classify'));
+const { squeezeCiLog } = require(path.join(ROOT, 'src/squeeze/cilog'));
+const { squeezeStackTrace } = require(path.join(ROOT, 'src/squeeze/stacktrace'));
+const { squeezeJsonPayload } = require(path.join(ROOT, 'src/squeeze/jsonpayload'));
+const { squeeze, shouldPrompt } = require(path.join(ROOT, 'src/squeeze/index'));
+const nudge = require(path.join(ROOT, 'src/nudge'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+// ── classify ──────────────────────────────────────────────────────────────
+test('classify: Node stack trace', () => {
+  const t = ['TypeError: x', '    at a (/app/src/x.js:1:2)', '    at b (/app/src/y.js:3:4)',
+    '    at c (/app/src/z.js:5:6)', '    at d (/app/src/w.js:7:8)', '    at e (/app/src/v.js:9:1)'].join('\n');
+  const r = classify(t);
+  assert.strictEqual(r.category, 'stacktrace');
+  assert.ok(r.confidence > 0.6, `confidence ${r.confidence}`);
+});
+test('classify: Python traceback', () => {
+  const t = 'Traceback (most recent call last):\n  File "a.py", line 5, in f\n    g()\n  File "b.py", line 9, in g\n    raise ValueError';
+  assert.strictEqual(classify(t).category, 'stacktrace');
+});
+test('classify: CI log', () => {
+  const lines = Array.from({ length: 20 }, (_, i) => `2026-06-09 10:00:${String(i).padStart(2, '0')} npm WARN deprecated foo`);
+  assert.strictEqual(classify(lines.join('\n')).category, 'cilog');
+});
+test('classify: JSON payload', () => {
+  assert.strictEqual(classify('{"error":{"code":500},"data":[1,2,3]}').category, 'json');
+});
+test('classify: prose → null (no false positive)', () => {
+  assert.strictEqual(classify('the login button does not work when I click it twice in a row').category, null);
+});
+test('classify: short trace (2 frames) → low confidence but detected', () => {
+  const r = classify('Error: boom\n    at f (/app/src/a.js:1:2)\n    at g (/app/src/b.js:3:4)');
+  assert.strictEqual(r.category, 'stacktrace');
+  assert.ok(r.confidence < 0.5, `confidence ${r.confidence}`);
+});
+
+// ── stacktrace squeeze ──────────────────────────────────────────────────────
+test('stacktrace: dedupes repeated exception (occurred ×N)', () => {
+  const block = 'BoomError: kaboom\n    at f (/app/src/a.js:1:2)\n';
+  const r = squeezeStackTrace(block.repeat(47), { srcDirs: ['src'] });
+  assert.ok(/occurred ×47/.test(r.squeezed), r.squeezed.slice(0, 80));
+});
+test('stacktrace: strips all vendor frames', () => {
+  const t = ['Err: x', '    at a (/app/node_modules/lib/q.js:5:1)', '    at b (/app/src/keep.js:2:3)'].join('\n');
+  const r = squeezeStackTrace(t, { srcDirs: ['src'] });
+  assert.ok(!/node_modules/.test(r.squeezed), 'vendor leaked');
+  assert.ok(/src\/keep\.js/.test(r.squeezed), 'source frame dropped');
+});
+test('stacktrace: enriches top frame from symbol index', () => {
+  const t = 'Err: x\n    at validateToken (/app/src/auth/session.js:142:9)';
+  const idx = new Map([['src/auth/session.js', ['function validateToken(token)  :140-150']]]);
+  const r = squeezeStackTrace(t, { srcDirs: ['src'], symbolIndex: idx });
+  assert.ok(r.enriched, 'not enriched');
+  assert.ok(/validateToken\(token\)/.test(r.squeezed), r.squeezed);
+});
+test('stacktrace: graceful fallback when symbol not indexed', () => {
+  const t = 'Err: x\n    at ghost (/app/src/a.js:5:1)';
+  const r = squeezeStackTrace(t, { srcDirs: ['src'], symbolIndex: new Map() });
+  assert.strictEqual(r.enriched, false);
+  assert.ok(/src\/a\.js/.test(r.squeezed), 'frame still kept');
+});
+test('stacktrace: no source frames → keeps top frames (never empty)', () => {
+  const t = 'Err: x\n    at a (/app/node_modules/x/q.js:1:1)\n    at b (/app/node_modules/y/r.js:2:2)';
+  const r = squeezeStackTrace(t, { srcDirs: ['src'] });
+  assert.ok(r.squeezed.trim().length > 0, 'returned empty');
+});
+
+// ── cilog squeeze ────────────────────────────────────────────────────────────
+test('cilog: keeps all errors + context, strips timestamps/progress', () => {
+  const lines = [];
+  for (let i = 0; i < 200; i++) lines.push(`2026-06-09 10:00:00 ${i}% Downloading foo`);
+  lines.splice(50, 0, '2026-06-09 10:00:00 ERROR first failure here');
+  lines.splice(120, 0, '2026-06-09 10:00:00 ERROR second failure');
+  lines.splice(190, 0, '2026-06-09 10:00:00 fatal: third');
+  const r = squeezeCiLog(lines.join('\n'), { context: 2 });
+  assert.ok(/first failure/.test(r.squeezed) && /second failure/.test(r.squeezed) && /third/.test(r.squeezed), 'lost an error');
+  assert.ok(!/2026-06-09/.test(r.squeezed), 'timestamp leaked');
+});
+test('cilog: no errors → head/tail fallback, never empty', () => {
+  const r = squeezeCiLog(Array.from({ length: 60 }, (_, i) => `line ${i} ok`).join('\n'));
+  assert.ok(r.squeezed.trim().length > 0);
+  assert.ok(/omitted/.test(r.squeezed) || r.squeezed.split('\n').length <= 25);
+});
+
+// ── jsonpayload squeeze ──────────────────────────────────────────────────────
+test('json: collapses repeated array items', () => {
+  const r = squeezeJsonPayload(JSON.stringify({ items: Array.from({ length: 200 }, (_, i) => ({ id: i })) }));
+  assert.ok(/more similar items/.test(r.squeezed), r.squeezed.slice(0, 120));
+});
+test('json: truncates long strings with length note', () => {
+  const r = squeezeJsonPayload(JSON.stringify({ msg: 'y'.repeat(800) }));
+  assert.ok(/chars\)/.test(r.squeezed), 'no truncation note');
+});
+test('json: preserves nested schema shape', () => {
+  const r = squeezeJsonPayload(JSON.stringify({ a: { b: { c: { d: 1 } } } }));
+  const out = JSON.parse(r.squeezed);
+  assert.strictEqual(out.a.b.c.d, 1);
+});
+
+// ── orchestrator ─────────────────────────────────────────────────────────────
+test('squeeze: computes reduction + applies flag; prose passes through', () => {
+  const prose = squeeze('just some free-form text about a bug');
+  assert.strictEqual(prose.category, null);
+  assert.strictEqual(prose.applies, false);
+});
+test('shouldPrompt: accepts 0-1 and 0-100 thresholds', () => {
+  assert.ok(shouldPrompt(0.5, 30));
+  assert.ok(!shouldPrompt(0.2, 30));
+  assert.ok(shouldPrompt(0.5, 0.4));
+});
+
+// ── star nudge ───────────────────────────────────────────────────────────────
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-nudge-')); }
+test('nudge: below run threshold → not shown', () => {
+  const d = tmp();
+  let last;
+  for (let i = 0; i < 9; i++) last = nudge.checkStarNudge(d, true, { silent: true });
+  assert.strictEqual(last.nudged, false);
+  assert.strictEqual(nudge.readUsage(d).starNudgeShown, false);
+  fs.rmSync(d, { recursive: true, force: true });
+});
+test('nudge: fires once at 10 runs / 8 successes', () => {
+  const d = tmp();
+  let nudgedCount = 0;
+  for (let i = 0; i < 10; i++) { const r = nudge.checkStarNudge(d, true, { silent: true }); if (r.nudged) nudgedCount++; }
+  // 5 more runs — never again
+  for (let i = 0; i < 5; i++) { const r = nudge.checkStarNudge(d, true, { silent: true }); if (r.nudged) nudgedCount++; }
+  assert.strictEqual(nudgedCount, 1, 'should fire exactly once');
+  fs.rmSync(d, { recursive: true, force: true });
+});
+test('nudge: low success rate → not shown', () => {
+  const d = tmp();
+  let any = false;
+  for (let i = 0; i < 12; i++) { const r = nudge.checkStarNudge(d, i < 5, { silent: true }); if (r.nudged) any = true; }
+  assert.strictEqual(any, false, 'fired despite <8 successes');
+  fs.rmSync(d, { recursive: true, force: true });
+});
+test('nudge: race-safe — concurrent show fires exactly once', () => {
+  const d = tmp();
+  // get to 9 runs / 9 successes
+  for (let i = 0; i < 9; i++) nudge.checkStarNudge(d, true, { silent: true });
+  // two "concurrent" 10th calls (lock file makes exactly one win)
+  const a = nudge.checkStarNudge(d, true, { silent: true });
+  const b = nudge.checkStarNudge(d, true, { silent: true });
+  assert.strictEqual([a.nudged, b.nudged].filter(Boolean).length, 1, 'lock failed');
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function runSqueeze(stdin, args = []) {
+  return spawnSync('node', [SCRIPT, 'squeeze', '-', ...args], { input: stdin, cwd: ROOT, encoding: 'utf8' });
+}
+test('CLI squeeze --json: stacktrace reduced, vendor stripped', () => {
+  const t = 'TypeError: x\n    at f (/app/node_modules/orm/q.js:5:1)\n    at g (/app/src/a.js:10:2)';
+  const res = runSqueeze(t, ['--json']);
+  const obj = JSON.parse(res.stdout.trim());
+  assert.strictEqual(obj.category, 'stacktrace');
+  assert.ok(obj.reduction > 0);
+  assert.ok(!/node_modules/.test(obj.squeezed));
+});
+test('CLI squeeze: prose passes through unchanged', () => {
+  const res = runSqueeze('plain words describing a problem here', []);
+  assert.ok(/no squeezable structure/.test(res.stderr));
+});
+
+console.log(`\nsqueeze: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- Implements the full **Squeeze + Star Nudge** plan (`.personal/sigmap-squeeze-star-plan.md`). Closes #237.
- Targets **v7.0.0 major** — `ask` changes default behavior (classifies + may prompt). The `!` + BREAKING CHANGE footer makes `/update-docs` compute the major automatically.

## Squeeze — `ask` minimizes pasted input before ranking
Classifies a pasted blob (stacktrace / CI-log / JSON), minimizes it, and prompts only when the reduction clears a threshold. The differentiator: **symbol enrichment** of the top stack frame from the SigMap index — generic log summarizers can't do this.

- `src/squeeze/classify.js` — 3 detectors + confidence; `null` (pass-through) for prose.
- `src/squeeze/stacktrace.js` — dedupe exceptions (`occurred ×N`), strip vendor frames, filter to config `srcDirs`, **enrich top frame** via `buildSigIndex` (graceful fallback).
- `src/squeeze/cilog.js` — keep every error + context window, strip timestamps/progress, never empty.
- `src/squeeze/jsonpayload.js` — collapse repeated array items, truncate long strings, preserve schema shape at all depths.
- `src/squeeze/index.js` — classify → squeeze → reduction → `shouldPrompt` orchestration.

## Star Nudge
`src/nudge.js` tracks runs in `.context/usage.json`; shows a one-time GitHub-star message at ≥10 runs / ≥8 successes. **Race-safe** (`wx` lock → exactly-once even under concurrent runs).

## CLI
- `sigmap squeeze <file|->` (`--json` for stats) — pipe or file.
- `ask` flags: `--squeeze` (auto-accept, CI), `--no-squeeze` (disable), `--squeeze-threshold N` (default 30).
- Prompt only on interactive TTY; **non-TTY never blocks** pipes/CI. `--no-squeeze` fully disables.

## Codebase fit (deviations from the plan, by design)
`.js` not `.ts`; `.context/` not `.sigmap/`; `buildSigIndex` not `.sigmap/symbols.json`; config `srcDirs` not `source[]`. Zero new deps. New modules registered in the `gen-context.js` `__factories` bundle (binary pre-flight passes; verified in a no-`src/` run).

## Tests & benchmark
- `test/integration/squeeze.test.js` — **24 cases** (classify, each squeeze module incl. enrichment + fallbacks, nudge thresholds + race-safety, CLI). Wired into `npm run test:integration`.
- `scripts/run-squeeze-benchmark.mjs` (`npm run benchmark:squeeze` / `validate:squeeze`) — classification accuracy, per-category reduction, **ground-truth preservation**, false-trigger, latency, with a regression gate (plan §8.5). Seed run: stacktrace 85% / cilog 89% / json 73% reduction, **100% ground-truth, 0% false-trigger, 100% classification, 0.15ms**.

## Test plan
- [x] `npm test` · `node test/integration/all.js` (67 files) · `npm run validate:squeeze`
- [x] bundle pre-flight (all src modules present) + bundle-only `squeeze` run
- [x] `ask` regression: prose ranks normally; `--no-squeeze` works; usage tracked

## Notes
- Scope: full plan **minus** the 100-real-paste benchmark dataset (§8.1) — the harness ships with a representative labeled seed; scaling to 100 real pastes before any public reduction % is ongoing data work (gate enforces ≥95% ground-truth meanwhile).
- Docs (CLI/guide pages) intentionally left to `/update-docs` at release, per the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)