### PR TITLE
feat(docs): auto-generate & CI-validate llms.txt + llms-full.txt

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -1,0 +1,295 @@
+# SigMap — Complete LLM Reference
+
+> Zero-dependency context engine that stops AI coding agents from guessing in your codebase.
+> Grounded context. Verified answers. No embeddings, no vector DB, fully offline.
+
+SigMap is a zero-dependency AI context engine. It extracts function and class
+signatures from a codebase and uses TF-IDF ranking to feed an AI assistant only
+the files relevant to the task — cutting tokens ~97% while keeping answers
+grounded. Deterministic, offline, no embeddings or vector database. Works with
+Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
+
+# Version: 6.15.0 | Benchmark: sigmap-v6.15-main (2026-06-09)
+# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
+
+---
+
+## Core metrics (benchmark: sigmap-v6.15-main, 2026-06-09)
+
+| Metric | Without SigMap | With SigMap |
+|--------|----------------|-------------|
+| Retrieval hit@5 | 13.6% (random) | 75.6% (5.6× lift) |
+| Token reduction | — | 97.1% average |
+| Task success proxy | 10% | 51.1% |
+| Prompts per task | 2.84 | 1.73 (39.0% fewer) |
+| Supported languages | — | 31 |
+| MCP tools | — | 11 |
+| npm runtime dependencies | — | 0 |
+
+---
+
+## Installation
+
+```bash
+# Run immediately without installing
+npx sigmap
+
+# Install globally
+npm install -g sigmap
+
+# Auto-wire MCP + editor config + git hook + watcher
+npx sigmap --setup
+```
+
+---
+
+## CLI commands — complete reference
+
+Every command and flag (`sigmap --help`):
+
+```
+sigmap                                   Generate context once and exit
+sigmap --monorepo                        Generate per-package context (monorepo)
+sigmap --each                            Run for every repo in the current directory
+sigmap --routing                         Include model routing hints in output
+sigmap --format cache                    Also write Anthropic prompt-cache JSON
+sigmap --track                           Append run metrics to .context/usage.ndjson
+sigmap --watch                           Generate + watch for file changes
+sigmap --setup                           Generate + install git hook + watch
+sigmap --mcp                             Start MCP server on stdio
+sigmap --report                          Token reduction stats to stdout
+sigmap --report --json                   Token report as JSON (for CI; exits 1 if over budget)
+sigmap --report --history                Print usage log summary from .context/usage.ndjson
+sigmap --report --history --chart        Include inline SVG charts + Unicode sparklines
+sigmap --dashboard                       Write benchmarks/reports/dashboard.html
+sigmap --suggest-tool "<task>"           Recommend model tier for a task description
+sigmap --suggest-tool "<task>" --json    Machine-readable tier recommendation
+sigmap --health                          Print composite health score
+sigmap --health --json                   Machine-readable health score
+sigmap --diff                            Generate context for git-changed files only
+sigmap --diff <base-ref>                 Generate context + structural diff vs base ref (e.g. main)
+sigmap --diff --staged                   Generate context for staged files only
+sigmap --benchmark                       Run retrieval benchmark (benchmarks/tasks/retrieval.jsonl)
+sigmap --adapter <name>                  Generate for a specific adapter only (v3.0+)
+sigmap --adapter <name> --json           Show adapter output path as JSON
+sigmap --benchmark --json                Benchmark results as JSON
+sigmap --eval                            Alias for --benchmark
+sigmap --analyze                         Per-file breakdown: sigs, tokens, extractor, coverage
+sigmap --analyze --json                  Breakdown as JSON
+sigmap --analyze --slow                  Re-time each extractor; flag files >50ms
+sigmap --diagnose-extractors             Run all 21 extractors vs fixtures; show pass/fail + diff
+sigmap --query "<text>"                  Rank files by relevance to a query
+sigmap --query "<text>" --json           Ranked results as JSON
+sigmap --query "<text>" --top <n>        Limit results to top N files (default 10)
+sigmap learn --good <files...>           Boost files in .context/weights.json
+sigmap learn --bad <files...>            Penalize files in .context/weights.json
+sigmap learn --reset                     Delete learned file weights
+sigmap weights                           Show learned file multipliers
+sigmap weights --json                    Learned weights as JSON
+sigmap --impact <file>                   Show every file impacted by changing <file>
+sigmap --impact <file> --json            Impact as JSON {changed, direct, transitive, tests, routes}
+sigmap --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited)
+sigmap verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
+sigmap verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
+sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
+sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
+sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
+sigmap note "<text>"                     Append a note to the cross-session decision log
+sigmap note                              List recent notes (also: note --list <N>)
+sigmap status                            Show repo state — branch, dirty files, index freshness, notes
+sigmap --init                            Write example config + .contextignore scaffold
+sigmap --help                            Show this message
+sigmap --version                         Show version
+```
+
+---
+
+## MCP server — 11 tools
+
+Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
+
+```json
+{ "mcpServers": { "sigmap": { "command": "npx", "args": ["sigmap", "--mcp"] } } }
+```
+
+### read_context
+
+Read extracted code signatures for the project or a specific module path. Returns the full copilot-instructions.md content (~500–4K tokens) or a filtered subset when a module path is provided (~50–500 tokens).
+
+```
+Input:  { module?: string }
+```
+
+### search_signatures
+
+Search extracted code signatures for a keyword, function name, or class name. Returns matching signature lines with their file paths.
+
+```
+Input:  { query: string }
+```
+
+### get_map
+
+Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. Requires gen-project-map.js to have been run first.
+
+```
+Input:  { type: string }
+```
+
+### create_checkpoint
+
+Create a session checkpoint summarising current project state. Returns recent git commits, active branch, token count, and a compact snapshot of the codebase context — ideal for session handoffs or periodic saves during long coding sessions.
+
+```
+Input:  { note?: string }
+```
+
+### get_routing
+
+Get model routing hints for this project — which files belong to which complexity tier (fast/balanced/powerful) and which AI model to use for each type of task. Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.
+
+```
+Input:  { } (no arguments)
+```
+
+### explain_file
+
+Explain a specific file: returns its extracted signatures, direct imports (files it depends on), and callers (files that import it). Ideal for understanding a file in isolation without reading raw source. Requires the context file to have been generated first.
+
+```
+Input:  { path: string }
+```
+
+### list_modules
+
+List all top-level modules (srcDirs) present in the context file, sorted by token count descending. Use this to decide which module to pass to read_context before querying a specific area of the codebase.
+
+```
+Input:  { } (no arguments)
+```
+
+### query_context
+
+Rank and return the most relevant files for a specific task or question. Uses keyword + symbol + path scoring to surface only the top-K files relevant to the query — much cheaper than reading all context. Returns ranked file list with signatures and relevance scores.
+
+```
+Input:  { query: string, topK?: number }
+```
+
+### get_impact
+
+Show every file that is impacted when a given file changes — direct importers, transitive importers, affected tests, and affected routes/controllers. Gives agents instant blast-radius awareness before making a change. Handles circular dependencies safely (no infinite loops).
+
+```
+Input:  { file: string, depth?: number }
+```
+
+### get_lines
+
+Fetch an exact line range from a source file on demand — the Surgical Context workhorse. Signatures carry `path:start-end` anchors; call this to read just those lines instead of re-opening the whole file. Lines are clamped to the file bounds and secret-scanned (redacted) before return. Path is sandboxed to the project root.
+
+```
+Input:  { file: string, start: number, end: number }
+```
+
+### read_memory
+
+Recall the project decision log — recent notes left by humans or agents across sessions (via `sigmap note`), plus the last ranking-session focus. Call this at the start of a task to kill cold-start: it answers "what were we doing and why" without re-reading the whole codebase.
+
+```
+Input:  { limit?: number }
+```
+
+---
+
+## Configuration (gen-context.config.json)
+
+Every config key and its default:
+
+```
+output = .github/copilot-instructions.md
+outputs = ["copilot"]
+adapters = null
+srcDirs = ["src","app","lib","packages","services","api","server","client","web","frontend","backend","desktop","mobile","shared","common","core","workers","functions","lambda","cmd","pages","components","hooks","routes","controllers","models","views","resources","config","db","projects","apps","libs","instance","blueprints","src/main/java","src/main/kotlin","src/main/scala","app/src/main/java","app/src/main/kotlin","src/test/java","src/test/kotlin"]
+exclude = ["node_modules",".git","dist","build","out","__pycache__",".next","coverage","target","vendor",".context","playwright-tmp","playwright-report","test-results",".turbo","storybook-static",".docusaurus"]
+maxDepth = 6
+maxSigsPerFile = 25
+maxTokens = 6000
+autoMaxTokens = true
+coverageTarget = 0.8
+modelContextLimit = 128000
+maxTokensHeadroom = 0.2
+secretScan = true
+monorepo = false
+diffPriority = true
+strategy = full
+hotCommits = 10
+watchDebounce = 300
+routing = false
+format = default
+tracking = false
+mcp = {"autoRegister":true}
+depMap = true
+todos = true
+changes = true
+changesCommits = 10
+testCoverage = false
+testDirs = ["tests","test","__tests__","spec"]
+sigCache = false
+impactRadius = false
+retrieval = {"topK":10,"recencyBoost":1.5}
+impact = {"depth":3,"includeSigs":true}
+```
+
+---
+
+## Supported languages (34 extractors)
+
+cpp, csharp, css, dart, dockerfile, gdscript, generic, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
+
+---
+
+## Integrations
+
+Generates native context files for: claude, codex, copilot, cursor, gemini, openai, willow, windsurf — plus an MCP server for any agent (Claude Code, Cursor, Cline, Windsurf, OpenCode, Gemini CLI, Aider). One `sigmap --setup` wires the lot.
+
+---
+
+## Compliance evidence support
+
+SigMap can surface repository facts that *support* technical-evidence narratives
+(e.g. DORA Art. 8–11, NIS2 Art. 21, ISO 27001 A.8) — it is a **technical evidence
+pack**, never a certification or a "compliance report". Signed evidence packs are
+planned for a later release. Any compliance-adjacent wording is reviewed against
+the relevant regulation before publication; SigMap makes no legal claims.
+
+---
+
+## Project information
+
+- Author: Manoj Mallick
+- License: MIT
+- Repository: https://github.com/manojmallick/sigmap
+- Documentation: https://manojmallick.github.io/sigmap/
+- npm: https://www.npmjs.com/package/sigmap
+- Benchmark dataset: https://doi.org/10.5281/zenodo.19898842
+- Issues: https://github.com/manojmallick/sigmap/issues
+
+---
+
+## What SigMap does not do
+
+- **No embeddings / vector database.** Ranking is deterministic TF-IDF over
+  extracted signatures — reproducible and offline, not a semantic vector search.
+- **No code execution.** SigMap reads source statically; it never runs your code.
+- **No network calls** on the core generate/ask/verify paths. Nothing is uploaded;
+  generation works fully offline.
+- **Not a linter or type checker.** It maps and ranks code structure; it does not
+  judge correctness (use `verify-ai-output` only to flag *fabricated* references).
+- **Not a full file reader.** It emits signatures + line anchors; an agent fetches
+  exact bodies on demand via the `get_lines` MCP tool.
+- **No telemetry.** Usage tracking (`--track`, `.context/usage.ndjson`) is local
+  and opt-in; nothing leaves your machine.

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -1,0 +1,56 @@
+# SigMap
+
+> Zero-dependency context engine that stops AI coding agents from guessing in your codebase.
+> Grounded context. Verified answers. No embeddings, no vector DB, fully offline.
+
+SigMap is a zero-dependency AI context engine. It extracts function and class
+signatures from a codebase and uses TF-IDF ranking to feed an AI assistant only
+the files relevant to the task — cutting tokens ~97% while keeping answers
+grounded. Deterministic, offline, no embeddings or vector database. Works with
+Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
+
+# Version: 6.15.0 | Benchmark: sigmap-v6.15-main (2026-06-09)
+# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
+
+## What SigMap solves
+
+- AI agents hallucinate functions, files, and imports that don't exist — `verify-ai-output` flags fabricated references before you trust them.
+- Agents load 60–80K tokens of raw source just to orient — `ask` ranks the codebase and sends ~2K tokens of the relevant signatures.
+- Cold start every session — `note` + the `read_memory` MCP tool carry decisions and focus across sessions.
+- No blast-radius awareness before editing a hub file — `--impact` shows every file a change touches.
+- Pasted stack traces, CI logs, and JSON bloat the prompt — `squeeze` minimizes them and enriches the top frame from the symbol index.
+
+## Core metrics (benchmark: sigmap-v6.15-main, 2026-06-09)
+
+- hit@5 retrieval: 75.6% vs 13.6% random baseline (5.6× lift)
+- Token reduction: 97.1% average across benchmark repos
+- Task success: 51.1% vs 10% without SigMap
+- Prompts per task: 1.73 vs 2.84 baseline (39.0% fewer)
+- Languages: 31 supported · MCP tools: 11
+- Dependencies: zero npm runtime dependencies · fully offline
+
+## Quick start
+```bash
+npx sigmap                          # generate compact signature context for the repo
+npx sigmap ask "<your query>"       # rank the files relevant to a task
+npx sigmap verify-ai-output ans.md  # flag fabricated files/imports/symbols in an AI answer
+npx sigmap --mcp                    # start the MCP server over stdio
+```
+
+## Docs
+- [Full documentation](https://manojmallick.github.io/sigmap/)
+- [CLI reference](https://manojmallick.github.io/sigmap/guide/cli)
+- [MCP tools](https://manojmallick.github.io/sigmap/guide/mcp)
+- [Benchmark methodology](https://manojmallick.github.io/sigmap/guide/benchmark)
+- [Configuration guide](https://manojmallick.github.io/sigmap/guide/config)
+- [Changelog](https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md)
+
+## Optional
+- [GitHub repository](https://github.com/manojmallick/sigmap)
+- [npm package](https://www.npmjs.com/package/sigmap)
+- [Benchmark dataset (Zenodo)](https://doi.org/10.5281/zenodo.19898842)
+- [Full LLM reference](https://manojmallick.github.io/sigmap/llms-full.txt)
+
+SigMap — grounded AI coding context. The lightweight, deterministic alternative
+to embeddings for feeding the right code to AI assistants.

--- a/docs-vp/public/robots.txt
+++ b/docs-vp/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
 
 Sitemap: https://manojmallick.github.io/sigmap/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
 
 Sitemap: https://manojmallick.github.io/sigmap/sitemap.xml

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,295 @@
+# SigMap — Complete LLM Reference
+
+> Zero-dependency context engine that stops AI coding agents from guessing in your codebase.
+> Grounded context. Verified answers. No embeddings, no vector DB, fully offline.
+
+SigMap is a zero-dependency AI context engine. It extracts function and class
+signatures from a codebase and uses TF-IDF ranking to feed an AI assistant only
+the files relevant to the task — cutting tokens ~97% while keeping answers
+grounded. Deterministic, offline, no embeddings or vector database. Works with
+Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
+
+# Version: 6.15.0 | Benchmark: sigmap-v6.15-main (2026-06-09)
+# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
+
+---
+
+## Core metrics (benchmark: sigmap-v6.15-main, 2026-06-09)
+
+| Metric | Without SigMap | With SigMap |
+|--------|----------------|-------------|
+| Retrieval hit@5 | 13.6% (random) | 75.6% (5.6× lift) |
+| Token reduction | — | 97.1% average |
+| Task success proxy | 10% | 51.1% |
+| Prompts per task | 2.84 | 1.73 (39.0% fewer) |
+| Supported languages | — | 31 |
+| MCP tools | — | 11 |
+| npm runtime dependencies | — | 0 |
+
+---
+
+## Installation
+
+```bash
+# Run immediately without installing
+npx sigmap
+
+# Install globally
+npm install -g sigmap
+
+# Auto-wire MCP + editor config + git hook + watcher
+npx sigmap --setup
+```
+
+---
+
+## CLI commands — complete reference
+
+Every command and flag (`sigmap --help`):
+
+```
+sigmap                                   Generate context once and exit
+sigmap --monorepo                        Generate per-package context (monorepo)
+sigmap --each                            Run for every repo in the current directory
+sigmap --routing                         Include model routing hints in output
+sigmap --format cache                    Also write Anthropic prompt-cache JSON
+sigmap --track                           Append run metrics to .context/usage.ndjson
+sigmap --watch                           Generate + watch for file changes
+sigmap --setup                           Generate + install git hook + watch
+sigmap --mcp                             Start MCP server on stdio
+sigmap --report                          Token reduction stats to stdout
+sigmap --report --json                   Token report as JSON (for CI; exits 1 if over budget)
+sigmap --report --history                Print usage log summary from .context/usage.ndjson
+sigmap --report --history --chart        Include inline SVG charts + Unicode sparklines
+sigmap --dashboard                       Write benchmarks/reports/dashboard.html
+sigmap --suggest-tool "<task>"           Recommend model tier for a task description
+sigmap --suggest-tool "<task>" --json    Machine-readable tier recommendation
+sigmap --health                          Print composite health score
+sigmap --health --json                   Machine-readable health score
+sigmap --diff                            Generate context for git-changed files only
+sigmap --diff <base-ref>                 Generate context + structural diff vs base ref (e.g. main)
+sigmap --diff --staged                   Generate context for staged files only
+sigmap --benchmark                       Run retrieval benchmark (benchmarks/tasks/retrieval.jsonl)
+sigmap --adapter <name>                  Generate for a specific adapter only (v3.0+)
+sigmap --adapter <name> --json           Show adapter output path as JSON
+sigmap --benchmark --json                Benchmark results as JSON
+sigmap --eval                            Alias for --benchmark
+sigmap --analyze                         Per-file breakdown: sigs, tokens, extractor, coverage
+sigmap --analyze --json                  Breakdown as JSON
+sigmap --analyze --slow                  Re-time each extractor; flag files >50ms
+sigmap --diagnose-extractors             Run all 21 extractors vs fixtures; show pass/fail + diff
+sigmap --query "<text>"                  Rank files by relevance to a query
+sigmap --query "<text>" --json           Ranked results as JSON
+sigmap --query "<text>" --top <n>        Limit results to top N files (default 10)
+sigmap learn --good <files...>           Boost files in .context/weights.json
+sigmap learn --bad <files...>            Penalize files in .context/weights.json
+sigmap learn --reset                     Delete learned file weights
+sigmap weights                           Show learned file multipliers
+sigmap weights --json                    Learned weights as JSON
+sigmap --impact <file>                   Show every file impacted by changing <file>
+sigmap --impact <file> --json            Impact as JSON {changed, direct, transitive, tests, routes}
+sigmap --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited)
+sigmap verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
+sigmap verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
+sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
+sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
+sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
+sigmap note "<text>"                     Append a note to the cross-session decision log
+sigmap note                              List recent notes (also: note --list <N>)
+sigmap status                            Show repo state — branch, dirty files, index freshness, notes
+sigmap --init                            Write example config + .contextignore scaffold
+sigmap --help                            Show this message
+sigmap --version                         Show version
+```
+
+---
+
+## MCP server — 11 tools
+
+Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
+
+```json
+{ "mcpServers": { "sigmap": { "command": "npx", "args": ["sigmap", "--mcp"] } } }
+```
+
+### read_context
+
+Read extracted code signatures for the project or a specific module path. Returns the full copilot-instructions.md content (~500–4K tokens) or a filtered subset when a module path is provided (~50–500 tokens).
+
+```
+Input:  { module?: string }
+```
+
+### search_signatures
+
+Search extracted code signatures for a keyword, function name, or class name. Returns matching signature lines with their file paths.
+
+```
+Input:  { query: string }
+```
+
+### get_map
+
+Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. Requires gen-project-map.js to have been run first.
+
+```
+Input:  { type: string }
+```
+
+### create_checkpoint
+
+Create a session checkpoint summarising current project state. Returns recent git commits, active branch, token count, and a compact snapshot of the codebase context — ideal for session handoffs or periodic saves during long coding sessions.
+
+```
+Input:  { note?: string }
+```
+
+### get_routing
+
+Get model routing hints for this project — which files belong to which complexity tier (fast/balanced/powerful) and which AI model to use for each type of task. Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.
+
+```
+Input:  { } (no arguments)
+```
+
+### explain_file
+
+Explain a specific file: returns its extracted signatures, direct imports (files it depends on), and callers (files that import it). Ideal for understanding a file in isolation without reading raw source. Requires the context file to have been generated first.
+
+```
+Input:  { path: string }
+```
+
+### list_modules
+
+List all top-level modules (srcDirs) present in the context file, sorted by token count descending. Use this to decide which module to pass to read_context before querying a specific area of the codebase.
+
+```
+Input:  { } (no arguments)
+```
+
+### query_context
+
+Rank and return the most relevant files for a specific task or question. Uses keyword + symbol + path scoring to surface only the top-K files relevant to the query — much cheaper than reading all context. Returns ranked file list with signatures and relevance scores.
+
+```
+Input:  { query: string, topK?: number }
+```
+
+### get_impact
+
+Show every file that is impacted when a given file changes — direct importers, transitive importers, affected tests, and affected routes/controllers. Gives agents instant blast-radius awareness before making a change. Handles circular dependencies safely (no infinite loops).
+
+```
+Input:  { file: string, depth?: number }
+```
+
+### get_lines
+
+Fetch an exact line range from a source file on demand — the Surgical Context workhorse. Signatures carry `path:start-end` anchors; call this to read just those lines instead of re-opening the whole file. Lines are clamped to the file bounds and secret-scanned (redacted) before return. Path is sandboxed to the project root.
+
+```
+Input:  { file: string, start: number, end: number }
+```
+
+### read_memory
+
+Recall the project decision log — recent notes left by humans or agents across sessions (via `sigmap note`), plus the last ranking-session focus. Call this at the start of a task to kill cold-start: it answers "what were we doing and why" without re-reading the whole codebase.
+
+```
+Input:  { limit?: number }
+```
+
+---
+
+## Configuration (gen-context.config.json)
+
+Every config key and its default:
+
+```
+output = .github/copilot-instructions.md
+outputs = ["copilot"]
+adapters = null
+srcDirs = ["src","app","lib","packages","services","api","server","client","web","frontend","backend","desktop","mobile","shared","common","core","workers","functions","lambda","cmd","pages","components","hooks","routes","controllers","models","views","resources","config","db","projects","apps","libs","instance","blueprints","src/main/java","src/main/kotlin","src/main/scala","app/src/main/java","app/src/main/kotlin","src/test/java","src/test/kotlin"]
+exclude = ["node_modules",".git","dist","build","out","__pycache__",".next","coverage","target","vendor",".context","playwright-tmp","playwright-report","test-results",".turbo","storybook-static",".docusaurus"]
+maxDepth = 6
+maxSigsPerFile = 25
+maxTokens = 6000
+autoMaxTokens = true
+coverageTarget = 0.8
+modelContextLimit = 128000
+maxTokensHeadroom = 0.2
+secretScan = true
+monorepo = false
+diffPriority = true
+strategy = full
+hotCommits = 10
+watchDebounce = 300
+routing = false
+format = default
+tracking = false
+mcp = {"autoRegister":true}
+depMap = true
+todos = true
+changes = true
+changesCommits = 10
+testCoverage = false
+testDirs = ["tests","test","__tests__","spec"]
+sigCache = false
+impactRadius = false
+retrieval = {"topK":10,"recencyBoost":1.5}
+impact = {"depth":3,"includeSigs":true}
+```
+
+---
+
+## Supported languages (34 extractors)
+
+cpp, csharp, css, dart, dockerfile, gdscript, generic, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
+
+---
+
+## Integrations
+
+Generates native context files for: claude, codex, copilot, cursor, gemini, openai, willow, windsurf — plus an MCP server for any agent (Claude Code, Cursor, Cline, Windsurf, OpenCode, Gemini CLI, Aider). One `sigmap --setup` wires the lot.
+
+---
+
+## Compliance evidence support
+
+SigMap can surface repository facts that *support* technical-evidence narratives
+(e.g. DORA Art. 8–11, NIS2 Art. 21, ISO 27001 A.8) — it is a **technical evidence
+pack**, never a certification or a "compliance report". Signed evidence packs are
+planned for a later release. Any compliance-adjacent wording is reviewed against
+the relevant regulation before publication; SigMap makes no legal claims.
+
+---
+
+## Project information
+
+- Author: Manoj Mallick
+- License: MIT
+- Repository: https://github.com/manojmallick/sigmap
+- Documentation: https://manojmallick.github.io/sigmap/
+- npm: https://www.npmjs.com/package/sigmap
+- Benchmark dataset: https://doi.org/10.5281/zenodo.19898842
+- Issues: https://github.com/manojmallick/sigmap/issues
+
+---
+
+## What SigMap does not do
+
+- **No embeddings / vector database.** Ranking is deterministic TF-IDF over
+  extracted signatures — reproducible and offline, not a semantic vector search.
+- **No code execution.** SigMap reads source statically; it never runs your code.
+- **No network calls** on the core generate/ask/verify paths. Nothing is uploaded;
+  generation works fully offline.
+- **Not a linter or type checker.** It maps and ranks code structure; it does not
+  judge correctness (use `verify-ai-output` only to flag *fabricated* references).
+- **Not a full file reader.** It emits signatures + line anchors; an agent fetches
+  exact bodies on demand via the `get_lines` MCP tool.
+- **No telemetry.** Usage tracking (`--track`, `.context/usage.ndjson`) is local
+  and opt-in; nothing leaves your machine.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,56 @@
+# SigMap
+
+> Zero-dependency context engine that stops AI coding agents from guessing in your codebase.
+> Grounded context. Verified answers. No embeddings, no vector DB, fully offline.
+
+SigMap is a zero-dependency AI context engine. It extracts function and class
+signatures from a codebase and uses TF-IDF ranking to feed an AI assistant only
+the files relevant to the task — cutting tokens ~97% while keeping answers
+grounded. Deterministic, offline, no embeddings or vector database. Works with
+Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
+
+# Version: 6.15.0 | Benchmark: sigmap-v6.15-main (2026-06-09)
+# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
+
+## What SigMap solves
+
+- AI agents hallucinate functions, files, and imports that don't exist — `verify-ai-output` flags fabricated references before you trust them.
+- Agents load 60–80K tokens of raw source just to orient — `ask` ranks the codebase and sends ~2K tokens of the relevant signatures.
+- Cold start every session — `note` + the `read_memory` MCP tool carry decisions and focus across sessions.
+- No blast-radius awareness before editing a hub file — `--impact` shows every file a change touches.
+- Pasted stack traces, CI logs, and JSON bloat the prompt — `squeeze` minimizes them and enriches the top frame from the symbol index.
+
+## Core metrics (benchmark: sigmap-v6.15-main, 2026-06-09)
+
+- hit@5 retrieval: 75.6% vs 13.6% random baseline (5.6× lift)
+- Token reduction: 97.1% average across benchmark repos
+- Task success: 51.1% vs 10% without SigMap
+- Prompts per task: 1.73 vs 2.84 baseline (39.0% fewer)
+- Languages: 31 supported · MCP tools: 11
+- Dependencies: zero npm runtime dependencies · fully offline
+
+## Quick start
+```bash
+npx sigmap                          # generate compact signature context for the repo
+npx sigmap ask "<your query>"       # rank the files relevant to a task
+npx sigmap verify-ai-output ans.md  # flag fabricated files/imports/symbols in an AI answer
+npx sigmap --mcp                    # start the MCP server over stdio
+```
+
+## Docs
+- [Full documentation](https://manojmallick.github.io/sigmap/)
+- [CLI reference](https://manojmallick.github.io/sigmap/guide/cli)
+- [MCP tools](https://manojmallick.github.io/sigmap/guide/mcp)
+- [Benchmark methodology](https://manojmallick.github.io/sigmap/guide/benchmark)
+- [Configuration guide](https://manojmallick.github.io/sigmap/guide/config)
+- [Changelog](https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md)
+
+## Optional
+- [GitHub repository](https://github.com/manojmallick/sigmap)
+- [npm package](https://www.npmjs.com/package/sigmap)
+- [Benchmark dataset (Zenodo)](https://doi.org/10.5281/zenodo.19898842)
+- [Full LLM reference](https://manojmallick.github.io/sigmap/llms-full.txt)
+
+SigMap — grounded AI coding context. The lightweight, deterministic alternative
+to embeddings for feeding the right code to AI assistants.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node test/run.js && node test/r-language.test.js",
-    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js && node test/integration/memory-tools.test.js && node test/integration/squeeze.test.js && node test/integration/context-consistency.test.js",
+    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js && node test/integration/memory-tools.test.js && node test/integration/squeeze.test.js && node test/integration/context-consistency.test.js && node test/integration/features/llms-current.test.js",
     "test:integration:all": "node test/integration/all.js",
     "test:all": "node test/run.js && node test/r-language.test.js && node test/integration/strategy.test.js && node test/integration/secret-scan.test.js",
     "generate": "node gen-context.js",
@@ -33,7 +33,10 @@
     "mcp": "node gen-context.js --mcp",
     "build:binary": "node scripts/build-binary.mjs",
     "verify:binary": "node scripts/verify-binary.mjs",
-    "version:sync": "node scripts/sync-versions.mjs"
+    "version:sync": "node scripts/sync-versions.mjs",
+    "generate:llms": "node scripts/generate-llms.mjs",
+    "validate:llms": "node scripts/validate-llms.mjs",
+    "prepublishOnly": "node scripts/generate-llms.mjs"
   },
   "files": [
     "gen-context.js",
@@ -44,6 +47,8 @@
     "AGENTS.md",
     "LICENSE",
     "CHANGELOG.md",
+    "llms.txt",
+    "llms-full.txt",
     ".contextignore.example",
     "gen-context.config.json.example"
   ],

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Generate SigMap's own llms.txt (concise) + llms-full.txt (full LLM reference)
+ * from source of truth — so any LLM reading them knows exactly how to use SigMap,
+ * and the docs can never silently go stale (issue #242).
+ *
+ *   node scripts/generate-llms.mjs            # write the files
+ *   node scripts/generate-llms.mjs --check    # print, don't write (used by validate)
+ *
+ * Sources of truth (never hand-typed): package.json, version.json (metrics),
+ * src/mcp/tools.js (MCP tools + schemas), src/config/defaults.js (config keys),
+ * the extractor set (languages), packages/adapters (integrations), and
+ * `gen-context.js --help` (CLI commands). Brand/legal/philosophy prose comes
+ * from scripts/llms-manual.mjs verbatim.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { tagline, solves, projectDescription, doesNotDo, compliance, positioning } from './llms-manual.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const bq = (s) => s.split('\n').map((l) => `> ${l}`).join('\n');
+const pct = (n, d = 1) => `${Number(n).toFixed(d)}%`;
+
+// ── Gather source of truth (deterministic) ──────────────────────────────────
+function gather() {
+  const pkg = require(path.join(ROOT, 'package.json'));
+  const version = require(path.join(ROOT, 'version.json'));
+  const { TOOLS } = require(path.join(ROOT, 'src/mcp/tools.js'));
+  const { DEFAULTS } = require(path.join(ROOT, 'src/config/defaults.js'));
+
+  const HELPERS = new Set(['line-anchor', 'deps', 'coverage', 'patterns', 'python_ast', 'python_dataclass', 'todos', 'prdiff']);
+  const languages = fs.readdirSync(path.join(ROOT, 'src/extractors'))
+    .filter((f) => f.endsWith('.js')).map((f) => f.replace(/\.js$/, ''))
+    .filter((n) => !HELPERS.has(n)).sort();
+
+  const ADAPTER_HELPERS = new Set(['index', 'llm-full']);
+  const adapters = fs.readdirSync(path.join(ROOT, 'packages/adapters'))
+    .filter((f) => f.endsWith('.js')).map((f) => f.replace(/\.js$/, ''))
+    .filter((n) => !ADAPTER_HELPERS.has(n)).sort();
+
+  let helpLines = [];
+  try {
+    const out = spawnSync('node', [path.join(ROOT, 'gen-context.js'), '--help'], { encoding: 'utf8' }).stdout || '';
+    helpLines = out.split('\n').map((l) => l.replace(/\s+$/, ''))
+      .filter((l) => /^\s+(sigmap|gen-context)\b/.test(l))
+      .map((l) => l.trim().replace(/^gen-context\b/, 'sigmap'));
+  } catch (_) {}
+
+  const repo = String((pkg.repository && pkg.repository.url) || 'https://github.com/manojmallick/sigmap')
+    .replace(/^git\+/, '').replace(/\.git$/, '');
+  const home = pkg.homepage || 'https://manojmallick.github.io/sigmap/';
+  return { pkg, version, TOOLS, DEFAULTS, languages, adapters, helpLines, repo, home };
+}
+
+function stamp(d) {
+  return [
+    `# Version: ${d.pkg.version} | Benchmark: ${d.version.benchmark_id} (${d.version.benchmark_date})`,
+    '# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js',
+    '# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms',
+  ].join('\n');
+}
+
+function metricsBullets(d) {
+  const m = d.version.metrics;
+  return [
+    `## Core metrics (benchmark: ${d.version.benchmark_id}, ${d.version.benchmark_date})`,
+    '',
+    `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)} vs ${pct(m.baseline_hit_at_5 * 100)} random baseline (${m.retrieval_lift}× lift)`,
+    `- Token reduction: ${pct(m.overall_token_reduction_pct)} average across benchmark repos`,
+    `- Task success: ${pct(m.task_success_proxy_pct)} vs 10% without SigMap`,
+    `- Prompts per task: ${m.prompts_per_task} vs ${m.baseline_prompts_per_task} baseline (${pct(m.prompt_reduction_pct)} fewer)`,
+    `- Languages: ${d.version.languages} supported · MCP tools: ${d.version.mcp_tools}`,
+    '- Dependencies: zero npm runtime dependencies · fully offline',
+  ].join('\n');
+}
+
+function metricsTable(d) {
+  const m = d.version.metrics;
+  return [
+    `## Core metrics (benchmark: ${d.version.benchmark_id}, ${d.version.benchmark_date})`,
+    '',
+    '| Metric | Without SigMap | With SigMap |',
+    '|--------|----------------|-------------|',
+    `| Retrieval hit@5 | ${pct(m.baseline_hit_at_5 * 100)} (random) | ${pct(m.hit_at_5 * 100)} (${m.retrieval_lift}× lift) |`,
+    `| Token reduction | — | ${pct(m.overall_token_reduction_pct)} average |`,
+    `| Task success proxy | 10% | ${pct(m.task_success_proxy_pct)} |`,
+    `| Prompts per task | ${m.prompts_per_task < m.baseline_prompts_per_task ? m.baseline_prompts_per_task : '—'} | ${m.prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer) |`,
+    `| Supported languages | — | ${d.version.languages} |`,
+    `| MCP tools | — | ${d.version.mcp_tools} |`,
+    '| npm runtime dependencies | — | 0 |',
+  ].join('\n');
+}
+
+function mcpInputLine(t) {
+  const props = (t.inputSchema && t.inputSchema.properties) || {};
+  const req = new Set((t.inputSchema && t.inputSchema.required) || []);
+  const keys = Object.keys(props);
+  if (!keys.length) return 'Input:  { } (no arguments)';
+  const parts = keys.map((k) => `${k}${req.has(k) ? '' : '?'}: ${props[k].type || 'any'}`);
+  return `Input:  { ${parts.join(', ')} }`;
+}
+
+// ── Concise llms.txt ─────────────────────────────────────────────────────────
+export function buildConcise(d) {
+  return [
+    '# SigMap',
+    '',
+    bq(tagline),
+    '',
+    projectDescription,
+    '',
+    stamp(d),
+    '',
+    solves,
+    '',
+    metricsBullets(d),
+    '',
+    '## Quick start',
+    '```bash',
+    'npx sigmap                          # generate compact signature context for the repo',
+    'npx sigmap ask "<your query>"       # rank the files relevant to a task',
+    'npx sigmap verify-ai-output ans.md  # flag fabricated files/imports/symbols in an AI answer',
+    'npx sigmap --mcp                    # start the MCP server over stdio',
+    '```',
+    '',
+    '## Docs',
+    `- [Full documentation](${d.home})`,
+    `- [CLI reference](${d.home}guide/cli)`,
+    `- [MCP tools](${d.home}guide/mcp)`,
+    `- [Benchmark methodology](${d.home}guide/benchmark)`,
+    `- [Configuration guide](${d.home}guide/config)`,
+    `- [Changelog](${d.repo}/blob/main/CHANGELOG.md)`,
+    '',
+    '## Optional',
+    `- [GitHub repository](${d.repo})`,
+    '- [npm package](https://www.npmjs.com/package/sigmap)',
+    '- [Benchmark dataset (Zenodo)](https://doi.org/10.5281/zenodo.19898842)',
+    `- [Full LLM reference](${d.home}llms-full.txt)`,
+    '',
+    positioning,
+    '',
+  ].join('\n');
+}
+
+// ── Full llms-full.txt ───────────────────────────────────────────────────────
+export function buildFull(d) {
+  const { pkg, TOOLS, DEFAULTS, languages, adapters, helpLines } = d;
+  const L = [
+    '# SigMap — Complete LLM Reference', '',
+    bq(tagline), '',
+    projectDescription, '',
+    stamp(d), '',
+    '---', '',
+    metricsTable(d), '',
+    '---', '',
+    '## Installation', '',
+    '```bash',
+    '# Run immediately without installing',
+    'npx sigmap',
+    '',
+    '# Install globally',
+    'npm install -g sigmap',
+    '',
+    '# Auto-wire MCP + editor config + git hook + watcher',
+    'npx sigmap --setup',
+    '```', '',
+    '---', '',
+    '## CLI commands — complete reference', '',
+    'Every command and flag (`sigmap --help`):', '',
+  ];
+  if (helpLines.length) L.push('```', ...helpLines, '```');
+  else L.push('_Run `sigmap --help` for the full list._');
+  L.push('', '---', '');
+
+  L.push(`## MCP server — ${TOOLS.length} tools`, '',
+    'Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:', '',
+    '```json',
+    '{ "mcpServers": { "sigmap": { "command": "npx", "args": ["sigmap", "--mcp"] } } }',
+    '```', '');
+  for (const t of TOOLS) {
+    const desc = String(t.description || '').replace(/\s+/g, ' ').trim();
+    L.push(`### ${t.name}`, '', desc, '', '```', mcpInputLine(t), '```', '');
+  }
+  L.push('---', '');
+
+  L.push('## Configuration (gen-context.config.json)', '',
+    'Every config key and its default:', '', '```');
+  for (const k of Object.keys(DEFAULTS)) {
+    const v = DEFAULTS[k];
+    L.push(`${k} = ${(v && typeof v === 'object') ? JSON.stringify(v) : String(v)}`);
+  }
+  L.push('```', '', '---', '');
+
+  L.push(`## Supported languages (${languages.length} extractors)`, '', languages.join(', '), '', '---', '');
+
+  L.push('## Integrations', '',
+    `Generates native context files for: ${adapters.join(', ')} — plus an MCP server for any agent (Claude Code, Cursor, Cline, Windsurf, OpenCode, Gemini CLI, Aider). One \`sigmap --setup\` wires the lot.`,
+    '', '---', '');
+
+  L.push(compliance, '', '---', '');
+
+  L.push('## Project information', '',
+    `- Author: ${(pkg.author && pkg.author.name) || 'Manoj Mallick'}`,
+    `- License: ${pkg.license || 'MIT'}`,
+    `- Repository: ${d.repo}`,
+    `- Documentation: ${d.home}`,
+    '- npm: https://www.npmjs.com/package/sigmap',
+    '- Benchmark dataset: https://doi.org/10.5281/zenodo.19898842',
+    `- Issues: ${d.repo}/issues`,
+    '', '---', '');
+
+  L.push(doesNotDo, '');
+  return L.join('\n');
+}
+
+// ── Targets / run ────────────────────────────────────────────────────────────
+export const TARGETS = {
+  concise: ['docs-vp/public/llms.txt', 'llms.txt'],
+  full: ['docs-vp/public/llms-full.txt', 'llms-full.txt'],
+};
+export function generate() {
+  const d = gather();
+  return { concise: buildConcise(d), full: buildFull(d) };
+}
+function main() {
+  const { concise, full } = generate();
+  if (process.argv.includes('--check')) { process.stdout.write(concise + '\n----8<----\n' + full); return; }
+  for (const rel of TARGETS.concise) { const p = path.join(ROOT, rel); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, concise); }
+  for (const rel of TARGETS.full) { const p = path.join(ROOT, rel); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, full); }
+  console.log(`[llms] wrote ${concise.length}B concise + ${full.length}B full → ${[...TARGETS.concise, ...TARGETS.full].join(', ')}`);
+}
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/llms-manual.mjs
+++ b/scripts/llms-manual.mjs
@@ -1,0 +1,48 @@
+// Manual sections for llms.txt / llms-full.txt (issue #242).
+//
+// These three blocks are NOT derivable from code — they reflect product
+// philosophy, legal wording, and brand positioning. The generator injects them
+// verbatim and never overwrites them. Review quarterly (Q3 2026, Q4 2026, …) and
+// when EU compliance guidance or major positioning changes.
+
+export const tagline = `Zero-dependency context engine that stops AI coding agents from guessing in your codebase.
+Grounded context. Verified answers. No embeddings, no vector DB, fully offline.`;
+
+export const solves = `## What SigMap solves
+
+- AI agents hallucinate functions, files, and imports that don't exist — \`verify-ai-output\` flags fabricated references before you trust them.
+- Agents load 60–80K tokens of raw source just to orient — \`ask\` ranks the codebase and sends ~2K tokens of the relevant signatures.
+- Cold start every session — \`note\` + the \`read_memory\` MCP tool carry decisions and focus across sessions.
+- No blast-radius awareness before editing a hub file — \`--impact\` shows every file a change touches.
+- Pasted stack traces, CI logs, and JSON bloat the prompt — \`squeeze\` minimizes them and enriches the top frame from the symbol index.`;
+
+export const projectDescription = `SigMap is a zero-dependency AI context engine. It extracts function and class
+signatures from a codebase and uses TF-IDF ranking to feed an AI assistant only
+the files relevant to the task — cutting tokens ~97% while keeping answers
+grounded. Deterministic, offline, no embeddings or vector database. Works with
+Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.`;
+
+export const doesNotDo = `## What SigMap does not do
+
+- **No embeddings / vector database.** Ranking is deterministic TF-IDF over
+  extracted signatures — reproducible and offline, not a semantic vector search.
+- **No code execution.** SigMap reads source statically; it never runs your code.
+- **No network calls** on the core generate/ask/verify paths. Nothing is uploaded;
+  generation works fully offline.
+- **Not a linter or type checker.** It maps and ranks code structure; it does not
+  judge correctness (use \`verify-ai-output\` only to flag *fabricated* references).
+- **Not a full file reader.** It emits signatures + line anchors; an agent fetches
+  exact bodies on demand via the \`get_lines\` MCP tool.
+- **No telemetry.** Usage tracking (\`--track\`, \`.context/usage.ndjson\`) is local
+  and opt-in; nothing leaves your machine.`;
+
+export const compliance = `## Compliance evidence support
+
+SigMap can surface repository facts that *support* technical-evidence narratives
+(e.g. DORA Art. 8–11, NIS2 Art. 21, ISO 27001 A.8) — it is a **technical evidence
+pack**, never a certification or a "compliance report". Signed evidence packs are
+planned for a later release. Any compliance-adjacent wording is reviewed against
+the relevant regulation before publication; SigMap makes no legal claims.`;
+
+export const positioning = `SigMap — grounded AI coding context. The lightweight, deterministic alternative
+to embeddings for feeding the right code to AI assistants.`;

--- a/scripts/validate-llms.mjs
+++ b/scripts/validate-llms.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Fail (exit 1) if the committed llms.txt / llms-full.txt differ from what the
+ * generator would produce — so a PR can never merge with stale LLM docs (#242).
+ *
+ *   npm run validate:llms
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { generate, TARGETS } from './generate-llms.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const { concise, full } = generate();
+const expected = [
+  ...TARGETS.concise.map((rel) => [rel, concise]),
+  ...TARGETS.full.map((rel) => [rel, full]),
+];
+
+let stale = false;
+for (const [rel, want] of expected) {
+  let got = null;
+  try { got = fs.readFileSync(path.join(ROOT, rel), 'utf8'); } catch (_) { got = null; }
+  if (got !== want) {
+    console.error(`❌ ${rel} is out of date`);
+    stale = true;
+  }
+}
+
+if (stale) {
+  console.error('\n   Run: npm run generate:llms   (then commit the updated files)');
+  process.exit(1);
+}
+console.log(`✓ llms.txt + llms-full.txt are current (${expected.length} files checked)`);

--- a/test/integration/features/llms-current.test.js
+++ b/test/integration/features/llms-current.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * CI gate (#242): the committed llms.txt / llms-full.txt must match what the
+ * generator produces from source of truth. Fails the build if they are stale —
+ * so LLM-facing docs can never silently drift from the code.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../../..');
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+test('llms.txt + llms-full.txt exist at repo root and docs-vp/public', () => {
+  for (const rel of ['llms.txt', 'llms-full.txt', 'docs-vp/public/llms.txt', 'docs-vp/public/llms-full.txt']) {
+    assert.ok(fs.existsSync(path.join(ROOT, rel)), `${rel} missing`);
+  }
+});
+
+test('committed llms files are current (npm run validate:llms passes)', () => {
+  const res = spawnSync('node', [path.join(ROOT, 'scripts', 'validate-llms.mjs')], { cwd: ROOT, encoding: 'utf8' });
+  assert.strictEqual(res.status, 0, `validate:llms failed — run \`npm run generate:llms\`:\n${res.stdout}${res.stderr}`);
+});
+
+test('llms-full.txt reflects current MCP tool count + metrics from version.json', () => {
+  const full = fs.readFileSync(path.join(ROOT, 'llms-full.txt'), 'utf8');
+  const v = JSON.parse(fs.readFileSync(path.join(ROOT, 'version.json'), 'utf8'));
+  assert.ok(full.includes(`## MCP server — ${v.mcp_tools} tools`), 'MCP tool count drifted');
+  assert.ok(full.includes(`${(v.metrics.overall_token_reduction_pct).toFixed(1)}%`), 'token-reduction metric drifted');
+  assert.ok(!full.includes('<!-- sigmap-tools -->'), 'unexpected stale tools-json marker');
+});
+
+console.log(`\nllms-current: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #242. SigMap's own LLM reference (`llms.txt` concise + `llms-full.txt` full) is now **generated from source of truth and gated in CI** — it can't silently go stale.

## How it works
- **`scripts/generate-llms.mjs`** builds both files from: `package.json`, `version.json` (metrics), `src/mcp/tools.js` (**11 MCP tools**, with arg signatures), `src/config/defaults.js` (config keys), the extractor set (languages), and `gen-context.js --help` (CLI commands). Nothing is hand-typed.
- **Deterministic stamp** — version + `benchmark_id`/date from `version.json`, **not `new Date()`** (the docx's approach would make the validator fail daily). Output only changes when source changes.
- **`scripts/llms-manual.mjs`** — 3 hand-written blocks (*What SigMap does not do*, *Compliance evidence support*, *positioning*) injected verbatim, never overwritten.
- **`scripts/validate-llms.mjs`** — regenerates in memory, fails (exit 1) on drift with a `run npm run generate:llms` hint.

## Wiring
- `npm run generate:llms` / `npm run validate:llms`; **`prepublishOnly`** regenerates before publish; `llms.txt` + `llms-full.txt` added to published `files[]`.
- **CI gate:** `test/integration/features/llms-current.test.js` (auto-discovered by `all.js`, which CI runs) runs the validator + checks tool-count/metric drift → a PR can't merge with stale LLM docs.
- Files written to **repo root** (agents reading the repo) and **docs-vp/public** (GitHub Pages); `robots.txt` (both copies) now `Allow: /llms.txt` + `/llms-full.txt`.

## Adapted from the .docx (which assumed a different layout)
- **JS, not TS**; no `src/cli/commands.ts` / `*.ts` toolchain.
- **11 MCP tools**, not 9; **no `sigmap-tools/registry` (130 tools)** — doesn't exist here.
- Metrics from **`version.json`** (canonical, current `0.756`/`97.1%`), not a stale `0.789`.
- Builds on the existing JS generator pattern; zero new deps.

## Verification
- `npm run generate:llms` → writes 4 files; `validate:llms` passes; tamper → exit 1 → regenerate → passes.
- `npm test` + full `node test/integration/all.js` (**69 files**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)