### PR TITLE
fix: nudge counts generation runs + supply-chain hardening (shell-free, main, fingerprint)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -12470,6 +12470,23 @@ function runGenerate(cwd, config, reportMode, reportJson = false) {
     }
   }
 
+  // v7.0.1: count a plain context-generation run for the one-time star nudge.
+  // Most users only ever run `sigmap` to build the context file — count that too,
+  // not just ask/squeeze. Guard so a monorepo (many runGenerate calls per process)
+  // counts as a single run. Interactive only — silent under --json/--report or non-TTY.
+  if (!global.__sigmapGenCounted) {
+    global.__sigmapGenCounted = true;
+    try {
+      const { checkStarNudge } = requireSourceOrBundled('./src/nudge');
+      const showNudge = !!process.stderr.isTTY
+        && !reportJson
+        && !process.argv.includes('--json')
+        && !process.argv.includes('--report')
+        && !process.argv.includes('--quiet');
+      checkStarNudge(global.__sigmapRootCwd || cwd, true, { silent: !showNudge });
+    } catch (_) {}
+  }
+
   return result;
 }
 
@@ -13011,6 +13028,9 @@ function main() {
   const cwd = cwdFlag
     ? path.resolve(invokedFrom, cwdFlag)
     : resolveProjectRoot(invokedFrom);
+  // v7.0.1: remember the invocation root so the generation star-nudge always tracks
+  // usage at the repo root, even when runGenerate is called per-package (monorepo).
+  global.__sigmapRootCwd = cwd;
   const scriptPath = process.argv[1] || path.join(invokedFrom, 'gen-context.js');
 
   if (cwdFlag) {

--- a/test/integration/features/nudge-generation.test.js
+++ b/test/integration/features/nudge-generation.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Integration test: the star nudge counts plain `sigmap` context-generation runs,
+ * not just `ask`/`squeeze` (v7.0.1). Most users only ever run `sigmap` to build the
+ * context file — they must still reach the one-time GitHub-star nudge.
+ *
+ * Verifies, by spawning the real CLI:
+ *   - a default generation run increments usage.json
+ *   - the nudge fires once at the 10-run / 8-success threshold
+ *   - --json generation still counts but stays silent
+ *   - a monorepo run counts once, at the repo root (not per package)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function makeRepo() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-gennudge-'));
+  fs.mkdirSync(path.join(d, 'src'));
+  fs.writeFileSync(path.join(d, 'src', 'm.js'),
+    'function login(user, pass) { return token; }\nmodule.exports = { login };\n');
+  return d;
+}
+
+function seedUsage(d, totalRuns) {
+  fs.mkdirSync(path.join(d, '.context'), { recursive: true });
+  fs.writeFileSync(path.join(d, '.context', 'usage.json'), JSON.stringify({
+    totalRuns, successfulRuns: totalRuns, squeezeOffered: 0, squeezeAccepted: 0,
+    starNudgeShown: false, machineId: '', firstRunDate: '2026-06-13', lastRunDate: '2026-06-13',
+  }));
+}
+
+function readUsage(d) {
+  return JSON.parse(fs.readFileSync(path.join(d, '.context', 'usage.json'), 'utf8'));
+}
+
+function runGen(cwd, args = []) {
+  return spawnSync('node', [SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('generation: a default run increments the usage counter', () => {
+  const d = makeRepo();
+  seedUsage(d, 0);
+  runGen(d);
+  const u = readUsage(d);
+  assert.strictEqual(u.totalRuns, 1, 'totalRuns should advance to 1');
+  assert.strictEqual(u.successfulRuns, 1, 'successfulRuns should advance to 1');
+});
+
+test('generation: fires the star nudge once at the 10-run threshold', () => {
+  const d = makeRepo();
+  seedUsage(d, 9);
+  runGen(d);
+  const u = readUsage(d);
+  assert.strictEqual(u.totalRuns, 10, 'should reach 10 runs');
+  assert.strictEqual(u.starNudgeShown, true, 'nudge should have fired');
+});
+
+test('generation: --json run still counts toward the nudge', () => {
+  const d = makeRepo();
+  seedUsage(d, 5);
+  runGen(d, ['--json']);
+  assert.strictEqual(readUsage(d).totalRuns, 6, '--json run must still count');
+});
+
+test('generation: monorepo counts once at the root, not per package', () => {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-gennudge-mono-'));
+  for (const pkg of ['a', 'b']) {
+    fs.mkdirSync(path.join(d, 'packages', pkg, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(d, 'packages', pkg, 'package.json'), JSON.stringify({ name: pkg }));
+    fs.writeFileSync(path.join(d, 'packages', pkg, 'src', `${pkg}.js`),
+      `function f${pkg}() {}\nmodule.exports = { f${pkg} };\n`);
+  }
+  seedUsage(d, 0);
+  runGen(d, ['--monorepo']);
+  assert.strictEqual(readUsage(d).totalRuns, 1, 'monorepo run should count exactly once');
+  // and it must not scatter a usage.json into the package dirs
+  assert.ok(!fs.existsSync(path.join(d, 'packages', 'a', '.context', 'usage.json')),
+    'no per-package usage.json should be written');
+});
+
+console.log(`\nnudge-generation: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Three related fixes that improve the published package's reach and supply-chain posture.

## 1. Star nudge counts plain `sigmap` runs (closes #250)
v7.0.0 only counted `ask`/`squeeze`, so users who only run `sigmap` to build the context file never reached the 10-run nudge threshold. Now counted once per process at the end of `runGenerate` (guarded against monorepo multi-counting; tracked at the invocation root). Interactive-only — silent under `--json`/`--report`/`--quiet`/non-TTY.

## 2. Eliminate system-shell access — Socket Supply Chain Security 75 → 100
Socket flagged **"Shell access"** + an **"AI-detected potential security risk"** (the screenshotted 75/100). Both came from `child_process.execSync` (runs via `/bin/sh -c`), several with values interpolated into the command string (`git diff ${range}`, `HEAD~${n}`, `printf '%s' … | ${clipCmd}`, `node -e "…http.get…"`) — a genuine shell-injection surface and the classic AI-scanner trigger.

Converted **every** call to shell-free `execFileSync` with an arguments array:
- New `src/util/git.js` (`git()`/`tryGit()` → `execFileSync('git', [...])`, stderr discarded — replaces `2>/dev/null`).
- All `src/` modules + every bundled-factory copy + inline CLI git call in `gen-context.js`.
- `extends` config fetch passes the URL as an argv to node (not interpolated into `-e`); `compare` benchmark spawns node by argv; clipboard spawns `pbcopy`/`xclip` and writes via stdin (no pipe, no shell).

Result: **zero** `execSync`/`exec`/`shell:true` in the published surface.

## 3. Package hygiene (Bundlephobia + privacy)
- `main`: `gen-context.js` → `packages/core/index.js`. The CLI bundle runs `main()`+`process.exit` on `require`, and Bundlephobia reads `main` — so it reported the ~1.2 MB CLI instead of the real zero-dep API. Now matches `exports["."]`.
- Removed the unused `machineId = sha256(os.hostname())` from the nudge — written to `usage.json` but never read or transmitted (a fingerprint scanners flag); dropped the `os`/`crypto` requires.

## Verification
- `node test/integration/all.js` — **71 passed, 0 failed**; `npm test` — pass; MCP — **19/19**
- All git features re-verified end-to-end (changes block, `status`, `suggest-profile`, project-root resolution, MCP git state)
- Benchmarks all green (matrix token 96.5% / hit@5 81.1% / task 41.8%; squeeze gate OK; verify precision OK)
- Local supply-chain audit: no shell spawns · no install scripts · `main` exports the API · no fingerprinting

Snyk is already clean (0 vulns, MIT). The `/plan-task` skill gained a **Phase 4B supply-chain gate** (the local audit above) so this can't regress.

Release flow: merge to `develop` → `/update-docs` (patch → v7.0.1) → `/ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)