### PR TITLE
fix(bundle): register ./src/util/git factory (unblocks binary build)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -8928,6 +8928,20 @@ __factories["./src/discovery/source-root-registry"] = function(module, exports) 
   module.exports = { REGISTRY };
 };
 
+// ── ./src/util/git ──
+__factories["./src/util/git"] = function(module, exports) {
+  'use strict';
+  const { execFileSync } = require('child_process');
+  function git(args, opts = {}) {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], ...opts });
+  }
+  function tryGit(args, opts = {}) {
+    try { return git(args, opts).toString().trim(); }
+    catch (_) { return ''; }
+  }
+  module.exports = { git, tryGit };
+};
+
 // ── ./src/discovery/sigmapignore ──
 __factories["./src/discovery/sigmapignore"] = function(module, exports) {
   'use strict';


### PR DESCRIPTION
## Summary
The v7.0.1 **Release Binaries** workflow failed on all three OS targets — the binary build's pre-flight gate requires every `src/**/*.js` to have a matching `__factories` entry in `gen-context.js`, and `src/util/git.js` (added in #252) was never registered. `npm publish` doesn't run this gate (it ships `src/` + bundle and prefers `src/` at runtime), so **7.0.1 published to npm fine**, but the standalone binaries didn't build.

## Changes
- `gen-context.js`: add the bundled `__factories["./src/util/git"]` factory (`git()`/`tryGit()`), mirroring `src/util/git.js`.

## Test plan
- [x] `node scripts/build-binary.mjs` → `✓ bundle pre-flight: all src/ modules present in gen-context.js` (local SEA/postject step needs CI toolchain)
- [x] `node test/integration/all.js` — 71 passed, 0 failed
- [x] `node -c gen-context.js` parses; `require('./src/util/git')` exports `git, tryGit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)