### PR TITLE
docs(readme): add Sponsor section with tier ladder + funding goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,21 @@ SigMap is built and maintained by one developer, kept **zero-dependency**, offli
 
 One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
 
-**Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
+### Where your sponsorship goes
+
+Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
+
+- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
+- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.dev` for the documentation site
+- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
+- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
+- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
+
+**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.dev` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
+
+### Can only spare a little? That's perfect 💜
+
+If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
 
 ### About the maintainer
 

--- a/README.md
+++ b/README.md
@@ -247,38 +247,9 @@ If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/m
 
 ## Sponsor
 
-SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI, the `sigmap.io` domain, and ongoing supply-chain hardening.
 
-💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
-
-| Tier | | Reward |
-|---|:--:|---|
-| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
-| **Backer** | $25/mo | Your name or handle in this README |
-| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
-| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
-
-One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
-
-### Where your sponsorship goes
-
-Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
-
-- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
-- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.dev` for the documentation site
-- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
-- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
-- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
-
-**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.dev` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
-
-### Can only spare a little? That's perfect 💜
-
-If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
-
-### About the maintainer
-
-SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)** · see **[SPONSOR.md](SPONSOR.md)** for tiers and exactly where your support goes. Any amount helps — even $1/mo — and a ⭐ or a share counts too.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the n
 
 **Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
 
+### About the maintainer
+
+SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -245,6 +245,25 @@ If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/m
 
 ---
 
+## Sponsor
+
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
+
+| Tier | | Reward |
+|---|:--:|---|
+| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
+| **Backer** | $25/mo | Your name or handle in this README |
+| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
+| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
+
+One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
+
+**Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
+
+---
+
 ## Contributing
 
 SigMap welcomes contributions! 

--- a/SPONSOR.md
+++ b/SPONSOR.md
@@ -1,0 +1,36 @@
+# Sponsor SigMap
+
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free for everyone. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
+
+## Tiers
+
+| Tier | | Reward |
+|---|:--:|---|
+| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
+| **Backer** | $25/mo | Your name or handle in the SigMap README |
+| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
+| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
+
+One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
+
+## Where your sponsorship goes
+
+Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
+
+- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
+- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.io` for the documentation site
+- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
+- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
+- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
+
+**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.io` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
+
+## Can only spare a little? That's perfect 💜
+
+If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
+
+## About the maintainer
+
+SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜


### PR DESCRIPTION
## Summary
Surfaces the sponsorship path in the README. `.github/FUNDING.yml` (`github: [manojmallick]`) and the `package.json` `funding` field were already in place (#241) — this adds the user-facing section so visitors see the tiers + goal.

## Changes
- `README.md` — new `## Sponsor` section (between Support and Contributing): GitHub Sponsors button, a four-tier monthly ladder (Supporter $5 / Backer $25 / Team $100 / Company $500), one-time rewards ($10 shoutout, $50 release-notes credit), and a $200/mo funding goal.

These mirror the tiers to configure in the GitHub Sponsors dashboard (badge → README name → website logo + priority bugs → commercial acknowledgement).

## Test plan
- [x] `node test/integration/features/readme-structure.test.js` — 51 passed (no pinned metric/heading changes)
- [x] `node test/integration/all.js` — 71 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)