### PR TITLE
fix(bundle): register ./src/util/git factory — unblock v7.0.1 binaries

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -8928,6 +8928,20 @@ __factories["./src/discovery/source-root-registry"] = function(module, exports) 
   module.exports = { REGISTRY };
 };
 
+// ── ./src/util/git ──
+__factories["./src/util/git"] = function(module, exports) {
+  'use strict';
+  const { execFileSync } = require('child_process');
+  function git(args, opts = {}) {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], ...opts });
+  }
+  function tryGit(args, opts = {}) {
+    try { return git(args, opts).toString().trim(); }
+    catch (_) { return ''; }
+  }
+  module.exports = { git, tryGit };
+};
+
 // ── ./src/discovery/sigmapignore ──
 __factories["./src/discovery/sigmapignore"] = function(module, exports) {
   'use strict';


### PR DESCRIPTION
Carries the bundle-factory fix (#255) to `main` so the **v7.0.1 tag can be moved here** and the Release Binaries workflow can build.

## Why
The v7.0.1 binary build failed its pre-flight gate: `src/util/git.js` (added in #252) had no `__factories` entry in `gen-context.js`. npm publish succeeded (7.0.1 is live), but standalone binaries didn't build. This adds the missing factory.

## After merge
The `v7.0.1` tag will be moved to this merge commit (the prior binary pipeline failed — sanctioned re-tag), re-triggering Release Binaries (now builds) + Release Core (no-ops on the already-published npm version).

## Verification
- `node scripts/build-binary.mjs` pre-flight: `✓ all src/ modules present`
- `node test/integration/all.js` — 71 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)