### PR TITLE
fix(prdiff): robust symbol-name extraction in the changes block (no more phantom +is)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -3164,55 +3164,78 @@ __factories["./src/extractors/coverage"] = function(module, exports) {
 
 // ── ./src/extractors/prdiff ──
 __factories["./src/extractors/prdiff"] = function(module, exports) {
+'use strict';
 
-  'use strict';
+/**
+ * Compare signature arrays and produce compact diff markers.
+ * @param {string[]} baseSigs
+ * @param {string[]} currentSigs
+ * @returns {{added:string[], removed:string[], modified:string[]}}
+ */
+function diffSignatures(baseSigs, currentSigs) {
+  const base = new Set(baseSigs || []);
+  const curr = new Set(currentSigs || []);
 
-  /**
-   * Compare signature arrays and produce compact diff markers.
-   * @param {string[]} baseSigs
-   * @param {string[]} currentSigs
-   * @returns {{added:string[], removed:string[], modified:string[]}}
-   */
-  function diffSignatures(baseSigs, currentSigs) {
-    const base = new Set(baseSigs || []);
-    const curr = new Set(currentSigs || []);
+  const added = [...curr].filter((s) => !base.has(s));
+  const removed = [...base].filter((s) => !curr.has(s));
 
-    const added = [...curr].filter((s) => !base.has(s));
-    const removed = [...base].filter((s) => !curr.has(s));
-
-    const byName = (arr) => {
-      const m = new Map();
-      for (const s of arr) {
-        const n = extractName(s);
-        if (!n) continue;
-        if (!m.has(n)) m.set(n, []);
-        m.get(n).push(s);
-      }
-      return m;
-    };
-
-    const aBy = byName(added);
-    const rBy = byName(removed);
-    const modified = [];
-
-    for (const [name] of aBy) {
-      if (rBy.has(name)) modified.push(name);
+  const byName = (arr) => {
+    const m = new Map();
+    for (const s of arr) {
+      const n = extractName(s);
+      if (!n) continue;
+      if (!m.has(n)) m.set(n, []);
+      m.get(n).push(s);
     }
+    return m;
+  };
 
-    return { added, removed, modified };
+  const aBy = byName(added);
+  const rBy = byName(removed);
+  const modified = [];
+
+  for (const [name] of aBy) {
+    if (rBy.has(name)) modified.push(name);
   }
 
-  function extractName(sig) {
-    if (!sig) return '';
-    const t = sig.trim();
-    const m = t.match(/(?:def|function|func|class|interface|trait|struct|enum|record)?\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|$)/);
-    return m ? m[1] : '';
-  }
+  return { added, removed, modified };
+}
 
-  module.exports = { diffSignatures, extractName };
+/**
+ * Extract the declared symbol name from a signature line.
+ *
+ * Robust to the real forms SigMap emits — `export class X`, `const x = () =>`,
+ * `async function x`, members, a trailing `:start-end` anchor, and `→ return`
+ * suffixes. Anchored so it never returns a mid-string fragment (the old regex
+ * could turn a signature into a 2-char name like `is`), and returns '' for
+ * non-symbol lines (`module.exports = {…}`, markdown headers) instead of guessing.
+ */
+function extractName(sig) {
+  if (!sig) return '';
+  // Drop a trailing `:start-end` (or `:line`) line anchor.
+  let t = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '').trim();
+  // Re-export / barrel lines carry no single declared name.
+  if (/^(?:module\.)?exports\b/.test(t) || /^export\s*\{/.test(t) || /^export\s+\*/.test(t)) return '';
+  // Strip leading modifiers so the keyword/name is at the start.
+  t = t.replace(/^export\s+/, '')
+       .replace(/^default\s+/, '')
+       .replace(/^(?:public|private|protected|static|abstract|final|override|readonly)\s+/g, '')
+       .replace(/^async\s+/, '');
+  let m;
+  // Declared forms: function/def/func/fn/class/interface/trait/struct/enum/record/type <name>
+  if ((m = t.match(/^(?:def|function|func|fn|class|interface|trait|struct|enum|record|type)\s+([A-Za-z_$][\w$]*)/))) return m[1];
+  // const/let/var/val <name> = …  (arrow functions, assigned values)
+  if ((m = t.match(/^(?:const|let|var|val)\s+([A-Za-z_$][\w$]*)/))) return m[1];
+  // Call / method form: <name>(…)
+  if ((m = t.match(/^([A-Za-z_$][\w$]*)\s*\(/))) return m[1];
+  // Lone identifier (e.g. a collapsed `symbol` after the anchor was stripped).
+  if ((m = t.match(/^([A-Za-z_$][\w$]*)$/))) return m[1];
+  return '';
+}
+
+module.exports = { diffSignatures, extractName };
 
 };
-
 // ── ./src/extractors/r ──
 __factories["./src/extractors/r"] = function(module, exports) {
 

--- a/src/extractors/prdiff.js
+++ b/src/extractors/prdiff.js
@@ -35,11 +35,36 @@ function diffSignatures(baseSigs, currentSigs) {
   return { added, removed, modified };
 }
 
+/**
+ * Extract the declared symbol name from a signature line.
+ *
+ * Robust to the real forms SigMap emits — `export class X`, `const x = () =>`,
+ * `async function x`, members, a trailing `:start-end` anchor, and `→ return`
+ * suffixes. Anchored so it never returns a mid-string fragment (the old regex
+ * could turn a signature into a 2-char name like `is`), and returns '' for
+ * non-symbol lines (`module.exports = {…}`, markdown headers) instead of guessing.
+ */
 function extractName(sig) {
   if (!sig) return '';
-  const t = sig.trim();
-  const m = t.match(/(?:def|function|func|class|interface|trait|struct|enum|record)?\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|$)/);
-  return m ? m[1] : '';
+  // Drop a trailing `:start-end` (or `:line`) line anchor.
+  let t = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '').trim();
+  // Re-export / barrel lines carry no single declared name.
+  if (/^(?:module\.)?exports\b/.test(t) || /^export\s*\{/.test(t) || /^export\s+\*/.test(t)) return '';
+  // Strip leading modifiers so the keyword/name is at the start.
+  t = t.replace(/^export\s+/, '')
+       .replace(/^default\s+/, '')
+       .replace(/^(?:public|private|protected|static|abstract|final|override|readonly)\s+/g, '')
+       .replace(/^async\s+/, '');
+  let m;
+  // Declared forms: function/def/func/fn/class/interface/trait/struct/enum/record/type <name>
+  if ((m = t.match(/^(?:def|function|func|fn|class|interface|trait|struct|enum|record|type)\s+([A-Za-z_$][\w$]*)/))) return m[1];
+  // const/let/var/val <name> = …  (arrow functions, assigned values)
+  if ((m = t.match(/^(?:const|let|var|val)\s+([A-Za-z_$][\w$]*)/))) return m[1];
+  // Call / method form: <name>(…)
+  if ((m = t.match(/^([A-Za-z_$][\w$]*)\s*\(/))) return m[1];
+  // Lone identifier (e.g. a collapsed `symbol` after the anchor was stripped).
+  if ((m = t.match(/^([A-Za-z_$][\w$]*)$/))) return m[1];
+  return '';
 }
 
 module.exports = { diffSignatures, extractName };

--- a/test/integration/features/prdiff-names.test.js
+++ b/test/integration/features/prdiff-names.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Regression tests for prdiff.extractName — the symbol-name extractor behind the
+ * "## changes" block. The old regex was unanchored and optional-keyword, so it
+ * mishandled JS forms (`export class X`, `const x = () =>`) and could emit a
+ * 2-char fragment like `is` (seen as a phantom `+is ~is` in AGENTS.md).
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { extractName, diffSignatures } = require(path.resolve(__dirname, '../../..', 'src/extractors/prdiff'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+const CASES = [
+  // declared forms (+ trailing :anchor and → return-type)
+  ['function isTestPath(p)  :28-28', 'isTestPath'],
+  ['export function format(context, opts = {}) → string  :25-40', 'format'],
+  ['async function fetchWithTimeout(url)  :72-80', 'fetchWithTimeout'],
+  ['export class UserRepository  :18-36', 'UserRepository'],
+  ['def extract  :268-338', 'extract'],
+  ['interface Options', 'Options'],
+  // const / arrow forms
+  ['const closestMatch = (a) =>  :10-20', 'closestMatch'],
+  ['let counter = 0', 'counter'],
+  // call / member form
+  ['get_lines(file, start, end)', 'get_lines'],
+  // genuine short name is kept (not a fragment)
+  ['function is(x)', 'is'],
+  ['is  :140-150', 'is'],
+  // non-symbol lines → empty (no guessing)
+  ['module.exports = { verify, isTestPath }  :219-219', ''],
+  ['module.exports = { extract }  :131-131', ''],
+  ['export { a, b } from "./m"', ''],
+  ['export * from "./m"', ''],
+  ['h1 sigmap-core', ''],
+  ['', ''],
+];
+
+for (const [input, expected] of CASES) {
+  test(`extractName(${JSON.stringify(input)}) === ${JSON.stringify(expected)}`, () => {
+    assert.strictEqual(extractName(input), expected);
+  });
+}
+
+test('extractName never returns a strict substring fragment of the real symbol', () => {
+  for (const sig of ['function isTestPath(p)', 'export class IsThingy', 'const isReady = () =>']) {
+    const n = extractName(sig);
+    assert.ok(n.length > 2 || n === '', `got short fragment ${JSON.stringify(n)} from ${JSON.stringify(sig)}`);
+  }
+});
+
+test('diffSignatures attributes added/removed/modified by clean names', () => {
+  const base = ['export class UserRepo  :1-9', 'function isTestPath(p)  :20-22'];
+  const curr = ['export class UserRepo  :1-12', 'function loadScripts(c)  :30-40'];
+  const { added, removed, modified } = diffSignatures(base, curr);
+  assert.deepStrictEqual(modified, ['UserRepo'], 'UserRepo changed → modified');
+  assert.ok(added.some((s) => extractName(s) === 'loadScripts'));
+  assert.ok(removed.some((s) => extractName(s) === 'isTestPath'));
+  // No phantom 2-char names leak in.
+  assert.ok(![...added, ...removed].some((s) => extractName(s) === 'is'), 'phantom "is" leaked');
+});
+
+console.log(`\nprdiff-names: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Fixes the `+is ~is` phantom symbol you spotted in the `## changes` block of AGENTS.md.

## Root cause
`prdiff.extractName` (which names symbols for the changes/PR-diff block) used one unanchored, optional-keyword regex:
```js
sig.match(/(?:def|function|...)?\s*([A-Za-z_]\w*)\s*(?:\(|$)/)
```
That:
- returned `''` for `export class UserRepo` and `const closestMatch = (a) =>` (couldn't handle those JS forms),
- could match a **mid-string fragment** and emit a 2-char name like `is` — which surfaced as the phantom `+is  ~is` (a symbol counted as both added and modified).

## Fix
Rewrite `extractName` to be anchored and form-aware:
- strip a trailing `:start-end` anchor first,
- handle `export`/`default`/`async`/visibility modifiers, `function`/`class`/`def`/`type`, `const`/`let`/`var`/`val` arrow assignments, call/member forms, and lone identifiers,
- return `''` for re-export/barrel lines (`module.exports = {…}`, `export {…}`/`export *`) and non-symbol lines, instead of guessing a fragment.

## Tests
`test/integration/features/prdiff-names.test.js` — **19 cases** covering every form + the phantom-`is` regression + `diffSignatures` attribution (verifies no 2-char fragment leaks into added/removed/modified). Auto-discovered by `all.js` and wired into `test:integration`.

## Verification
- 11/11 form checks pass; `export class X` → `UserRepo`, `const x = () =>` → `closestMatch`, `module.exports = {…}` → `''`, genuine `function is(x)` → `is`.
- Bundle factory re-synced (binary path); preflight OK; `npm test` + 69/69 integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)