### PR TITLE
Release: sigmap.io domain + docs-site fix + sponsor docs

### DIFF
--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Commit version updates
         run: |
           git config user.name "SigMap Bot"
-          git config user.email "bot@sigmap.dev"
+          git config user.email "bot@sigmap.io"
           git add package.json vscode-extension/package.json jetbrains-plugin/build.gradle.kts
           git commit -m "prerelease: npm ${{ steps.version.outputs.npm_version }}, vscode ${{ steps.version.outputs.vscode_version }}"
           git push origin HEAD:${GITHUB_REF#refs/heads/}

--- a/README.md
+++ b/README.md
@@ -260,7 +260,21 @@ SigMap is built and maintained by one developer, kept **zero-dependency**, offli
 
 One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
 
-**Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
+### Where your sponsorship goes
+
+Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
+
+- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
+- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.dev` for the documentation site
+- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
+- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
+- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
+
+**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.dev` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
+
+### Can only spare a little? That's perfect 💜
+
+If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
 
 ### About the maintainer
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Repos tested   : 21 (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift
 Measured on 90 coding tasks across 18 real public repos. No LLM API — fully reproducible.
 
 **Resources:**
-- [Full methodology →](https://manojmallick.github.io/sigmap/guide/benchmark.html)
+- [Full methodology →](https://sigmap.io/guide/benchmark.html)
 - [Benchmark suite (GitHub)](https://github.com/manojmallick/sigmap-benchmark-suite) — scripts, tasks, and raw data
 - [Benchmark data (Zenodo)](https://zenodo.org/records/19898842) — archived results for reproducibility
 
@@ -172,8 +172,8 @@ sigmap --adapter claude    # works with Claude Code
 **Open-source agents & local LLMs:**
 
 Use SigMap with open-source tools and fully self-hosted setups:
-- **[Open-source agents guide →](https://manojmallick.github.io/sigmap/guide/agents)** — OpenCode, Aider, OpenHands, Cline
-- **[Local LLMs guide →](https://manojmallick.github.io/sigmap/guide/local-llms)** — Ollama, llama.cpp, vLLM (no API keys, full privacy)
+- **[Open-source agents guide →](https://sigmap.io/guide/agents)** — OpenCode, Aider, OpenHands, Cline
+- **[Local LLMs guide →](https://sigmap.io/guide/local-llms)** — Ollama, llama.cpp, vLLM (no API keys, full privacy)
 
 **IDE extensions:**
 
@@ -219,21 +219,21 @@ sigmap --health
 | 👶 **New** | [Quick start guide](docs/readmes/GETTING_STARTED.md) — setup in 60 seconds |
 | ⚡ **Daily** | `sigmap ask` / `sigmap validate` / `sigmap judge` |
 | 🧠 **Advanced** | [Context strategies](docs/readmes/CONTEXT_STRATEGIES.md) · [MCP setup](docs/readmes/MCP_SETUP.md) |
-| 🏢 **Teams** | [Config reference](https://manojmallick.github.io/sigmap/guide/config.html) · [CI setup](docs/readmes/ENTERPRISE_SETUP.md) |
+| 🏢 **Teams** | [Config reference](https://sigmap.io/guide/config.html) · [CI setup](docs/readmes/ENTERPRISE_SETUP.md) |
 
 ---
 
 ## Docs
 
-**[manojmallick.github.io/sigmap](https://manojmallick.github.io/sigmap)**
+**[sigmap.io](https://sigmap.io)**
 
 | Section | Link |
 |---|---|
-| CLI reference (32 commands) | [cli.html](https://manojmallick.github.io/sigmap/guide/cli.html) |
-| Benchmark methodology | [benchmark.html](https://manojmallick.github.io/sigmap/guide/benchmark.html) |
-| Config reference | [config.html](https://manojmallick.github.io/sigmap/guide/config.html) |
-| Roadmap | [roadmap.html](https://manojmallick.github.io/sigmap/guide/roadmap.html) |
-| 31 languages | [generalization.html](https://manojmallick.github.io/sigmap/guide/generalization.html) |
+| CLI reference (32 commands) | [cli.html](https://sigmap.io/guide/cli.html) |
+| Benchmark methodology | [benchmark.html](https://sigmap.io/guide/benchmark.html) |
+| Config reference | [config.html](https://sigmap.io/guide/config.html) |
+| Roadmap | [roadmap.html](https://sigmap.io/guide/roadmap.html) |
+| 31 languages | [generalization.html](https://sigmap.io/guide/generalization.html) |
 
 ---
 
@@ -284,7 +284,7 @@ TypeScript · JavaScript · Python · Java · Kotlin · Go · Rust · C# · C/C+
 
 All implemented with zero external dependencies.
 
-[Full language table →](https://manojmallick.github.io/sigmap/guide/generalization.html)
+[Full language table →](https://sigmap.io/guide/generalization.html)
 
 ---
 
@@ -296,7 +296,7 @@ MIT © 2026 [Manoj Mallick](https://github.com/manojmallick) · Made in Amsterda
 
 <div align="center">
 
-**[Docs](https://manojmallick.github.io/sigmap) · [Changelog](CHANGELOG.md) · [Roadmap](https://manojmallick.github.io/sigmap/roadmap.html) · [npm](https://www.npmjs.com/package/sigmap)**
+**[Docs](https://sigmap.io) · [Changelog](CHANGELOG.md) · [Roadmap](https://sigmap.io/roadmap.html) · [npm](https://www.npmjs.com/package/sigmap)**
 
 ⭐ [Star on GitHub](https://github.com/manojmallick/sigmap) if SigMap saves you tokens.
 

--- a/README.md
+++ b/README.md
@@ -247,38 +247,9 @@ If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/m
 
 ## Sponsor
 
-SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI, the `sigmap.io` domain, and ongoing supply-chain hardening.
 
-💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
-
-| Tier | | Reward |
-|---|:--:|---|
-| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
-| **Backer** | $25/mo | Your name or handle in this README |
-| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
-| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
-
-One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
-
-### Where your sponsorship goes
-
-Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
-
-- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
-- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.dev` for the documentation site
-- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
-- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
-- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
-
-**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.dev` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
-
-### Can only spare a little? That's perfect 💜
-
-If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
-
-### About the maintainer
-
-SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)** · see **[SPONSOR.md](SPONSOR.md)** for tiers and exactly where your support goes. Any amount helps — even $1/mo — and a ⭐ or a share counts too.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the n
 
 **Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
 
+### About the maintainer
+
+SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -245,6 +245,25 @@ If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/m
 
 ---
 
+## Sponsor
+
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
+
+| Tier | | Reward |
+|---|:--:|---|
+| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
+| **Backer** | $25/mo | Your name or handle in this README |
+| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
+| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
+
+One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
+
+**Goal:** $200/mo covers benchmark CI compute and keeps SigMap zero-dependency, supply-chain-hardened, and free for everyone.
+
+---
+
 ## Contributing
 
 SigMap welcomes contributions! 

--- a/SPONSOR.md
+++ b/SPONSOR.md
@@ -1,0 +1,36 @@
+# Sponsor SigMap
+
+SigMap is built and maintained by one developer, kept **zero-dependency**, offline, and free for everyone. If it saves your team context or API spend, sponsoring keeps it that way — and funds the benchmark CI and ongoing supply-chain hardening.
+
+💜 **[Become a sponsor →](https://github.com/sponsors/manojmallick)**
+
+## Tiers
+
+| Tier | | Reward |
+|---|:--:|---|
+| **Supporter** | $5/mo | Sponsor badge on your profile + my gratitude |
+| **Backer** | $25/mo | Your name or handle in the SigMap README |
+| **Team** | $100/mo | Your logo on the site + **priority on bug reports** you file |
+| **Company** | $500/mo | Commercial-use acknowledgement, prominent logo, and a direct line for issues |
+
+One-time: **$10** — a thank-you shoutout on X · **$50** — credited in the next release notes.
+
+## Where your sponsorship goes
+
+Every dollar is spent on keeping SigMap free, fast, and independent — no salaries, no overhead:
+
+- 🧪 **More benchmarking** — CI compute to run the token / retrieval / quality / task matrix across 21 real repos on every release, so the numbers stay honest and reproducible
+- 🌐 **Domain & docs hosting** — registering and renewing `sigmap.io` for the documentation site
+- 🛠️ **Support & maintenance** — time to triage issues, review PRs, answer questions, and ship releases
+- 🔒 **Supply-chain hardening** — keeping the package zero-dependency, shell-free, and audited
+- 🌍 **New languages & IDE support** — expanding extractors and editor integrations
+
+**Goal:** **$200/mo** covers the benchmark CI and the `sigmap.io` domain, and frees up real maintenance time. Anything beyond goes straight into new features.
+
+## Can only spare a little? That's perfect 💜
+
+If SigMap has helped you, **any amount helps** — even **$1/month**. No tier is too small, and you don't need a reason beyond *"it was useful."* And if you can't sponsor right now, that's completely fine — a ⭐ on the repo or sharing it with a teammate helps just as much.
+
+## About the maintainer
+
+SigMap is built and maintained by **[Manoj Mallick](https://github.com/manojmallick)** — solo, in the open, and kept free for everyone. The goal is simple: make AI coding assistants answer from the *right* files instead of guessing, with **zero dependencies**, fully offline, and no telemetry. Sponsorship funds the reproducible benchmark CI, ongoing supply-chain hardening, and new language/IDE support — and keeps the project independent. 💜

--- a/docs-vp/.vitepress/config.mts
+++ b/docs-vp/.vitepress/config.mts
@@ -1,19 +1,19 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  base: '/sigmap/',
+  base: '/',
   title: 'SigMap',
   description: 'Zero-dependency AI context engine. 97% token reduction.',
 
   appearance: 'dark',
 
   head: [
-    ['link', { rel: 'icon', href: '/sigmap/favicon.png' }],
+    ['link', { rel: 'icon', href: '/favicon.png' }],
     // Global defaults — overridden per-page via frontmatter head
     ['meta', { property: 'og:site_name', content: 'SigMap' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { property: 'og:image', content: 'https://manojmallick.github.io/sigmap/sigmap-banner.png' }],
-    ['meta', { name: 'twitter:image', content: 'https://manojmallick.github.io/sigmap/sigmap-banner.png' }],
+    ['meta', { property: 'og:image', content: 'https://sigmap.io/sigmap-banner.png' }],
+    ['meta', { name: 'twitter:image', content: 'https://sigmap.io/sigmap-banner.png' }],
   ],
 
   themeConfig: {
@@ -118,6 +118,6 @@ export default defineConfig({
   },
 
   sitemap: {
-    hostname: 'https://manojmallick.github.io/sigmap/',
+    hostname: 'https://sigmap.io/',
   },
 })

--- a/docs-vp/.vitepress/public/robots.txt
+++ b/docs-vp/.vitepress/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://manojmallick.github.io/sigmap/sitemap.xml
+Sitemap: https://sigmap.io/sitemap.xml

--- a/docs-vp/guide/agents.md
+++ b/docs-vp/guide/agents.md
@@ -10,7 +10,7 @@ head:
       content: "Use SigMap with open-source coding agents and local LLM inference. Works with OpenCode, OpenHands, Cline, Aider, Ollama, llama.cpp, vLLM."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/agents"
+      content: "https://sigmap.io/guide/agents"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -10,7 +10,7 @@ head:
       content: "Token, retrieval, quality, and task metrics from latest v7.0.0 benchmark run (2026-06-14) with 21 repositories including R language support."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/benchmark"
+      content: "https://sigmap.io/guide/benchmark"
 ---
 
 # Benchmark overview

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -10,7 +10,7 @@ head:
       content: "All 46 SigMap commands and flags documented with examples. ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/cli"
+      content: "https://sigmap.io/guide/cli"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -651,7 +651,7 @@ sigmap share
 ```
 Generated with SigMap — zero-dependency AI context engine
 97.0% fewer tokens · 75.6% retrieval hit@5 · 39.4% fewer prompts
-https://sigmap.dev
+https://sigmap.io
 [sigmap] Copied to clipboard.
 ```
 

--- a/docs-vp/guide/compare-alternatives.md
+++ b/docs-vp/guide/compare-alternatives.md
@@ -10,7 +10,7 @@ head:
       content: "Side-by-side comparison: SigMap vs RAG, embeddings, RepoMix, and Copilot context. Zero infra, deterministic, 5.6× retrieval lift."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/compare-alternatives"
+      content: "https://sigmap.io/guide/compare-alternatives"
 ---
 
 # SigMap vs alternatives

--- a/docs-vp/guide/config.md
+++ b/docs-vp/guide/config.md
@@ -10,7 +10,7 @@ head:
       content: "Every gen-context.config.json key documented with types, defaults, and examples."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/config"
+      content: "https://sigmap.io/guide/config"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/generalization.md
+++ b/docs-vp/guide/generalization.md
@@ -10,7 +10,7 @@ head:
       content: "SigMap's latest public snapshot spans 18 repos, 13 languages, and 9 domains without per-repo tuning."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/generalization"
+      content: "https://sigmap.io/guide/generalization"
 ---
 
 # Generalization

--- a/docs-vp/guide/how-i-built-sigmap.md
+++ b/docs-vp/guide/how-i-built-sigmap.md
@@ -10,7 +10,7 @@ head:
       content: "Most AI coding tools fail because they read the wrong files. Here's how I fixed that with deterministic retrieval, zero dependencies, and a continuous LLM feedback loop."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/how-i-built-sigmap"
+      content: "https://sigmap.io/guide/how-i-built-sigmap"
 ---
 
 # How I built SigMap

--- a/docs-vp/guide/languages.md
+++ b/docs-vp/guide/languages.md
@@ -10,7 +10,7 @@ head:
       content: "Pure regex AST extraction for 31 languages and formats. No compiler required, no binary dependencies."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/languages"
+      content: "https://sigmap.io/guide/languages"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/local-llms.md
+++ b/docs-vp/guide/local-llms.md
@@ -10,7 +10,7 @@ head:
       content: "Use SigMap with self-hosted LLMs for code understanding. No subscription, no telemetry, full privacy. Works with Ollama, llama.cpp, vLLM."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/local-llms"
+      content: "https://sigmap.io/guide/local-llms"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -10,7 +10,7 @@ head:
       content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 11 MCP tools over stdio."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/mcp"
+      content: "https://sigmap.io/guide/mcp"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/methodology.md
+++ b/docs-vp/guide/methodology.md
@@ -10,7 +10,7 @@ head:
       content: "Design and methodology behind SigMap's retrieval, quality, and task benchmarks."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/methodology"
+      content: "https://sigmap.io/guide/methodology"
 ---
 
 # Benchmark methodology

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -10,7 +10,7 @@ head:
       content: "16/21 repos overflow GPT-4o without SigMap. 5,200+ files would be hidden. $10,500+/month saved in GPT-4o input cost at 10 calls/day."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/quality-benchmark"
+      content: "https://sigmap.io/guide/quality-benchmark"
 ---
 
 # Quality benchmark

--- a/docs-vp/guide/quick-start.md
+++ b/docs-vp/guide/quick-start.md
@@ -10,7 +10,7 @@ head:
       content: "Install once, generate signatures, ask a real question, validate coverage, and judge the answer."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/quick-start"
+      content: "https://sigmap.io/guide/quick-start"
 ---
 # Quick start
 

--- a/docs-vp/guide/repomix.md
+++ b/docs-vp/guide/repomix.md
@@ -10,7 +10,7 @@ head:
       content: "SigMap for always-on signatures, Repomix for full-depth sessions. Use both for complete AI context coverage."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/repomix"
+      content: "https://sigmap.io/guide/repomix"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -10,7 +10,7 @@ head:
       content: "Latest saved run: 76% hit@5 vs 13.6% random baseline, 6.0x lift, 90 tasks, 18 repos."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/retrieval-benchmark"
+      content: "https://sigmap.io/guide/retrieval-benchmark"
 ---
 
 # Retrieval benchmark

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -10,7 +10,7 @@ head:
       content: "51 versions shipped. See what changed in each release and what is coming next."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/roadmap"
+      content: "https://sigmap.io/guide/roadmap"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/strategies.md
+++ b/docs-vp/guide/strategies.md
@@ -10,7 +10,7 @@ head:
       content: "Choose the right SigMap strategy for your workflow. Token cost comparison, MCP integration, and decision guide."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/strategies"
+      content: "https://sigmap.io/guide/strategies"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -10,7 +10,7 @@ head:
       content: "Latest saved run: 52.2% correct, 1.72 prompts per task, 39.4% prompt reduction, 90 tasks, 18+ repos with R support."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/task-benchmark"
+      content: "https://sigmap.io/guide/task-benchmark"
 ---
 
 # Task benchmark

--- a/docs-vp/guide/troubleshooting.md
+++ b/docs-vp/guide/troubleshooting.md
@@ -10,7 +10,7 @@ head:
       content: "Fix common SigMap issues. No context file found, zero signatures, watch mode not triggering, and more."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/troubleshooting"
+      content: "https://sigmap.io/guide/troubleshooting"
   - - meta
     - property: og:type
       content: article

--- a/docs-vp/guide/walkthrough.md
+++ b/docs-vp/guide/walkthrough.md
@@ -10,7 +10,7 @@ head:
       content: "Watch the full SigMap workflow on a real repo: ask ranks files, validate checks coverage, judge scores groundedness, learn reinforces what helped."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/walkthrough"
+      content: "https://sigmap.io/guide/walkthrough"
 ---
 
 # End-to-end walkthrough

--- a/docs-vp/guide/when-to-use.md
+++ b/docs-vp/guide/when-to-use.md
@@ -10,7 +10,7 @@ head:
       content: "Know exactly which SigMap command to run for your situation. Full context vs focused ask, with real token numbers across 18 repos."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/guide/when-to-use"
+      content: "https://sigmap.io/guide/when-to-use"
 ---
 
 # When to use what

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -11,7 +11,7 @@ head:
       content: "Ask, validate, judge, and learn from real code context. 75.6% hit@5, 39.4% fewer prompts, 97.0% overall token reduction."
   - - meta
     - property: og:url
-      content: "https://manojmallick.github.io/sigmap/"
+      content: "https://sigmap.io/"
   - - meta
     - property: og:type
       content: website

--- a/docs-vp/public/CNAME
+++ b/docs-vp/public/CNAME
@@ -1,0 +1,1 @@
+sigmap.io

--- a/docs-vp/public/cli.html
+++ b/docs-vp/public/cli.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>CLI Reference – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/cli">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/cli">
+<link rel="canonical" href="https://sigmap.io/guide/cli">
+<meta http-equiv="refresh" content="0; url=/guide/cli">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/cli">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/cli")</script>
+<p>Page moved. <a href="/guide/cli">Click here</a>.</p>
+<script>window.location.replace("/guide/cli")</script>
 </body></html>

--- a/docs-vp/public/config.html
+++ b/docs-vp/public/config.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Config Reference – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/config">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/config">
+<link rel="canonical" href="https://sigmap.io/guide/config">
+<meta http-equiv="refresh" content="0; url=/guide/config">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/config">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/config")</script>
+<p>Page moved. <a href="/guide/config">Click here</a>.</p>
+<script>window.location.replace("/guide/config")</script>
 </body></html>

--- a/docs-vp/public/languages.html
+++ b/docs-vp/public/languages.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Languages – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/languages">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/languages">
+<link rel="canonical" href="https://sigmap.io/guide/languages">
+<meta http-equiv="refresh" content="0; url=/guide/languages">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/languages">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/languages")</script>
+<p>Page moved. <a href="/guide/languages">Click here</a>.</p>
+<script>window.location.replace("/guide/languages")</script>
 </body></html>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -273,7 +273,7 @@ the relevant regulation before publication; SigMap makes no legal claims.
 - Author: Manoj Mallick
 - License: MIT
 - Repository: https://github.com/manojmallick/sigmap
-- Documentation: https://manojmallick.github.io/sigmap/
+- Documentation: https://sigmap.io/
 - npm: https://www.npmjs.com/package/sigmap
 - Benchmark dataset: https://doi.org/10.5281/zenodo.19898842
 - Issues: https://github.com/manojmallick/sigmap/issues

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -39,18 +39,18 @@ npx sigmap --mcp                    # start the MCP server over stdio
 ```
 
 ## Docs
-- [Full documentation](https://manojmallick.github.io/sigmap/)
-- [CLI reference](https://manojmallick.github.io/sigmap/guide/cli)
-- [MCP tools](https://manojmallick.github.io/sigmap/guide/mcp)
-- [Benchmark methodology](https://manojmallick.github.io/sigmap/guide/benchmark)
-- [Configuration guide](https://manojmallick.github.io/sigmap/guide/config)
+- [Full documentation](https://sigmap.io/)
+- [CLI reference](https://sigmap.io/guide/cli)
+- [MCP tools](https://sigmap.io/guide/mcp)
+- [Benchmark methodology](https://sigmap.io/guide/benchmark)
+- [Configuration guide](https://sigmap.io/guide/config)
 - [Changelog](https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md)
 
 ## Optional
 - [GitHub repository](https://github.com/manojmallick/sigmap)
 - [npm package](https://www.npmjs.com/package/sigmap)
 - [Benchmark dataset (Zenodo)](https://doi.org/10.5281/zenodo.19898842)
-- [Full LLM reference](https://manojmallick.github.io/sigmap/llms-full.txt)
+- [Full LLM reference](https://sigmap.io/llms-full.txt)
 
 SigMap — grounded AI coding context. The lightweight, deterministic alternative
 to embeddings for feeding the right code to AI assistants.

--- a/docs-vp/public/mcp.html
+++ b/docs-vp/public/mcp.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>MCP Server – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/mcp">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/mcp">
+<link rel="canonical" href="https://sigmap.io/guide/mcp">
+<meta http-equiv="refresh" content="0; url=/guide/mcp">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/mcp">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/mcp")</script>
+<p>Page moved. <a href="/guide/mcp">Click here</a>.</p>
+<script>window.location.replace("/guide/mcp")</script>
 </body></html>

--- a/docs-vp/public/quick-start.html
+++ b/docs-vp/public/quick-start.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Quick Start – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/quick-start">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/quick-start">
+<link rel="canonical" href="https://sigmap.io/guide/quick-start">
+<meta http-equiv="refresh" content="0; url=/guide/quick-start">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/quick-start">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/quick-start")</script>
+<p>Page moved. <a href="/guide/quick-start">Click here</a>.</p>
+<script>window.location.replace("/guide/quick-start")</script>
 </body></html>

--- a/docs-vp/public/repomix.html
+++ b/docs-vp/public/repomix.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Repomix Integration – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/repomix">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/repomix">
+<link rel="canonical" href="https://sigmap.io/guide/repomix">
+<meta http-equiv="refresh" content="0; url=/guide/repomix">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/repomix">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/repomix")</script>
+<p>Page moved. <a href="/guide/repomix">Click here</a>.</p>
+<script>window.location.replace("/guide/repomix")</script>
 </body></html>

--- a/docs-vp/public/roadmap.html
+++ b/docs-vp/public/roadmap.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Roadmap – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/roadmap">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/roadmap">
+<link rel="canonical" href="https://sigmap.io/guide/roadmap">
+<meta http-equiv="refresh" content="0; url=/guide/roadmap">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/roadmap">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/roadmap")</script>
+<p>Page moved. <a href="/guide/roadmap">Click here</a>.</p>
+<script>window.location.replace("/guide/roadmap")</script>
 </body></html>

--- a/docs-vp/public/robots.txt
+++ b/docs-vp/public/robots.txt
@@ -3,4 +3,4 @@ Allow: /
 Allow: /llms.txt
 Allow: /llms-full.txt
 
-Sitemap: https://manojmallick.github.io/sigmap/sitemap.xml
+Sitemap: https://sigmap.io/sitemap.xml

--- a/docs-vp/public/strategies.html
+++ b/docs-vp/public/strategies.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Strategies – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/strategies">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/strategies">
+<link rel="canonical" href="https://sigmap.io/guide/strategies">
+<meta http-equiv="refresh" content="0; url=/guide/strategies">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/strategies">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/strategies")</script>
+<p>Page moved. <a href="/guide/strategies">Click here</a>.</p>
+<script>window.location.replace("/guide/strategies")</script>
 </body></html>

--- a/docs-vp/public/troubleshooting.html
+++ b/docs-vp/public/troubleshooting.html
@@ -1,10 +1,10 @@
 <!doctype html><html><head>
 <meta charset="utf-8">
 <title>Troubleshooting – SigMap</title>
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/guide/troubleshooting">
-<meta http-equiv="refresh" content="0; url=/sigmap/guide/troubleshooting">
+<link rel="canonical" href="https://sigmap.io/guide/troubleshooting">
+<meta http-equiv="refresh" content="0; url=/guide/troubleshooting">
 <meta name="robots" content="noindex">
 </head><body>
-<p>Page moved. <a href="/sigmap/guide/troubleshooting">Click here</a>.</p>
-<script>window.location.replace("/sigmap/guide/troubleshooting")</script>
+<p>Page moved. <a href="/guide/troubleshooting">Click here</a>.</p>
+<script>window.location.replace("/guide/troubleshooting")</script>
 </body></html>

--- a/docs/JETBRAINS_SETUP.md
+++ b/docs/JETBRAINS_SETUP.md
@@ -43,6 +43,6 @@ SigMap adds a health indicator to the IDE status bar. Click it to view the curre
 
 ## More Information
 
-- [SigMap CLI Documentation](https://manojmallick.github.io/sigmap/)
+- [SigMap CLI Documentation](https://sigmap.io/)
 - [GitHub Repository](https://github.com/manojmallick/sigmap)
 - [Changelog](../CHANGELOG.md)

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -7,18 +7,18 @@
 <meta name="description" content="Complete SigMap CLI reference. All flags with examples: --watch, --setup, --diff, --mcp, --report, --health, --suggest-tool, --monorepo, --format, --track, --init.">
 <meta property="og:title" content="SigMap CLI Reference — every flag with examples">
 <meta property="og:description" content="All 22 SigMap CLI flags documented with examples. --watch, --setup, --diff, --mcp, --report, --health and more.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/cli.html">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:url" content="https://sigmap.io/cli.html">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap CLI Reference — every flag with examples">
 <meta name="twitter:description" content="All 22 SigMap CLI flags documented with examples. --watch, --setup, --diff, --mcp, --report, --health and more.">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:image:alt" content="SigMap CLI Reference">
 <meta name="keywords" content="sigmap cli, sigmap flags, sigmap --watch, sigmap --mcp, sigmap --diff, sigmap --report, sigmap --init, command line reference">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/cli.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap CLI Reference — every flag with examples","description":"Complete SigMap CLI reference. All flags documented with examples.","url":"https://manojmallick.github.io/sigmap/cli.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/cli.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap CLI Reference — every flag with examples","description":"Complete SigMap CLI reference. All flags documented with examples.","url":"https://sigmap.io/cli.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -670,8 +670,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/config.html
+++ b/docs/config.html
@@ -7,18 +7,18 @@
 <meta name="description" content="Complete SigMap configuration reference. All 21 keys in gen-context.config.json with types, defaults, and examples. srcDirs, maxTokens, strategy, outputs, secretScan and more.">
 <meta property="og:title" content="SigMap Configuration Reference — all 21 keys">
 <meta property="og:description" content="Every gen-context.config.json key documented with types, defaults, and examples.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/config.html">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:url" content="https://sigmap.io/config.html">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap Configuration Reference — all 21 keys">
 <meta name="twitter:description" content="Every gen-context.config.json key documented with types, defaults, and examples.">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:image:alt" content="SigMap Configuration Reference">
 <meta name="keywords" content="sigmap config, gen-context.config.json, sigmap configuration, srcDirs, maxTokens, strategy, outputs, secretScan, sigmap settings">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/config.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap Configuration Reference","description":"Complete gen-context.config.json reference. All 21 keys with types, defaults, and examples.","url":"https://manojmallick.github.io/sigmap/config.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/config.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap Configuration Reference","description":"Complete gen-context.config.json reference. All 21 keys with types, defaults, and examples.","url":"https://sigmap.io/config.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -491,8 +491,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,19 +7,19 @@
 <meta name="description" content="Reduce AI coding agent token consumption by 97%. Extracts signatures from 29 languages and formats, writes copilot-instructions.md automatically. Zero npm install.">
 <meta property="og:title" content="SigMap — 97% token reduction for AI coding agents">
 <meta property="og:description" content="node gen-context.js — that's the entire install. Reduces Copilot sessions from 80K to 4K tokens automatically.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/">
+<meta property="og:url" content="https://sigmap.io/">
 <meta name="twitter:card" content="summary_large_image">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap — 97% token reduction for AI coding agents">
 <meta name="twitter:description" content="node gen-context.js — that's the entire install. Reduces Copilot sessions from 80K to 4K tokens automatically.">
 <meta name="twitter:image:alt" content="SigMap — Zero-dependency AI context engine for AI coding agents">
 <meta name="keywords" content="sigmap, ai context engine, copilot token reduction, ai coding agent, context window optimization, zero dependency, copilot-instructions, claude code context, cursor context, windsurf context">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/">
-<link rel="sitemap" type="application/xml" href="https://manojmallick.github.io/sigmap/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"SigMap","applicationCategory":"DeveloperApplication","description":"Zero-dependency AI context engine. 97% token reduction for AI coding agents. Extracts signatures from 29 languages and formats. No npm install.","url":"https://manojmallick.github.io/sigmap/","downloadUrl":"https://www.npmjs.com/package/sigmap","softwareVersion":"5.8.0","operatingSystem":"Any (Node.js 18+)","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"}}</script>
+<link rel="canonical" href="https://sigmap.io/">
+<link rel="sitemap" type="application/xml" href="https://sigmap.io/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"SigMap","applicationCategory":"DeveloperApplication","description":"Zero-dependency AI context engine. 97% token reduction for AI coding agents. Extracts signatures from 29 languages and formats. No npm install.","url":"https://sigmap.io/","downloadUrl":"https://www.npmjs.com/package/sigmap","softwareVersion":"5.8.0","operatingSystem":"Any (Node.js 18+)","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -256,7 +256,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px;t
       </div>
     </div>
     <p style="text-align:center;margin-top:14px;font-size:.9rem;color:var(--t2)">
-      See the <a href="https://manojmallick.github.io/sigmap/guide/walkthrough" style="color:var(--p)">full end-to-end walkthrough →</a>
+      See the <a href="https://sigmap.io/guide/walkthrough" style="color:var(--p)">full end-to-end walkthrough →</a>
     </p>
   </div>
 </section>
@@ -413,7 +413,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px;t
       <div class="qs-body">
         <h4>Download gen-context.js</h4>
         <p>One file, no install required. Drop it in your project root or download globally.</p>
-        <code>curl -O https://raw.githubusercontent.com/manojmallick/sigmap/main/gen-context.js</code>
+        <code>curl -O https://raw.githubusercontent.com/manojmallick/main/gen-context.js</code>
       </div>
     </div>
     <div class="qs-step">
@@ -465,7 +465,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px;t
   <p>Free forever. Zero telemetry. Runs locally. Adding a language extractor is 80 lines of code — contributions welcome.</p>
   <div style="display:flex;justify-content:center;gap:12px;flex-wrap:wrap">
     <a class="btn-primary" href="https://github.com/manojmallick/sigmap" target="_blank">★ Star on GitHub</a>
-    <a class="btn-secondary" href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md" target="_blank">Contribute</a>
+    <a class="btn-secondary" href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md" target="_blank">Contribute</a>
   </div>
 </div>
 
@@ -484,8 +484,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px;t
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -7,18 +7,18 @@
 <meta name="description" content="SigMap extracts signatures from 29 languages and formats using pure regex — no npm install, no Tree-sitter. TypeScript, Python, Go, Rust, Java, Kotlin, C#, C++, Ruby, PHP, Swift, Dart, Scala, Vue, Svelte, HTML, CSS, YAML, Shell, Dockerfile.">
 <meta property="og:title" content="SigMap — 29 languages and formats, zero dependencies">
 <meta property="og:description" content="Signature extraction for TypeScript, Python, Go, Rust, Java, Kotlin, C#, C++, Ruby, PHP, Swift, Dart, Scala, Vue, Svelte, HTML, CSS, YAML, Shell, Dockerfile.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/languages.html">
+<meta property="og:url" content="https://sigmap.io/languages.html">
 <meta name="twitter:card" content="summary_large_image">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap — 29 languages and formats, zero dependencies">
 <meta name="twitter:description" content="Signature extraction for TypeScript, Python, Go, Rust, Java, Kotlin, C#, C++, Ruby, PHP, Swift, Dart, Scala, Vue, Svelte and more.">
 <meta name="twitter:image:alt" content="SigMap Language Support — 29 languages and formats">
 <meta name="keywords" content="sigmap languages, typescript context, python ai context, go context, rust context, java ai coding, kotlin context, csharp ai, multi-language ai context">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/languages.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap language support — 29 languages and formats, zero dependencies","description":"Signature extraction for TypeScript, Python, Go, Rust, Java, Kotlin, C#, C++, Ruby, PHP, Swift, Dart, Scala, Vue, Svelte, HTML, CSS, YAML, Shell, Dockerfile. Pure regex, no npm install.","url":"https://manojmallick.github.io/sigmap/languages.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/languages.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap language support — 29 languages and formats, zero dependencies","description":"Signature extraction for TypeScript, Python, Go, Rust, Java, Kotlin, C#, C++, Ruby, PHP, Swift, Dart, Scala, Vue, Svelte, HTML, CSS, YAML, Shell, Dockerfile. Pure regex, no npm install.","url":"https://sigmap.io/languages.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -618,7 +618,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
   <h2>Contributing is simple</h2>
   <p class="section-sub">One file per language. Follow the extractor contract. All tests must pass. See CONTRIBUTING.md.</p>
   <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:8px">
-    <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md" style="background:var(--p);color:#fff;padding:11px 24px;border-radius:9px;font-size:14px;font-weight:600;text-decoration:none;transition:.15s">Read contributing guide</a>
+    <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md" style="background:var(--p);color:#fff;padding:11px 24px;border-radius:9px;font-size:14px;font-weight:600;text-decoration:none;transition:.15s">Read contributing guide</a>
     <a href="quick-start.html" style="background:transparent;color:var(--t1);border:1px solid var(--line2);padding:11px 20px;border-radius:9px;font-size:14px;font-weight:500;text-decoration:none;transition:.15s">Quick start →</a>
   </div>
 </section>
@@ -637,8 +637,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -7,19 +7,19 @@
 <meta name="description" content="Set up SigMap MCP server with Claude Code, Cursor, and Windsurf. 8 on-demand tools: read_context, search_signatures, get_map, explain_file, list_modules, create_checkpoint, get_routing, query_context.">
 <meta property="og:title" content="SigMap MCP Server Setup — Claude Code, Cursor, Windsurf">
 <meta property="og:description" content="Configure SigMap's 7 MCP tools for Claude Code, Cursor, and Windsurf. Zero-dependency stdio server.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/mcp.html">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:url" content="https://sigmap.io/mcp.html">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap MCP Server Setup — Claude Code, Cursor, Windsurf">
 <meta name="twitter:description" content="Configure SigMap MCP tools for Claude Code, Cursor, and Windsurf. Zero-dependency stdio server.">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:image:alt" content="SigMap MCP Server Setup">
 <meta name="keywords" content="sigmap mcp, mcp server, claude code mcp, cursor mcp, windsurf mcp, model context protocol, read_context, search_signatures, ai coding tools">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/mcp.html">
+<link rel="canonical" href="https://sigmap.io/mcp.html">
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap MCP Server Setup — Claude Code, Cursor, Windsurf","description":"Configure SigMap's 7 MCP tools for Claude Code, Cursor, and Windsurf. Zero-dependency stdio server.","url":"https://manojmallick.github.io/sigmap/mcp.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap MCP Server Setup — Claude Code, Cursor, Windsurf","description":"Configure SigMap's 7 MCP tools for Claude Code, Cursor, and Windsurf. Zero-dependency stdio server.","url":"https://sigmap.io/mcp.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
 :root{
@@ -531,8 +531,8 @@ code{font-family:'IBM Plex Mono',monospace;font-size:12px;background:var(--s3);p
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -7,18 +7,18 @@
 <meta name="description" content="Get SigMap running in under 2 minutes. One file download, zero npm install, instant 97% token reduction for your AI coding agent.">
 <meta property="og:title" content="SigMap Quick Start — under 2 minutes to working">
 <meta property="og:description" content="node gen-context.js. That's the entire install. Reduces AI context from 80K to 4K tokens automatically.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/quick-start.html">
+<meta property="og:url" content="https://sigmap.io/quick-start.html">
 <meta name="twitter:card" content="summary_large_image">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap Quick Start — under 2 minutes to working">
 <meta name="twitter:description" content="node gen-context.js. That's the entire install. Reduces AI context from 80K to 4K tokens automatically.">
 <meta name="twitter:image:alt" content="SigMap Quick Start Guide">
 <meta name="keywords" content="sigmap quick start, install sigmap, ai context setup, copilot instructions setup, zero npm install, sigmap tutorial, npx sigmap">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/quick-start.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Get SigMap running in 60 seconds","description":"Zero npm install — reduce AI coding agent token usage by 97% in under 2 minutes.","url":"https://manojmallick.github.io/sigmap/quick-start.html","step":[{"@type":"HowToStep","name":"Install","text":"Run npx sigmap or npm install -g sigmap"},{"@type":"HowToStep","name":"Generate context","text":"Run sigmap in your project root to create .github/copilot-instructions.md"},{"@type":"HowToStep","name":"Commit","text":"git add .github/copilot-instructions.md and commit — Copilot reads it automatically"}]}</script>
+<link rel="canonical" href="https://sigmap.io/quick-start.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Get SigMap running in 60 seconds","description":"Zero npm install — reduce AI coding agent token usage by 97% in under 2 minutes.","url":"https://sigmap.io/quick-start.html","step":[{"@type":"HowToStep","name":"Install","text":"Run npx sigmap or npm install -g sigmap"},{"@type":"HowToStep","name":"Generate context","text":"Run sigmap in your project root to create .github/copilot-instructions.md"},{"@type":"HowToStep","name":"Commit","text":"git add .github/copilot-instructions.md and commit — Copilot reads it automatically"}]}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -303,7 +303,7 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
               <span class="term-title">your-project/</span>
             </div>
             <div class="term-body">
-              <div><span class="tc">$</span> <span class="tw">curl -O https://raw.githubusercontent.com/manojmallick/sigmap/main/gen-context.js</span></div>
+              <div><span class="tc">$</span> <span class="tw">curl -O https://raw.githubusercontent.com/manojmallick/main/gen-context.js</span></div>
               <div><span class="ts">100  48.2K  100  48.2K  ←  single file, ~50KB</span></div>
             </div>
           </div>
@@ -370,22 +370,22 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       </div>
       <div class="term-body">
         <div><span class="tc"># macOS Apple Silicon (arm64)</span></div>
-        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/sigmap/releases/latest/download/sigmap-macos-arm64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
+        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/releases/latest/download/sigmap-macos-arm64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
         <div>&nbsp;</div>
         <div><span class="tc"># macOS Intel (x64)</span></div>
-        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/sigmap/releases/latest/download/sigmap-macos-x64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
+        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/releases/latest/download/sigmap-macos-x64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
         <div>&nbsp;</div>
         <div><span class="tc"># Linux (x64)</span></div>
-        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/sigmap/releases/latest/download/sigmap-linux-x64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
+        <div><span class="tc">$</span> <span class="tw">curl -L https://github.com/manojmallick/releases/latest/download/sigmap-linux-x64 -o sigmap &amp;&amp; chmod +x sigmap</span></div>
         <div>&nbsp;</div>
         <div><span class="tc"># Windows (x64) — PowerShell</span></div>
-        <div><span class="tc">$</span> <span class="tw">curl.exe -L https://github.com/manojmallick/sigmap/releases/latest/download/sigmap-win-x64.exe -o sigmap.exe</span></div>
+        <div><span class="tc">$</span> <span class="tw">curl.exe -L https://github.com/manojmallick/releases/latest/download/sigmap-win-x64.exe -o sigmap.exe</span></div>
         <div>&nbsp;</div>
         <div><span class="tc">$</span> <span class="tw">./sigmap --version</span></div>
         <div><span class="ts">sigmap v3.5.0</span></div>
       </div>
     </div>
-    <p style="font-size:13px;color:var(--t2);margin-top:12px">Built with Node.js SEA (Single Executable Application). No Node.js runtime needed. Available on the <a href="https://github.com/manojmallick/sigmap/releases" style="color:var(--pd)">GitHub Releases page</a>.</p>
+    <p style="font-size:13px;color:var(--t2);margin-top:12px">Built with Node.js SEA (Single Executable Application). No Node.js runtime needed. Available on the <a href="https://github.com/manojmallick/releases" style="color:var(--pd)">GitHub Releases page</a>.</p>
   </div>
 
   <!-- vscode -->
@@ -739,8 +739,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/readmes/JETBRAINS_SETUP.md
+++ b/docs/readmes/JETBRAINS_SETUP.md
@@ -140,7 +140,7 @@ Opens the SigMap roadmap in your default browser.
 
 **Access:** **Tools** → **SigMap** → **View Roadmap**
 
-**URL:** https://manojmallick.github.io/sigmap/roadmap.html
+**URL:** https://sigmap.io/roadmap.html
 
 ---
 
@@ -160,7 +160,7 @@ Create `gen-context.config.json` in your project root:
 }
 ```
 
-See [Configuration Reference](https://manojmallick.github.io/sigmap/config.html) for all options.
+See [Configuration Reference](https://sigmap.io/config.html) for all options.
 
 ---
 
@@ -366,9 +366,9 @@ git push origin v2.9.0
 
 ## Support
 
-- **Documentation:** https://manojmallick.github.io/sigmap/
+- **Documentation:** https://sigmap.io/
 - **GitHub Issues:** https://github.com/manojmallick/sigmap/issues
-- **Roadmap:** https://manojmallick.github.io/sigmap/roadmap.html
+- **Roadmap:** https://sigmap.io/roadmap.html
 
 ---
 

--- a/docs/readmes/SEO_GUIDE.md
+++ b/docs/readmes/SEO_GUIDE.md
@@ -1,6 +1,6 @@
 # SEO Guide for SigMap Docs
 
-Every HTML file in `docs/` is served at `https://manojmallick.github.io/sigmap/`.
+Every HTML file in `docs/` is served at `https://sigmap.io/`.
 Follow this guide whenever you add or edit a page so it stays indexable and search-friendly.
 
 ---
@@ -14,22 +14,22 @@ Every page must have **all** of these tags, in this order, before `<link rel="ca
 <meta name="description" content="{150–160 char description. Include the main keyword naturally.}">
 <meta property="og:title" content="{Short title for social sharing}">
 <meta property="og:description" content="{1–2 sentence social preview. Concrete, benefit-led.}">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/{filename}.html">
+<meta property="og:url" content="https://sigmap.io/{filename}.html">
 <meta property="og:type" content="article">           <!-- use "website" only on index.html -->
 <meta property="og:site_name" content="SigMap">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{Same as og:title}">
 <meta name="twitter:description" content="{Same as og:description}">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:image:alt" content="{What the banner image shows}">
 <meta name="keywords" content="{8–12 comma-separated terms, most specific first}">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/{filename}.html">
+<link rel="canonical" href="https://sigmap.io/{filename}.html">
 ```
 
 **index.html only** also needs:
 ```html
-<link rel="sitemap" type="application/xml" href="https://manojmallick.github.io/sigmap/sitemap.xml">
+<link rel="sitemap" type="application/xml" href="https://sigmap.io/sitemap.xml">
 ```
 
 ---
@@ -92,7 +92,7 @@ Use one `<script type="application/ld+json">` block per page. Choose the schema 
   "name": "SigMap",
   "applicationCategory": "DeveloperApplication",
   "description": "...",
-  "url": "https://manojmallick.github.io/sigmap/",
+  "url": "https://sigmap.io/",
   "downloadUrl": "https://www.npmjs.com/package/sigmap",
   "softwareVersion": "3.x.x",
   "operatingSystem": "Any (Node.js 18+)",
@@ -108,7 +108,7 @@ Use one `<script type="application/ld+json">` block per page. Choose the schema 
   "@type": "HowTo",
   "name": "Get SigMap running in 60 seconds",
   "description": "...",
-  "url": "https://manojmallick.github.io/sigmap/quick-start.html",
+  "url": "https://sigmap.io/quick-start.html",
   "step": [
     { "@type": "HowToStep", "name": "Step name", "text": "Step detail" }
   ]
@@ -137,9 +137,9 @@ Use one `<script type="application/ld+json">` block per page. Choose the schema 
   "@type": "TechArticle",
   "headline": "...",
   "description": "...",
-  "url": "https://manojmallick.github.io/sigmap/{filename}.html",
+  "url": "https://sigmap.io/{filename}.html",
   "author": { "@type": "Person", "name": "Manoj Mallick", "url": "https://github.com/manojmallick" },
-  "isPartOf": { "@type": "WebSite", "name": "SigMap", "url": "https://manojmallick.github.io/sigmap/" }
+  "isPartOf": { "@type": "WebSite", "name": "SigMap", "url": "https://sigmap.io/" }
 }
 ```
 

--- a/docs/readmes/jetbrains-plugin.md
+++ b/docs/readmes/jetbrains-plugin.md
@@ -78,7 +78,7 @@ Place `gen-context.config.json` in your project root to customize:
 }
 ```
 
-See [Configuration Guide](https://manojmallick.github.io/sigmap/config.html) for all options.
+See [Configuration Guide](https://sigmap.io/config.html) for all options.
 
 ## CLI Quick Reference
 
@@ -120,9 +120,9 @@ Ensure at least one exists.
 
 ## Support
 
-- [Documentation](https://manojmallick.github.io/sigmap/)
+- [Documentation](https://sigmap.io/)
 - [GitHub Issues](https://github.com/manojmallick/sigmap/issues)
-- [Roadmap](https://manojmallick.github.io/sigmap/roadmap.html)
+- [Roadmap](https://sigmap.io/roadmap.html)
 
 ## License
 

--- a/docs/readmes/vscode-extension.md
+++ b/docs/readmes/vscode-extension.md
@@ -330,7 +330,7 @@ dist/
 
 | Resource | Link |
 |---|---|
-| 📖 Documentation | [manojmallick.github.io/sigmap](https://manojmallick.github.io/sigmap/) |
+| 📖 Documentation | [sigmap.io](https://sigmap.io/) |
 | 📦 npm package | [npmjs.com/package/sigmap](https://www.npmjs.com/package/sigmap) |
 | 🟣 Open VSX | [open-vsx.org/extension/manojmallick/sigmap](https://open-vsx.org/extension/manojmallick/sigmap) |
 | 💻 GitHub | [github.com/manojmallick/sigmap](https://github.com/manojmallick/sigmap) |

--- a/docs/repomix.html
+++ b/docs/repomix.html
@@ -7,18 +7,18 @@
 <meta name="description" content="Use SigMap and Repomix together for the two-layer AI context strategy. SigMap for always-on signatures; Repomix for deep one-off sessions. Together they cover every workflow.">
 <meta property="og:title" content="SigMap + Repomix — the two-layer context strategy">
 <meta property="og:description" content="SigMap for daily always-on context. Repomix for deep one-off sessions. Use both. Never choose.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/repomix.html">
+<meta property="og:url" content="https://sigmap.io/repomix.html">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="keywords" content="repomix integration, repomix sigmap, ai context management, copilot token reduction, claude context window, repomix alternative, repomix complement">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap + Repomix — the two-layer context strategy">
 <meta name="twitter:description" content="SigMap for daily always-on context. Repomix for deep one-off sessions. Use both. Never choose.">
 <meta name="twitter:image:alt" content="SigMap and Repomix Integration Guide">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/repomix.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap + Repomix — the two-layer AI context strategy","description":"Use SigMap for always-on daily signatures and Repomix for deep one-off sessions. Together they cover every AI coding workflow at minimal token cost.","url":"https://manojmallick.github.io/sigmap/repomix.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/repomix.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap + Repomix — the two-layer AI context strategy","description":"Use SigMap for always-on daily signatures and Repomix for deep one-off sessions. Together they cover every AI coding workflow at minimal token cost.","url":"https://sigmap.io/repomix.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -535,8 +535,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -7,18 +7,18 @@
 <meta name="description" content="SigMap shipped v0.1 through v3.0 — 97% token reduction, 360+ tests. Multi-adapter platform (Copilot, Claude, Cursor, Windsurf, OpenAI, Gemini) is the current milestone. Full visual timeline from baseline to complete system.">
 <meta property="og:title" content="SigMap Roadmap — v0.1 to v2.10 · 97% token reduction">
 <meta property="og:description" content="25 versions shipped/planned. 97% token reduction. 340 tests. MIT license. See how SigMap evolved from first extractor to full context platform.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/roadmap.html">
+<meta property="og:url" content="https://sigmap.io/roadmap.html">
 <meta name="twitter:card" content="summary_large_image">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap Roadmap — from v0.1 to v3.x">
 <meta name="twitter:description" content="25+ versions shipped. 97% token reduction. 360+ tests. MIT license. See how SigMap evolved.">
 <meta name="twitter:image:alt" content="SigMap Development Roadmap">
 <meta name="keywords" content="sigmap roadmap, sigmap versions, sigmap changelog, sigmap features, sigmap development, ai context engine roadmap">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/roadmap.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap roadmap — v0.1 to v2.10","description":"25 versions shipped/planned. 97% token reduction. 340+ tests. MIT license. Reporting charts and advanced metrics are the current milestone.","url":"https://manojmallick.github.io/sigmap/roadmap.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/roadmap.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap roadmap — v0.1 to v2.10","description":"25 versions shipped/planned. 97% token reduction. 340+ tests. MIT license. Reporting charts and advanced metrics are the current milestone.","url":"https://sigmap.io/roadmap.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -1101,8 +1101,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -3,4 +3,4 @@ Allow: /
 Allow: /llms.txt
 Allow: /llms-full.txt
 
-Sitemap: https://manojmallick.github.io/sigmap/sitemap.xml
+Sitemap: https://sigmap.io/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://manojmallick.github.io/sigmap/</loc>
+    <loc>https://sigmap.io/</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/quick-start.html</loc>
+    <loc>https://sigmap.io/quick-start.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/cli.html</loc>
+    <loc>https://sigmap.io/cli.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/config.html</loc>
+    <loc>https://sigmap.io/config.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/mcp.html</loc>
+    <loc>https://sigmap.io/mcp.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/troubleshooting.html</loc>
+    <loc>https://sigmap.io/troubleshooting.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/strategies.html</loc>
+    <loc>https://sigmap.io/strategies.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/languages.html</loc>
+    <loc>https://sigmap.io/languages.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/repomix.html</loc>
+    <loc>https://sigmap.io/repomix.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://manojmallick.github.io/sigmap/roadmap.html</loc>
+    <loc>https://sigmap.io/roadmap.html</loc>
     <lastmod>2026-04-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/docs/strategies.html
+++ b/docs/strategies.html
@@ -7,18 +7,18 @@
 <meta name="description" content="Choose the right SigMap strategy: full, per-module, or hot-cold. Detailed examples, decision tree, token trade-offs, and MCP vs non-MCP workflows.">
 <meta property="og:title" content="SigMap strategies: full vs per-module vs hot-cold">
 <meta property="og:description" content="Detailed case-by-case guide to reduce tokens without losing context. Learn when to use each strategy and how to configure it.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/strategies.html">
+<meta property="og:url" content="https://sigmap.io/strategies.html">
 <meta name="twitter:card" content="summary_large_image">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap strategies: full vs per-module vs hot-cold">
 <meta name="twitter:description" content="Detailed guide to reduce tokens without losing context. Learn when to use each strategy.">
 <meta name="twitter:image:alt" content="SigMap Context Strategies Guide">
 <meta name="keywords" content="sigmap strategies, full strategy, per-module strategy, hot-cold strategy, ai context strategy, token reduction strategy, copilot context strategy">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/strategies.html">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap context strategies: full vs per-module vs hot-cold","description":"Choose the right SigMap strategy. Full: single file all sigs. Per-module: one file per directory. Hot-cold: recent files injected, stable files via MCP.","url":"https://manojmallick.github.io/sigmap/strategies.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://manojmallick.github.io/sigmap/"}}</script>
+<link rel="canonical" href="https://sigmap.io/strategies.html">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"SigMap context strategies: full vs per-module vs hot-cold","description":"Choose the right SigMap strategy. Full: single file all sigs. Per-module: one file per directory. Hot-cold: recent files injected, stable files via MCP.","url":"https://sigmap.io/strategies.html","author":{"@type":"Person","name":"Manoj Mallick","url":"https://github.com/manojmallick"},"isPartOf":{"@type":"WebSite","name":"SigMap","url":"https://sigmap.io/"}}</script>
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
 <style>
@@ -292,9 +292,9 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
   <p class="section-sub">For complete migration steps, compatibility matrix, and advanced examples, use the full Markdown guide.</p>
   <div class="list">
     <ol>
-      <li>Detailed guide in repository: <a href="https://github.com/manojmallick/sigmap/blob/main/docs/CONTEXT_STRATEGIES.md" style="color:var(--pd)">docs/CONTEXT_STRATEGIES.md</a></li>
+      <li>Detailed guide in repository: <a href="https://github.com/manojmallick/blob/main/docs/CONTEXT_STRATEGIES.md" style="color:var(--pd)">docs/CONTEXT_STRATEGIES.md</a></li>
       <li>CLI reference and setup: <a href="quick-start.html" style="color:var(--pd)">Quick Start</a></li>
-      <li>MCP setup: <a href="https://github.com/manojmallick/sigmap/blob/main/docs/MCP_SETUP.md" style="color:var(--pd)">docs/MCP_SETUP.md</a></li>
+      <li>MCP setup: <a href="https://github.com/manojmallick/blob/main/docs/MCP_SETUP.md" style="color:var(--pd)">docs/MCP_SETUP.md</a></li>
     </ol>
   </div>
 </section>
@@ -313,8 +313,8 @@ footer{background:var(--s1);border-top:1px solid var(--line);padding:32px 24px}
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -7,17 +7,17 @@
 <meta name="description" content="Fix common SigMap issues. Context file not found, Copilot not reading context, low token reduction, VS Code extension errors, MCP server not appearing, secret scan false positives.">
 <meta property="og:title" content="SigMap Troubleshooting — common issues and fixes">
 <meta property="og:description" content="Fix context file not found, Copilot not reading context, low token reduction, VS Code issues, and MCP errors.">
-<meta property="og:url" content="https://manojmallick.github.io/sigmap/troubleshooting.html">
-<meta property="og:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta property="og:url" content="https://sigmap.io/troubleshooting.html">
+<meta property="og:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="SigMap">
 <meta name="twitter:title" content="SigMap Troubleshooting — common issues and fixes">
 <meta name="twitter:description" content="Fix context file not found, Copilot not reading context, low token reduction, VS Code issues, and MCP errors.">
-<meta name="twitter:image" content="https://manojmallick.github.io/sigmap/sigmap-banner.png">
+<meta name="twitter:image" content="https://sigmap.io/sigmap-banner.png">
 <meta name="twitter:image:alt" content="SigMap Troubleshooting Guide">
 <meta name="keywords" content="sigmap troubleshooting, sigmap errors, copilot context not found, mcp server not working, sigmap debug, token reduction fix, vs code sigmap">
-<link rel="canonical" href="https://manojmallick.github.io/sigmap/troubleshooting.html">
+<link rel="canonical" href="https://sigmap.io/troubleshooting.html">
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"SigMap context file not found","acceptedAnswer":{"@type":"Answer","text":"Run sigmap or node gen-context.js to generate .github/copilot-instructions.md. The file must be generated before the VS Code extension or MCP server can read it."}},{"@type":"Question","name":"GitHub Copilot not using SigMap context","acceptedAnswer":{"@type":"Answer","text":"The file must be at .github/copilot-instructions.md in your workspace root. Check with: ls .github/copilot-instructions.md"}},{"@type":"Question","name":"Token reduction is only 60%","acceptedAnswer":{"@type":"Answer","text":"You are likely indexing test files or generated code. Run sigmap --init to create a .contextignore and exclude test files, dist/, build/, and generated code."}},{"@type":"Question","name":"SigMap MCP server not appearing in tool list","acceptedAnswer":{"@type":"Answer","text":"Check that the absolute path in your settings file points to the correct gen-context.js. Use: node /path/to/gen-context.js --version to verify it resolves."}},{"@type":"Question","name":"Secret scan is redacting a false positive","acceptedAnswer":{"@type":"Answer","text":"Add a .contextignore rule to exclude that file, or check which pattern triggered. The 10 patterns are: AWS keys, GitHub tokens, JWTs, DB URLs, SSH keys, GCP keys, Stripe keys, Twilio keys, generic passwords/api_keys."}}]}</script>
 <script>(function(){var r=document.documentElement;if(localStorage.getItem('cf-theme')==='light')r.classList.add('light');document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.theme-toggle').forEach(function(b){b.addEventListener('click',function(){r.classList.toggle('light');localStorage.setItem('cf-theme',r.classList.contains('light')?'light':'dark');});});});})();</script>
@@ -592,7 +592,7 @@ code{font-family:'IBM Plex Mono',monospace;font-size:12px;background:var(--s3);p
     <div class="prereq-icon">🐛</div>
     <div>
       <div class="prereq-title">Open a GitHub issue</div>
-      <div class="prereq-text">Share the output of <code>sigmap --health --json</code> at <a href="https://github.com/manojmallick/sigmap/issues" style="color:var(--pd)">github.com/manojmallick/sigmap/issues</a>. Include your OS, Node.js version, and a brief description of the symptom.</div>
+      <div class="prereq-text">Share the output of <code>sigmap --health --json</code> at <a href="https://github.com/manojmallick/issues" style="color:var(--pd)">github.com/manojmallick/issues</a>. Include your OS, Node.js version, and a brief description of the symptom.</div>
     </div>
   </div>
 </section>
@@ -635,8 +635,8 @@ code{font-family:'IBM Plex Mono',monospace;font-size:12px;background:var(--s3);p
       <a href="roadmap.html">Roadmap</a>
       <a href="repomix.html">Repomix</a>
       <a href="https://github.com/manojmallick/sigmap">GitHub</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/manojmallick/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/manojmallick/blob/main/CHANGELOG.md">Changelog</a>
     </div>
     <span class="footer-mit">MIT © 2026 Manoj Mallick · Made in Amsterdam 🇳🇱</span>
   </div>

--- a/gen-context.js
+++ b/gen-context.js
@@ -13373,7 +13373,7 @@ function main() {
     const shareText = [
       'Generated with SigMap — zero-dependency AI context engine',
       `${reduction}% fewer tokens · ${hitAt5}% retrieval accuracy · 6× better results`,
-      'https://sigmap.dev',
+      'https://sigmap.io',
     ].join('\n');
 
     console.log(shareText);

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -273,7 +273,7 @@ the relevant regulation before publication; SigMap makes no legal claims.
 - Author: Manoj Mallick
 - License: MIT
 - Repository: https://github.com/manojmallick/sigmap
-- Documentation: https://manojmallick.github.io/sigmap/
+- Documentation: https://sigmap.io/
 - npm: https://www.npmjs.com/package/sigmap
 - Benchmark dataset: https://doi.org/10.5281/zenodo.19898842
 - Issues: https://github.com/manojmallick/sigmap/issues

--- a/llms.txt
+++ b/llms.txt
@@ -39,18 +39,18 @@ npx sigmap --mcp                    # start the MCP server over stdio
 ```
 
 ## Docs
-- [Full documentation](https://manojmallick.github.io/sigmap/)
-- [CLI reference](https://manojmallick.github.io/sigmap/guide/cli)
-- [MCP tools](https://manojmallick.github.io/sigmap/guide/mcp)
-- [Benchmark methodology](https://manojmallick.github.io/sigmap/guide/benchmark)
-- [Configuration guide](https://manojmallick.github.io/sigmap/guide/config)
+- [Full documentation](https://sigmap.io/)
+- [CLI reference](https://sigmap.io/guide/cli)
+- [MCP tools](https://sigmap.io/guide/mcp)
+- [Benchmark methodology](https://sigmap.io/guide/benchmark)
+- [Configuration guide](https://sigmap.io/guide/config)
 - [Changelog](https://github.com/manojmallick/sigmap/blob/main/CHANGELOG.md)
 
 ## Optional
 - [GitHub repository](https://github.com/manojmallick/sigmap)
 - [npm package](https://www.npmjs.com/package/sigmap)
 - [Benchmark dataset (Zenodo)](https://doi.org/10.5281/zenodo.19898842)
-- [Full LLM reference](https://manojmallick.github.io/sigmap/llms-full.txt)
+- [Full LLM reference](https://sigmap.io/llms-full.txt)
 
 SigMap — grounded AI coding context. The lightweight, deterministic alternative
 to embeddings for feeding the right code to AI assistants.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "type": "git",
     "url": "https://github.com/manojmallick/sigmap.git"
   },
-  "homepage": "https://manojmallick.github.io/sigmap/",
+  "homepage": "https://sigmap.io/",
   "bugs": {
     "url": "https://github.com/manojmallick/sigmap/issues"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/manojmallick/sigmap.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://manojmallick.github.io/sigmap/",
+  "homepage": "https://sigmap.io/",
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # sigmap-core
 
-Programmatic API for [SigMap](https://manojmallick.github.io/sigmap/) — zero-dependency code signature extraction, ranked retrieval, secret scanning, project health scoring, and multi-adapter output formatting (v3.0+).
+Programmatic API for [SigMap](https://sigmap.io/) — zero-dependency code signature extraction, ranked retrieval, secret scanning, project health scoring, and multi-adapter output formatting (v3.0+).
 
 ## Installation
 
@@ -145,7 +145,7 @@ const geminiInstruction = adapt(context, 'gemini');
 // All 6 adapters: copilot | claude | cursor | windsurf | openai | gemini
 ```
 
-See the full [roadmap](https://manojmallick.github.io/sigmap/roadmap.html).
+See the full [roadmap](https://sigmap.io/roadmap.html).
 
 ## Zero dependencies
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/manojmallick/sigmap.git",
     "directory": "packages/core"
   },
-  "homepage": "https://manojmallick.github.io/sigmap/",
+  "homepage": "https://sigmap.io/",
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/gen-logo.cjs
+++ b/scripts/gen-logo.cjs
@@ -123,7 +123,7 @@ const bannerSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="
   <line x1="610" y1="470" x2="1140" y2="470" stroke="#818cf8" stroke-width="1.5" opacity="0.25"/>
   <text x="613" y="510"
         font-family="'SF Mono','JetBrains Mono',monospace"
-        font-size="22" fill="#6366f1" opacity="0.6">sigmap.dev</text>
+        font-size="22" fill="#6366f1" opacity="0.6">sigmap.io</text>
 </svg>`;
 
 // ─── Output targets ───────────────────────────────────────────────────────────

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -55,7 +55,7 @@ function gather() {
 
   const repo = String((pkg.repository && pkg.repository.url) || 'https://github.com/manojmallick/sigmap')
     .replace(/^git\+/, '').replace(/\.git$/, '');
-  const home = pkg.homepage || 'https://manojmallick.github.io/sigmap/';
+  const home = pkg.homepage || 'https://sigmap.io/';
   return { pkg, version, TOOLS, DEFAULTS, languages, adapters, helpLines, repo, home };
 }
 

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -225,7 +225,7 @@ test('start-guide: Teams routing present (🏢)', () => {
 // ── Section 12: Docs link ─────────────────────────────────────────────────────
 
 test('docs: main docs link present', () => {
-  assert.ok(src.includes('manojmallick.github.io/sigmap'), 'missing docs link');
+  assert.ok(src.includes('sigmap.io'), 'missing docs link');
 });
 
 // ── Section 13: Support CTA ───────────────────────────────────────────────────


### PR DESCRIPTION
Promotes the **sigmap.io domain switch**, the **docs-site fix**, and the **sponsor docs** from `develop` to `main`. Merging redeploys GitHub Pages with `base: '/'` so the site serves correctly at the custom domain.

## What's included

### Docs site → sigmap.io (#258)
- **Root cause fix:** VitePress `base: '/sigmap/'` → `'/'`. On the custom domain (served at root) the `/sigmap/` prefix broke every link and 404'd all CSS/JS (unstyled page). Now assets are root-relative and styles load.
- og:url / canonical / sitemap / robots / favicon / og:image → sigmap.io
- `docs-vp/public/CNAME` → sigmap.io; `package.json` + sub-package `homepage` → sigmap.io; `llms.txt`/`llms-full.txt` regenerated
- `sigmap share` URL, cli.md example, logo banner text, prerelease bot email → sigmap.io

### Sponsor docs (#257)
- README `## Sponsor` section (blurb + button + link) and a dedicated **`SPONSOR.md`** with tiers, a transparent "where your sponsorship goes" breakdown (benchmark CI, `sigmap.io` domain, maintenance, supply-chain hardening, new languages), a low-barrier "any amount / a star helps" welcome, and a maintainer blurb.

## Verified
- ✅ VitePress build succeeds with `base: '/'`; built assets root-relative; CNAME in deploy dir; `guide/quick-start.html` at root
- ✅ `node test/integration/all.js` — 71 passed, 0 failed
- ✅ No site-base `/sigmap/` left (remaining `/sigmap/` are legit `github.com/manojmallick/sigmap/…` repo URLs)

## Post-merge (outside the repo)
1. **DNS:** point `sigmap.io` at GitHub Pages (apex A records to GitHub IPs, or CNAME `manojmallick.github.io`).
2. **Repo → Settings → Pages → Custom domain:** set `sigmap.io` + Enforce HTTPS.
3. **Regenerate banner:** `npm i -g sharp && node scripts/gen-logo.cjs` (`docs/sigmap-banner.png` still shows old text).

## Merged PRs
#257 (sponsor) · #258 (domain + site fix)

> Note: this is a docs/site/metadata release — no version bump. If you want it published to npm as v7.0.2, run `/update-docs` → `/ship` instead of merging directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)