### PR TITLE
chore(npm): enrich package metadata for discoverability + GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [manojmallick]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sigmap",
   "version": "6.15.0",
-  "description": "Zero-dependency AI context engine — 97% token reduction. No npm install. Runs on Node 18+.",
+  "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "gen-context.js",
   "exports": {
     ".": "./packages/core/index.js",
@@ -49,19 +49,25 @@
   ],
   "keywords": [
     "ai",
-    "context",
-    "copilot",
-    "claude",
-    "cursor",
-    "windsurf",
     "llm",
-    "tokens",
+    "context",
     "token-reduction",
-    "code-signatures",
-    "ai-context",
-    "zero-dependency",
+    "codebase",
+    "retrieval",
+    "tf-idf",
+    "cursor",
+    "claude",
+    "github-copilot",
+    "aider",
+    "windsurf",
+    "developer-tools",
     "mcp",
-    "github-copilot"
+    "function-signatures",
+    "code-intelligence",
+    "context-compression",
+    "local-llm",
+    "ollama",
+    "ai-coding"
   ],
   "author": {
     "name": "Manoj Mallick",
@@ -74,6 +80,10 @@
   "homepage": "https://manojmallick.github.io/sigmap/",
   "bugs": {
     "url": "https://github.com/manojmallick/sigmap/issues"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/manojmallick"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Implements **Phase 1.1** of `.personal/sigmap_growth_plan.md.txt` — the concrete, in-repo discoverability work. (The rest of the plan is content/social/community activity, not code.)

## Changes
- **description** → benefit-driven and keyword-rich: leads with "97% token reduction for AI coding", names the supported tools (Claude / Cursor / Copilot / Aider / Windsurf / local LLMs / MCP) and the TF-IDF approach, and the npx/offline/zero-dep angle.
- **keywords** → expanded **14 → 20**: adds `tf-idf`, `retrieval`, `aider`, `local-llm`, `ollama`, `function-signatures`, `code-intelligence`, `context-compression`, `developer-tools`, `ai-coding`, `codebase`. Better npm + Google surface area.
- **funding** → GitHub Sponsors field in `package.json` + new `.github/FUNDING.yml` (enables the repo "Sponsor" button).

## Not done here (by design)
- **No version bump / npm publish** — the plan suggests `npm version patch && npm publish`, but per the repo workflow the version is owned by `/update-docs` and publishing happens via the `/ship` release pipeline. These metadata changes ship with the next release automatically.
- README badges (Phase 1.2) are **already comprehensive** (npm version/downloads, CI, zero-deps, MIT, stars, star-history) — no change needed.
- Marketing activities (content, social, VS Code Marketplace copy, website CTAs) are out-of-repo and out of scope for a code PR.

## Verification
- `package.json` is valid JSON (20 keywords, funding present).
- Full `node test/integration/all.js` (68 files) green; `version-json` + `docs-sync` tests pass (no test pins description/keywords).

🤖 Generated with [Claude Code](https://claude.com/claude-code)