### PR TITLE
chore(release): v7.1.0 — gain dashboard, docs, version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.1.0] — 2026-06-16
+
+Minor release — a token-savings dashboard in the terminal, plus domain and sponsorship docs.
+
+### Added
+- **Token-savings dashboard — `sigmap gain` (#260):** surfaces cumulative savings right in the terminal — total tokens saved, % efficiency, estimated $ saved, latency, and a by-operation breakdown, plus `gain --all` for daily / weekly / monthly trends. Savings are captured per operation (`ask`, `generate`) into a dedicated local log `.context/gain.ndjson` (counts only — no paths, source, or query text). Capture is **default-on** and privacy-safe; opt out via `--no-track`, `SIGMAP_NO_TRACK=1`, or `config.gainTracking:false`. The legacy `usage.ndjson` / `--track` health log is unchanged. New `src/tracking/{aggregate,pricing}.js` (zero-dep aggregation + model→$/Mtok pricing) and `src/format/gain-terminal.js` (ANSI renderer, `NO_COLOR`/non-TTY safe). Flags: `gain --all | --json | --since <7d|ISO> | --top <n> | --model <name> | --reset`. "Saved" is labeled everywhere as an estimate vs the whole-file baseline.
+
+### Fixed
+- **Docs served at the sigmap.io root (#258):** the docs site now builds with base `/` (dropped the `/sigmap/` path prefix) and the project domain points to sigmap.io.
+
+### Changed
+- **Sponsorship transparency (#257):** README gained a Sponsor section with a tier ladder and funding goal; detail moved into `SPONSOR.md`, with an "About the maintainer" note and a low-barrier welcome.
+
+---
+
 ## [7.0.1] — 2026-06-14
 
 Patch release — supply-chain hardening and package hygiene, plus a wider star nudge.

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -7,7 +7,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 46 SigMap commands and flags documented with examples. ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 46 SigMap commands and flags documented with examples. ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -100,6 +100,13 @@ If you are new to the product, start with the workflow pages first:
 | `--routing` | Print the model routing table |
 | `--format cache` | Wrap output in Anthropic cache_control breakpoints |
 | `--track` | Log each run to `.context/usage.ndjson` |
+| `gain` | Token-savings dashboard — tokens saved, %, est. $, latency, by-operation |
+| `gain --all` | Add daily / weekly / monthly trend tables |
+| `gain --json` | Aggregate savings as JSON |
+| `gain --since <7d\|ISO>` | Window filter (`7d`, `30d`, `12h`, or ISO date) |
+| `gain --top <n> \| --model <name>` | Limit rows / set the $ pricing model |
+| `gain --reset` | Clear the local savings log (`.context/gain.ndjson`) |
+| `--no-track` | Disable gain savings capture for a run |
 | `--init` | Scaffold `gen-context.config.json` and `.contextignore` |
 | `--benchmark` | Run retrieval evaluation tasks |
 | `--impact <file>` | Trace every file that transitively imports the given file |
@@ -1104,6 +1111,55 @@ Log each run to `.context/usage.ndjson` for monitoring and audit. View history w
 
 ```bash
 sigmap --track
+```
+
+---
+
+## gain
+
+Token-savings dashboard. Shows how much SigMap has saved you — total tokens saved, % efficiency, estimated dollars, average latency, and a per-operation breakdown — built from a local, privacy-safe usage log.
+
+Savings are captured automatically: every `ask` and `generate` run appends a counts-only record to `.context/gain.ndjson` (no file paths, source, or query text). Capture is **default-on**; opt out per run with `--no-track`, globally with `SIGMAP_NO_TRACK=1`, or in config with `gainTracking: false`. This is separate from the legacy `--track` health log.
+
+```bash
+sigmap gain
+```
+
+```
+  ⚡ SigMap — Token Savings (this repo)                          ✓ v7.1.0
+  ──────────────────────────────────────────────────────────────────────
+  Total operations    : 2,402
+  Whole-file baseline : 48.7M tok   ← est. cost of feeding full files
+  SigMap context      :  2.9M tok
+  Tokens saved        : 45.8M  (94.0%)
+  Est. money saved    : $137.40   (claude-sonnet input @ $3/M · --model to change)
+  Avg latency         : 22 ms / op   (local, no API round-trip)
+
+  Efficiency   ▕███████████████████████████░░▏  94.0%
+
+  By operation
+   #  Operation             Count    Saved    Avg%    Time   Impact
+   1. ask                   1,164   22.8M    94.2%    41ms   ████████████
+   2. mcp:search_signatures   980    9.1M    88.0%     3ms   █████
+```
+
+"Saved" is a counterfactual estimate (whole-file baseline − actual context), not a measured delta — every view labels it as such and shows the pricing assumption inline.
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Add daily / weekly / monthly trend tables (with TOTAL rows) |
+| `--json` | Emit the aggregate as JSON (for badges, CI, dashboards) |
+| `--since <window>` | Filter to a window: `7d`, `30d`, `12h`, or an ISO date |
+| `--top <n>` | Limit the by-operation table to N rows (default 10) |
+| `--model <name>` | Pricing model for the `$` estimate (e.g. `gpt-4o`, `claude-opus`) |
+| `--reset` | Delete the local savings log (`.context/gain.ndjson`) |
+
+```bash
+sigmap gain --all                 # daily / weekly / monthly trends
+sigmap gain --since 7d --model gpt-4o
+sigmap gain --json | jq '.totals'
 ```
 
 ---

--- a/docs-vp/guide/config.md
+++ b/docs-vp/guide/config.md
@@ -181,6 +181,7 @@ To pin a fixed budget (v4.0 behaviour):
 | `secretScan` | `boolean` | `true` | Scan output for 10 credential patterns before writing. Matching content is replaced with `[REDACTED]`. Patterns: AWS keys, GitHub tokens, JWTs, database URLs, SSH keys, GCP keys, Stripe keys, Twilio keys, generic passwords/api_keys. |
 | `monorepo` | `boolean` | `false` | See Source scanning above. |
 | `sigCache` | `boolean` | `false` | Enable incremental signature cache. When true, caches extracted signatures with mtime-based validation. Cache is automatically busted on version changes. Skips re-extraction of unchanged files for faster subsequent runs. |
+| `gainTracking` | `boolean` | `true` | Capture per-operation token savings to `.context/gain.ndjson` for the [`sigmap gain`](/guide/cli#gain) dashboard. Counts only — no file paths, source, or query text — and never leaves the machine. Set `false` to disable (equivalent to passing `--no-track` or `SIGMAP_NO_TRACK=1`). Independent of the legacy `tracking` / `--track` health log. |
 
 ## Watch
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.0.1, with recent releases adding supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, full-signatures-under-budget, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.1.0, with recent releases adding the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, full-signatures-under-budget, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,9 +20,9 @@ head:
 ---
 # Roadmap
 
-Sixty-one versions shipped. MIT open source from day one.
+Sixty-two versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 988 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.1.0 — Token-savings dashboard (sigmap gain) ✓ (2026-06-16)
+
+**Minor release.** New **`sigmap gain`** (#260) surfaces cumulative token savings right in the terminal — total tokens saved, % efficiency, estimated dollars, average latency, and a per-operation breakdown — with `gain --all` for daily / weekly / monthly trends. Savings are captured automatically: every `ask` and `generate` run appends a counts-only record to a dedicated local log `.context/gain.ndjson` (no file paths, source, or query text). Capture is **default-on** and privacy-safe; opt out with `--no-track`, `SIGMAP_NO_TRACK=1`, or `config.gainTracking:false`, and the legacy `usage.ndjson` / `--track` health log is untouched. New zero-dep `src/tracking/{aggregate,pricing}.js` and `src/format/gain-terminal.js` (ANSI renderer, `NO_COLOR`/non-TTY safe). "Saved" is labeled everywhere as an estimate vs the whole-file baseline. Also in this release: docs served at the sigmap.io root (#258) and a transparent Sponsor section (#257).
+
+**Tags:** `sigmap gain` · `gain --all` · `gain --json` · `--no-track` · `gainTracking` · `.context/gain.ndjson` · `token-savings` · `privacy-safe` · `#257` · `#258` · `PR #261` · `#260`
+
+**Impact:** users can finally quantify what SigMap saves them (tokens, %, $); zero new dependencies; default-on local-only capture; 18 new tests for the gain data layer + real CLI capture.
+
+---
+
 ### v7.0.1 — Supply-chain hardening; importable core; wider star nudge ✓ (2026-06-14)
 
 **Patch release — security & package hygiene.** Every `child_process.execSync` call (which runs through `/bin/sh -c`) was converted to shell-free `execFileSync` with an arguments array — several had previously interpolated values into the command string (`git diff ${range}`, `HEAD~${n}`, `printf '%s' … | ${clipCmd}`, `node -e "…http.get…"`), a real shell-injection surface. A new `src/util/git.js` (`git()`/`tryGit()`) centralizes shell-free git; the `extends` config fetch passes the URL as an argv, `compare` spawns node by argv, and clipboard copy writes via stdin. Net: **zero `execSync`/`exec`/`shell:true` in the published surface**, clearing Socket's "Shell access" capability alert (#252). Also: `package.json` `main` now points at the importable core API (`require('sigmap')` no longer runs the CLI; Bundlephobia sees the real zero-dep library), the star nudge counts plain `sigmap` runs (not just `ask`/`squeeze`) so context-only users reach it (#251), and the unused `machineId = sha256(os.hostname())` fingerprint was removed from `usage.json` (#252).
@@ -850,9 +860,9 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.1+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.2+ (PR verification + Interactive Context Explorer)
 
-v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), and **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks. Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.0.1</span>
+  <span><strong>Release:</strong> v7.1.0</span>
   <span>·</span>
-  <span>Supply-chain hardening — zero system-shell access (shell-free subprocess calls), importable core API, no device fingerprint</span>
+  <span>New <code>sigmap gain</code> — terminal token-savings dashboard (tokens saved, %, est. $, daily/weekly/monthly trends), privacy-safe and local-only</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6254,7 +6254,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.0.1',
+  version: '7.1.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 
@@ -10961,7 +10961,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.0.1';
+const VERSION = '7.1.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.0.1',
+  version: '7.1.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.1",
+  "version": "7.1.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
Release prep for **v7.1.0** (run via `/update-docs`). This is the docs/version/changelog commit; `/ship` will tag + publish after merge.

## Version
- **7.0.1 → 7.1.0** (minor — the `sigmap gain` feature). Synced via `scripts/sync-versions.mjs` across `package.json` ×3, `gen-context.js`, `src/mcp/server.js`; `version.json` version bumped.

## Changelog
- **v7.1.0** entry — `sigmap gain` token-savings dashboard (#260), docs served at sigmap.io root (#258), transparent Sponsor section (#257).

## Docs (docs-vp)
- **cli.md** — full `gain` section + flags in the quick-reference; command count 46 → 53.
- **config.md** — new `gainTracking` key (default-on, opt-out).
- **roadmap.md** — v7.1.0 entry; current milestone → v7.2+; stats refreshed.
- **index.md** — release banner now highlights `sigmap gain`.
- Regenerated `llms.txt` / `llms-full.txt` for 7.1.0.

## Benchmarks
Re-run and **reproduced** — `gain` is purely additive (a dashboard reading a local log), so retrieval/token/task numbers are unchanged: **75.6% hit@5** (13.6% baseline), **97% token reduction**, **39% prompt reduction**, 72/72 integration + 23/23 unit. `version.json` metrics and `benchmark_date` left as-is (no drift; the benchmark date is pinned by `readme-structure.test.js`).

## Next
Merge into `develop`, then run `/ship` to tag `v7.1.0` and cut the GitHub release.
