### PR TITLE
Release v7.1.0 — sigmap gain token-savings dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.1.0] — 2026-06-16
+
+Minor release — a token-savings dashboard in the terminal, plus domain and sponsorship docs.
+
+### Added
+- **Token-savings dashboard — `sigmap gain` (#260):** surfaces cumulative savings right in the terminal — total tokens saved, % efficiency, estimated $ saved, latency, and a by-operation breakdown, plus `gain --all` for daily / weekly / monthly trends. Savings are captured per operation (`ask`, `generate`) into a dedicated local log `.context/gain.ndjson` (counts only — no paths, source, or query text). Capture is **default-on** and privacy-safe; opt out via `--no-track`, `SIGMAP_NO_TRACK=1`, or `config.gainTracking:false`. The legacy `usage.ndjson` / `--track` health log is unchanged. New `src/tracking/{aggregate,pricing}.js` (zero-dep aggregation + model→$/Mtok pricing) and `src/format/gain-terminal.js` (ANSI renderer, `NO_COLOR`/non-TTY safe). Flags: `gain --all | --json | --since <7d|ISO> | --top <n> | --model <name> | --reset`. "Saved" is labeled everywhere as an estimate vs the whole-file baseline.
+
+### Fixed
+- **Docs served at the sigmap.io root (#258):** the docs site now builds with base `/` (dropped the `/sigmap/` path prefix) and the project domain points to sigmap.io.
+
+### Changed
+- **Sponsorship transparency (#257):** README gained a Sponsor section with a tier ladder and funding goal; detail moved into `SPONSOR.md`, with an "About the maintainer" note and a low-barrier welcome.
+
+---
+
 ## [7.0.1] — 2026-06-14
 
 Patch release — supply-chain hardening and package hygiene, plus a wider star nudge.

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -7,7 +7,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 46 SigMap commands and flags documented with examples. ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 46 SigMap commands and flags documented with examples. ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -100,6 +100,13 @@ If you are new to the product, start with the workflow pages first:
 | `--routing` | Print the model routing table |
 | `--format cache` | Wrap output in Anthropic cache_control breakpoints |
 | `--track` | Log each run to `.context/usage.ndjson` |
+| `gain` | Token-savings dashboard — tokens saved, %, est. $, latency, by-operation |
+| `gain --all` | Add daily / weekly / monthly trend tables |
+| `gain --json` | Aggregate savings as JSON |
+| `gain --since <7d\|ISO>` | Window filter (`7d`, `30d`, `12h`, or ISO date) |
+| `gain --top <n> \| --model <name>` | Limit rows / set the $ pricing model |
+| `gain --reset` | Clear the local savings log (`.context/gain.ndjson`) |
+| `--no-track` | Disable gain savings capture for a run |
 | `--init` | Scaffold `gen-context.config.json` and `.contextignore` |
 | `--benchmark` | Run retrieval evaluation tasks |
 | `--impact <file>` | Trace every file that transitively imports the given file |
@@ -1104,6 +1111,55 @@ Log each run to `.context/usage.ndjson` for monitoring and audit. View history w
 
 ```bash
 sigmap --track
+```
+
+---
+
+## gain
+
+Token-savings dashboard. Shows how much SigMap has saved you — total tokens saved, % efficiency, estimated dollars, average latency, and a per-operation breakdown — built from a local, privacy-safe usage log.
+
+Savings are captured automatically: every `ask` and `generate` run appends a counts-only record to `.context/gain.ndjson` (no file paths, source, or query text). Capture is **default-on**; opt out per run with `--no-track`, globally with `SIGMAP_NO_TRACK=1`, or in config with `gainTracking: false`. This is separate from the legacy `--track` health log.
+
+```bash
+sigmap gain
+```
+
+```
+  ⚡ SigMap — Token Savings (this repo)                          ✓ v7.1.0
+  ──────────────────────────────────────────────────────────────────────
+  Total operations    : 2,402
+  Whole-file baseline : 48.7M tok   ← est. cost of feeding full files
+  SigMap context      :  2.9M tok
+  Tokens saved        : 45.8M  (94.0%)
+  Est. money saved    : $137.40   (claude-sonnet input @ $3/M · --model to change)
+  Avg latency         : 22 ms / op   (local, no API round-trip)
+
+  Efficiency   ▕███████████████████████████░░▏  94.0%
+
+  By operation
+   #  Operation             Count    Saved    Avg%    Time   Impact
+   1. ask                   1,164   22.8M    94.2%    41ms   ████████████
+   2. mcp:search_signatures   980    9.1M    88.0%     3ms   █████
+```
+
+"Saved" is a counterfactual estimate (whole-file baseline − actual context), not a measured delta — every view labels it as such and shows the pricing assumption inline.
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Add daily / weekly / monthly trend tables (with TOTAL rows) |
+| `--json` | Emit the aggregate as JSON (for badges, CI, dashboards) |
+| `--since <window>` | Filter to a window: `7d`, `30d`, `12h`, or an ISO date |
+| `--top <n>` | Limit the by-operation table to N rows (default 10) |
+| `--model <name>` | Pricing model for the `$` estimate (e.g. `gpt-4o`, `claude-opus`) |
+| `--reset` | Delete the local savings log (`.context/gain.ndjson`) |
+
+```bash
+sigmap gain --all                 # daily / weekly / monthly trends
+sigmap gain --since 7d --model gpt-4o
+sigmap gain --json | jq '.totals'
 ```
 
 ---

--- a/docs-vp/guide/config.md
+++ b/docs-vp/guide/config.md
@@ -181,6 +181,7 @@ To pin a fixed budget (v4.0 behaviour):
 | `secretScan` | `boolean` | `true` | Scan output for 10 credential patterns before writing. Matching content is replaced with `[REDACTED]`. Patterns: AWS keys, GitHub tokens, JWTs, database URLs, SSH keys, GCP keys, Stripe keys, Twilio keys, generic passwords/api_keys. |
 | `monorepo` | `boolean` | `false` | See Source scanning above. |
 | `sigCache` | `boolean` | `false` | Enable incremental signature cache. When true, caches extracted signatures with mtime-based validation. Cache is automatically busted on version changes. Skips re-extraction of unchanged files for faster subsequent runs. |
+| `gainTracking` | `boolean` | `true` | Capture per-operation token savings to `.context/gain.ndjson` for the [`sigmap gain`](/guide/cli#gain) dashboard. Counts only — no file paths, source, or query text — and never leaves the machine. Set `false` to disable (equivalent to passing `--no-track` or `SIGMAP_NO_TRACK=1`). Independent of the legacy `tracking` / `--track` health log. |
 
 ## Watch
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.0.1, with recent releases adding supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, full-signatures-under-budget, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.1.0, with recent releases adding the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, full-signatures-under-budget, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,9 +20,9 @@ head:
 ---
 # Roadmap
 
-Sixty-one versions shipped. MIT open source from day one.
+Sixty-two versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 988 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.1.0 — Token-savings dashboard (sigmap gain) ✓ (2026-06-16)
+
+**Minor release.** New **`sigmap gain`** (#260) surfaces cumulative token savings right in the terminal — total tokens saved, % efficiency, estimated dollars, average latency, and a per-operation breakdown — with `gain --all` for daily / weekly / monthly trends. Savings are captured automatically: every `ask` and `generate` run appends a counts-only record to a dedicated local log `.context/gain.ndjson` (no file paths, source, or query text). Capture is **default-on** and privacy-safe; opt out with `--no-track`, `SIGMAP_NO_TRACK=1`, or `config.gainTracking:false`, and the legacy `usage.ndjson` / `--track` health log is untouched. New zero-dep `src/tracking/{aggregate,pricing}.js` and `src/format/gain-terminal.js` (ANSI renderer, `NO_COLOR`/non-TTY safe). "Saved" is labeled everywhere as an estimate vs the whole-file baseline. Also in this release: docs served at the sigmap.io root (#258) and a transparent Sponsor section (#257).
+
+**Tags:** `sigmap gain` · `gain --all` · `gain --json` · `--no-track` · `gainTracking` · `.context/gain.ndjson` · `token-savings` · `privacy-safe` · `#257` · `#258` · `PR #261` · `#260`
+
+**Impact:** users can finally quantify what SigMap saves them (tokens, %, $); zero new dependencies; default-on local-only capture; 18 new tests for the gain data layer + real CLI capture.
+
+---
+
 ### v7.0.1 — Supply-chain hardening; importable core; wider star nudge ✓ (2026-06-14)
 
 **Patch release — security & package hygiene.** Every `child_process.execSync` call (which runs through `/bin/sh -c`) was converted to shell-free `execFileSync` with an arguments array — several had previously interpolated values into the command string (`git diff ${range}`, `HEAD~${n}`, `printf '%s' … | ${clipCmd}`, `node -e "…http.get…"`), a real shell-injection surface. A new `src/util/git.js` (`git()`/`tryGit()`) centralizes shell-free git; the `extends` config fetch passes the URL as an argv, `compare` spawns node by argv, and clipboard copy writes via stdin. Net: **zero `execSync`/`exec`/`shell:true` in the published surface**, clearing Socket's "Shell access" capability alert (#252). Also: `package.json` `main` now points at the importable core API (`require('sigmap')` no longer runs the CLI; Bundlephobia sees the real zero-dep library), the star nudge counts plain `sigmap` runs (not just `ask`/`squeeze`) so context-only users reach it (#251), and the unused `machineId = sha256(os.hostname())` fingerprint was removed from `usage.json` (#252).
@@ -850,9 +860,9 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.1+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.2+ (PR verification + Interactive Context Explorer)
 
-v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), and **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks. Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.0.1</span>
+  <span><strong>Release:</strong> v7.1.0</span>
   <span>·</span>
-  <span>Supply-chain hardening — zero system-shell access (shell-free subprocess calls), importable core API, no device fingerprint</span>
+  <span>New <code>sigmap gain</code> — terminal token-savings dashboard (tokens saved, %, est. $, daily/weekly/monthly trends), privacy-safe and local-only</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -67,6 +67,13 @@ sigmap --suggest-tool "<task>"           Recommend model tier for a task descrip
 sigmap --suggest-tool "<task>" --json    Machine-readable tier recommendation
 sigmap --health                          Print composite health score
 sigmap --health --json                   Machine-readable health score
+sigmap gain                              Token-savings dashboard (totals + by-operation)
+sigmap gain --all                        Add daily / weekly / monthly trend tables
+sigmap gain --json                       Aggregate savings as JSON
+sigmap gain --since 7d                    Window filter (7d, 30d, 12h, or ISO date)
+sigmap gain --top <n> | --model <name>   Limit rows / set $ pricing model
+sigmap gain --reset                      Clear the local savings log (.context/gain.ndjson)
+sigmap ... --no-track                    Disable gain savings capture for this run
 sigmap --diff                            Generate context for git-changed files only
 sigmap --diff <base-ref>                 Generate context + structural diff vs base ref (e.g. main)
 sigmap --diff --staged                   Generate context for staged files only

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6254,7 +6254,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.0.1',
+  version: '7.1.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 
@@ -10961,7 +10961,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.0.1';
+const VERSION = '7.1.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -12194,6 +12194,7 @@ function runDiff(cwd, config, stagedOnly, baseRef) {
 // Core generate pipeline
 // ---------------------------------------------------------------------------
 function runGenerate(cwd, config, reportMode, reportJson = false) {
+  const __genT0 = Date.now();
   const ignorePatterns = loadIgnorePatterns(cwd);
   let allFiles = buildFileList(cwd, config);
 
@@ -12393,7 +12394,7 @@ function runGenerate(cwd, config, reportMode, reportJson = false) {
     printReport(result.inputTokenTotal, result.finalTokens, result.fileCount, result.droppedCount, reportJson, effectiveMaxTokens, result.coverageResult, config.autoMaxTokens !== false && effectiveMaxTokens !== config.maxTokens, config.maxTokens);
   }
 
-  // Usage tracking (v0.9) — optional append-only NDJSON log
+  // Usage tracking (v0.9) — legacy health log, opt-in via config.tracking / --track.
   const trackingEnabled = !!(config.tracking || process.argv.includes('--track'));
   if (trackingEnabled && !reportMode) {
     try {
@@ -12411,6 +12412,22 @@ function runGenerate(cwd, config, reportMode, reportJson = false) {
     } catch (err) {
       console.warn(`[sigmap] tracking: ${err.message}`);
     }
+  }
+
+  // gain: capture generate savings (separate gain.ndjson; default ON, opt-out).
+  if (!reportMode) {
+    try {
+      const { recordUsage, isTrackingEnabled } = requireSourceOrBundled('./src/tracking/logger');
+      if (isTrackingEnabled(config, process.argv)) {
+        recordUsage({
+          version: VERSION,
+          op: 'generate',
+          baselineTokens: result.inputTokenTotal,
+          actualTokens: result.finalTokens,
+          durationMs: Date.now() - __genT0,
+        }, cwd);
+      }
+    } catch (_) { /* gain capture is best-effort */ }
   }
 
   // Feature 8: post-run summary — 6-line stdout after every normal run
@@ -12709,6 +12726,13 @@ Usage:
   ${cmd} --suggest-tool "<task>" --json    Machine-readable tier recommendation
   ${cmd} --health                          Print composite health score
   ${cmd} --health --json                   Machine-readable health score
+  ${cmd} gain                              Token-savings dashboard (totals + by-operation)
+  ${cmd} gain --all                        Add daily / weekly / monthly trend tables
+  ${cmd} gain --json                       Aggregate savings as JSON
+  ${cmd} gain --since 7d                    Window filter (7d, 30d, 12h, or ISO date)
+  ${cmd} gain --top <n> | --model <name>   Limit rows / set $ pricing model
+  ${cmd} gain --reset                      Clear the local savings log (.context/gain.ndjson)
+  ${cmd} ... --no-track                    Disable gain savings capture for this run
   ${cmd} --diff                            Generate context for git-changed files only
   ${cmd} --diff <base-ref>                 Generate context + structural diff vs base ref (e.g. main)
   ${cmd} --diff --staged                   Generate context for staged files only
@@ -13108,6 +13132,7 @@ function main() {
 
   // v4.2: `sigmap ask "<query>"` — unified pipeline
   if (args[0] === 'ask') {
+    const __askT0 = Date.now();
     // v6.8: Handle --followup flag which may appear before or after query
     let query = args[1];
     if (query === '--followup' && args[2]) {
@@ -13275,6 +13300,21 @@ function main() {
         bar,
       ].join('\n'));
     }
+    // gain: capture this query's savings for the `sigmap gain` dashboard.
+    try {
+      const { recordUsage, isTrackingEnabled } = requireSourceOrBundled('./src/tracking/logger');
+      if (isTrackingEnabled(config, args)) {
+        recordUsage({
+          version: VERSION,
+          op: 'ask',
+          baselineTokens: rawTok,
+          actualTokens: ctxTok,
+          durationMs: Date.now() - __askT0,
+          model,
+        }, cwd);
+      }
+    } catch (_) { /* gain capture is best-effort */ }
+
     // v7.0.0: record the run and show the one-time star nudge (interactive only).
     try {
       const { checkStarNudge } = requireSourceOrBundled('./src/nudge');
@@ -13284,6 +13324,44 @@ function main() {
         bump: { squeezeOffered: squeezeOffered ? 1 : 0, squeezeAccepted: squeezeAccepted ? 1 : 0 },
       });
     } catch (_) {}
+    process.exit(0);
+  }
+
+  // `sigmap gain` — token-savings dashboard (totals, by-operation, trends).
+  if (args[0] === 'gain') {
+    const valOf = (f, d) => { const i = args.indexOf(f); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
+    if (args.includes('--reset')) {
+      try {
+        const { GAIN_FILE } = requireSourceOrBundled('./src/tracking/logger');
+        const p = path.join(cwd, GAIN_FILE);
+        if (fs.existsSync(p)) fs.unlinkSync(p);
+        console.log('[sigmap] gain: usage log cleared.');
+      } catch (e) { console.error(`[sigmap] gain: ${e.message}`); }
+      process.exit(0);
+    }
+    try {
+      const { readGainLog } = requireSourceOrBundled('./src/tracking/logger');
+      const { aggregate } = requireSourceOrBundled('./src/tracking/aggregate');
+      const { renderSummary, renderBreakdown } = requireSourceOrBundled('./src/format/gain-terminal');
+      const records = readGainLog(cwd);
+      const agg = aggregate(records, {
+        model: valOf('--model', 'claude-sonnet'),
+        since: valOf('--since', null),
+        top: parseInt(valOf('--top', args.includes('--all') ? '0' : '10'), 10),
+      });
+      if (args.includes('--json')) {
+        process.stdout.write(JSON.stringify(agg, null, 2) + '\n');
+      } else {
+        const out = args.includes('--all')
+          ? renderSummary(agg, { version: VERSION }) + '\n' + renderBreakdown(agg)
+          : renderSummary(agg, { version: VERSION });
+        process.stdout.write(out + '\n');
+      }
+    } catch (e) {
+      console.error(`[sigmap] gain: ${e.message}`);
+      console.error('  (gain modules require src/ — for single-file installs, regenerate the bundle)');
+      process.exit(1);
+    }
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -67,6 +67,13 @@ sigmap --suggest-tool "<task>"           Recommend model tier for a task descrip
 sigmap --suggest-tool "<task>" --json    Machine-readable tier recommendation
 sigmap --health                          Print composite health score
 sigmap --health --json                   Machine-readable health score
+sigmap gain                              Token-savings dashboard (totals + by-operation)
+sigmap gain --all                        Add daily / weekly / monthly trend tables
+sigmap gain --json                       Aggregate savings as JSON
+sigmap gain --since 7d                    Window filter (7d, 30d, 12h, or ISO date)
+sigmap gain --top <n> | --model <name>   Limit rows / set $ pricing model
+sigmap gain --reset                      Clear the local savings log (.context/gain.ndjson)
+sigmap ... --no-track                    Disable gain savings capture for this run
 sigmap --diff                            Generate context for git-changed files only
 sigmap --diff <base-ref>                 Generate context + structural diff vs base ref (e.g. main)
 sigmap --diff --staged                   Generate context for staged files only

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.0.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/scripts/gain.mjs
+++ b/scripts/gain.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * SigMap `gain` — runnable CLI (src-only preview; bundling deferred).
+ *
+ * Usage:
+ *   node scripts/gain.mjs                 # global summary + by-operation
+ *   node scripts/gain.mjs --all           # daily / weekly / monthly trends
+ *   node scripts/gain.mjs --json          # machine-readable aggregate
+ *   node scripts/gain.mjs --since 7d      # window filter (7d, 30d, 12h, ISO date)
+ *   node scripts/gain.mjs --top 5         # limit by-operation rows
+ *   node scripts/gain.mjs --model gpt-4o  # pricing assumption for $
+ *   node scripts/gain.mjs --seed          # write a realistic small log for THIS repo
+ *   node scripts/gain.mjs --demo          # write a big RTK-style demo log, then render
+ *   node scripts/gain.mjs --reset         # delete the local usage log
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const { aggregate } = require(path.join(ROOT, 'src/tracking/aggregate.js'));
+const { renderSummary, renderBreakdown } = require(path.join(ROOT, 'src/format/gain-terminal.js'));
+const { readGainLog } = require(path.join(ROOT, 'src/tracking/logger.js'));
+
+const LOG_PATH = path.join(ROOT, '.context', 'gain.ndjson');
+
+// ── arg parsing ───────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const val = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? argv[i + 1] : d; };
+
+const opts = {
+  model: val('--model', 'claude-sonnet'),
+  since: val('--since', null),
+  top: parseInt(val('--top', has('--all') ? '0' : '10'), 10),
+};
+
+function version() {
+  try { return require(path.join(ROOT, 'version.json')).version; } catch { return ''; }
+}
+
+// ── seeders ────────────────────────────────────────────────────────────────
+function appendRecords(records) {
+  fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
+  const lines = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  fs.appendFileSync(LOG_PATH, lines, 'utf8');
+}
+
+// Deterministic pseudo-random so seeds are reproducible.
+function mulberry32(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seed({ days, opsPerDay, tokenScale = 1, rngSeed }) {
+  const rnd = mulberry32(rngSeed);
+  const OPS = [
+    { op: 'ask', weight: 0.45, base: [2200, 16000], pct: [0.90, 0.97], ms: [25, 70] },
+    { op: 'mcp:search_signatures', weight: 0.25, base: [900, 5000], pct: [0.82, 0.94], ms: [1, 8] },
+    { op: '--query', weight: 0.12, base: [2500, 15000], pct: [0.88, 0.96], ms: [25, 60] },
+    { op: 'mcp:get_map', weight: 0.08, base: [3500, 22000], pct: [0.93, 0.98], ms: [3, 12] },
+    { op: 'mcp:explain_file', weight: 0.06, base: [1200, 6000], pct: [0.80, 0.92], ms: [2, 9] },
+    { op: 'generate', weight: 0.04, base: [11000, 34000], pct: [0.94, 0.985], ms: [120, 320] },
+  ];
+  const pick = () => { let r = rnd(); for (const o of OPS) { if ((r -= o.weight) <= 0) return o; } return OPS[0]; };
+  const lerp = ([a, b]) => a + (b - a) * rnd();
+
+  const records = [];
+  const now = Date.now();
+  for (let d = days - 1; d >= 0; d--) {
+    const dayStart = now - d * 86400000;
+    const n = Math.max(1, Math.round(opsPerDay * (0.5 + rnd())));
+    for (let i = 0; i < n; i++) {
+      const o = pick();
+      const baseline = Math.round(lerp(o.base) * tokenScale);
+      const pct = lerp(o.pct);
+      const actual = Math.max(50, Math.round(baseline * (1 - pct)));
+      const ts = new Date(dayStart + Math.floor(rnd() * 86400000)).toISOString();
+      records.push({
+        ts,
+        v: version() || '7.0.1',
+        op: o.op,
+        baselineTokens: baseline,
+        actualTokens: actual,
+        savedTokens: baseline - actual,
+        savedPct: Math.round((1 - actual / baseline) * 1000) / 10,
+        durationMs: Math.round(lerp(o.ms)),
+        model: 'claude-sonnet',
+        ok: true,
+      });
+    }
+  }
+  records.sort((a, b) => (a.ts < b.ts ? -1 : 1));
+  appendRecords(records);
+  return records.length;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────
+if (has('--reset')) {
+  if (fs.existsSync(LOG_PATH)) fs.unlinkSync(LOG_PATH);
+  console.log('[sigmap] gain: usage log cleared.');
+  process.exit(0);
+}
+
+if (has('--seed')) {
+  const n = seed({ days: 4, opsPerDay: 45, tokenScale: 1, rngSeed: 42 });
+  console.log(`[sigmap] gain: seeded ${n} realistic records → ${path.relative(ROOT, LOG_PATH)}`);
+}
+
+if (has('--demo')) {
+  const n = seed({ days: 35, opsPerDay: 450, tokenScale: 1, rngSeed: 7 });
+  console.log(`[sigmap] gain: seeded ${n} demo records → ${path.relative(ROOT, LOG_PATH)}\n`);
+}
+
+const records = readGainLog(ROOT);
+const agg = aggregate(records, opts);
+
+if (has('--json')) {
+  console.log(JSON.stringify(agg, null, 2));
+  process.exit(0);
+}
+
+const out = has('--all')
+  ? renderSummary(agg, { version: version() }) + '\n' + renderBreakdown(agg)
+  : renderSummary(agg, { version: version() });
+process.stdout.write(out + '\n');

--- a/src/format/gain-terminal.js
+++ b/src/format/gain-terminal.js
@@ -1,0 +1,206 @@
+'use strict';
+
+/**
+ * SigMap `gain` — terminal renderer.
+ *
+ * Zero-dependency ANSI dashboard for token savings. Honors NO_COLOR and
+ * non-TTY output (plain text for pipes / --json consumers elsewhere).
+ *
+ * "saved" is a counterfactual estimate (whole-file baseline − actual context),
+ * never a measured delta — the footer says so on every view.
+ */
+
+const USE_COLOR = !process.env.NO_COLOR && process.stdout.isTTY;
+
+const C = {
+  reset: USE_COLOR ? '\x1b[0m' : '',
+  dim: USE_COLOR ? '\x1b[2m' : '',
+  bold: USE_COLOR ? '\x1b[1m' : '',
+  green: USE_COLOR ? '\x1b[32m' : '',
+  yellow: USE_COLOR ? '\x1b[33m' : '',
+  red: USE_COLOR ? '\x1b[31m' : '',
+  cyan: USE_COLOR ? '\x1b[36m' : '',
+  gray: USE_COLOR ? '\x1b[90m' : '',
+};
+
+// ── formatters ───────────────────────────────────────────────────────────
+function humanTokens(n) {
+  n = Number(n) || 0;
+  if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+  return String(Math.round(n));
+}
+
+function fmtInt(n) {
+  return (Number(n) || 0).toLocaleString('en-US');
+}
+
+function fmtUSD(n) {
+  n = Number(n) || 0;
+  if (n >= 1000) return '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+  return '$' + n.toFixed(2);
+}
+
+function fmtDuration(ms) {
+  ms = Number(ms) || 0;
+  if (ms >= 3.6e6) return (ms / 3.6e6).toFixed(1) + 'h';
+  if (ms >= 60000) return (ms / 60000).toFixed(1) + 'm';
+  if (ms >= 1000) return (ms / 1000).toFixed(1) + 's';
+  return Math.round(ms) + 'ms';
+}
+
+function fmtPct(p) {
+  return (Number(p) || 0).toFixed(1) + '%';
+}
+
+function colorPct(p, text) {
+  if (!USE_COLOR) return text;
+  const c = p >= 85 ? C.green : p >= 60 ? C.yellow : C.red;
+  return c + text + C.reset;
+}
+
+function pad(s, w, align) {
+  s = String(s);
+  const visible = s.replace(/\x1b\[[0-9;]*m/g, '');
+  const gap = Math.max(0, w - visible.length);
+  return align === 'right' ? ' '.repeat(gap) + s : s + ' '.repeat(gap);
+}
+
+/** Solid horizontal efficiency bar with a dotted remainder. */
+function bar(pct, width) {
+  const filled = Math.round((clamp(pct, 0, 100) / 100) * width);
+  const solid = '█'.repeat(filled);
+  const rest = '░'.repeat(Math.max(0, width - filled));
+  return (USE_COLOR ? C.green : '') + solid + (USE_COLOR ? C.gray : '') + rest + C.reset;
+}
+
+/** Proportional impact bar (share of total saved). */
+function impactBar(sharePct, width) {
+  const n = Math.max(1, Math.round((clamp(sharePct, 0, 100) / 100) * width));
+  return (USE_COLOR ? C.cyan : '') + '█'.repeat(n) + C.reset;
+}
+
+const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+const rule = (w) => C.gray + '─'.repeat(w) + C.reset;
+
+// ── views ──────────────────────────────────────────────────────────────
+/**
+ * Render the global summary + by-operation table.
+ * @param {object} agg     output of aggregate()
+ * @param {object} [opts]  { version, scope }
+ * @returns {string}
+ */
+function renderSummary(agg, opts = {}) {
+  const W = 74;
+  const t = agg.totals;
+  const L = [];
+  const scope = opts.scope || 'this repo';
+  const ver = opts.version ? `v${opts.version}` : '';
+
+  L.push('');
+  const heading = `⚡ SigMap — Token Savings (${scope})`;
+  L.push('  ' + C.bold + C.cyan + heading + C.reset +
+    pad(`${C.green}✓${C.reset} ${C.dim}${ver}${C.reset}`, W - heading.length, 'right'));
+  L.push('  ' + rule(W));
+  L.push('');
+
+  if (t.count === 0) {
+    L.push(`  ${C.yellow}No usage recorded yet.${C.reset}`);
+    L.push(`  ${C.dim}Run a few queries (sigmap ask "...") or seed a demo:${C.reset}`);
+    L.push(`  ${C.dim}  node scripts/gain.mjs --demo${C.reset}`);
+    L.push('');
+    return L.join('\n');
+  }
+
+  const label = (k) => C.dim + pad(k, 21) + C.reset;
+  L.push('  ' + label('Total operations') + ': ' + C.bold + fmtInt(t.count) + C.reset);
+  L.push('  ' + label('Whole-file baseline') + ': ' + humanTokens(t.baseline) + ' tok' +
+    `   ${C.dim}← est. cost of feeding full files${C.reset}`);
+  L.push('  ' + label('SigMap context') + ': ' + humanTokens(t.actual) + ' tok');
+  L.push('  ' + label('Tokens saved') + ': ' + C.bold + humanTokens(t.saved) + C.reset +
+    '  (' + colorPct(t.savedPct, fmtPct(t.savedPct)) + ')');
+  L.push('  ' + label('Est. money saved') + ': ' + C.bold + C.green + fmtUSD(t.usdSaved) + C.reset +
+    `   ${C.dim}(${agg.price.model} input @ $${agg.price.perMtok}/M · --model to change)${C.reset}`);
+  L.push('  ' + label('Avg latency') + ': ' + fmtDuration(t.avgMs) + ' / op' +
+    `   ${C.dim}(local, no API round-trip)${C.reset}`);
+  L.push('');
+  L.push('  ' + label('Efficiency') + ': ▕' + bar(t.savedPct, 30) + '▏  ' +
+    colorPct(t.savedPct, C.bold + fmtPct(t.savedPct) + C.reset));
+  L.push('');
+
+  // By operation table
+  L.push(`  ${C.bold}By operation${C.reset}`);
+  L.push('  ' + rule(W));
+  L.push('  ' + C.dim +
+    pad('#', 3) + pad('Operation', 24) + pad('Count', 8, 'right') +
+    pad('Saved', 9, 'right') + pad('Avg%', 8, 'right') + pad('Time', 8, 'right') +
+    '  Impact' + C.reset);
+  agg.byOp.forEach((o, i) => {
+    L.push('  ' +
+      pad(`${i + 1}.`, 3) +
+      pad(o.op, 24) +
+      pad(fmtInt(o.count), 8, 'right') +
+      pad(humanTokens(o.saved), 9, 'right') +
+      pad(colorPct(o.avgPct, fmtPct(o.avgPct)), 8, 'right') +
+      pad(fmtDuration(o.avgMs), 8, 'right') +
+      '  ' + impactBar(o.sharePct, 12));
+  });
+  L.push('  ' + rule(W));
+  L.push(`  ${C.dim}saved = baseline − actual · estimated vs whole-file reads · local-only${C.reset}`);
+  L.push('');
+  return L.join('\n');
+}
+
+/**
+ * Render daily / weekly / monthly trend tables.
+ * @param {object} agg
+ * @returns {string}
+ */
+function renderBreakdown(agg) {
+  const L = [];
+  if (agg.totals.count === 0) return renderSummary(agg);
+
+  const section = (icon, title, rows, keyHeader) => {
+    L.push('');
+    L.push(`  ${C.bold}${icon} ${title}${C.reset}`);
+    L.push('  ' + C.dim +
+      pad(keyHeader, 14) + pad('Ops', 7, 'right') + pad('Baseline', 11, 'right') +
+      pad('Actual', 10, 'right') + pad('Saved', 10, 'right') + pad('Save%', 8, 'right') +
+      pad('Time', 8, 'right') + C.reset);
+    let TB = 0, TA = 0, TS = 0, TC = 0, TM = 0;
+    for (const r of rows) {
+      TB += r.baseline; TA += r.actual; TS += r.saved; TC += r.count; TM += r.ms;
+      L.push('  ' +
+        pad(r.key, 14) + pad(fmtInt(r.count), 7, 'right') +
+        pad(humanTokens(r.baseline), 11, 'right') + pad(humanTokens(r.actual), 10, 'right') +
+        pad(humanTokens(r.saved), 10, 'right') +
+        pad(colorPct(r.savedPct, fmtPct(r.savedPct)), 8, 'right') +
+        pad(fmtDuration(r.ms), 8, 'right'));
+    }
+    const tp = TB > 0 ? (TS / TB) * 100 : 0;
+    L.push('  ' + C.bold +
+      pad('TOTAL', 14) + pad(fmtInt(TC), 7, 'right') +
+      pad(humanTokens(TB), 11, 'right') + pad(humanTokens(TA), 10, 'right') +
+      pad(humanTokens(TS), 10, 'right') + pad(fmtPct(tp), 8, 'right') +
+      pad(fmtDuration(TM), 8, 'right') + C.reset);
+  };
+
+  const daily = agg.buckets.daily.slice(-30);
+  section('📅', `Daily (last ${daily.length})`, daily, 'Date');
+  const weekly = agg.buckets.weekly.slice(-6);
+  section('📆', `Weekly (last ${weekly.length})`, weekly, 'Week of');
+  const monthly = agg.buckets.monthly.slice(-3);
+  section('🗓️', `Monthly (last ${monthly.length})`, monthly, 'Month');
+  L.push('');
+  L.push(`  ${C.dim}saved = baseline − actual · estimated vs whole-file reads · local-only${C.reset}`);
+  L.push('');
+  return L.join('\n');
+}
+
+module.exports = {
+  renderSummary,
+  renderBreakdown,
+  // exported for tests
+  humanTokens, fmtUSD, fmtDuration, fmtPct,
+};

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.0.1',
+  version: '7.1.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/src/tracking/aggregate.js
+++ b/src/tracking/aggregate.js
@@ -1,0 +1,195 @@
+'use strict';
+
+/**
+ * SigMap usage aggregation for the `gain` dashboard.
+ *
+ * Pure, zero-dependency functions that turn raw NDJSON usage records into the
+ * totals / by-operation / time-bucket shapes the terminal renderer consumes.
+ *
+ * Tolerant of BOTH schemas:
+ *   - new:    { op, baselineTokens, actualTokens, savedTokens, savedPct, durationMs, model }
+ *   - legacy: { rawTokens, finalTokens, reductionPct }   (from logger.js v0.9)
+ *
+ * "saved" is a counterfactual estimate (baseline − actual), never a measured
+ * delta. Callers are responsible for labeling it as such in the UI.
+ */
+
+const { resolvePrice } = require('./pricing');
+
+const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+
+/**
+ * Normalize one raw record into a canonical shape.
+ * @param {object} rec
+ */
+function normalize(rec) {
+  const baseline = num(rec.baselineTokens != null ? rec.baselineTokens : rec.rawTokens);
+  const actual = num(rec.actualTokens != null ? rec.actualTokens : rec.finalTokens);
+  const saved = rec.savedTokens != null ? num(rec.savedTokens) : Math.max(0, baseline - actual);
+  const savedPct = rec.savedPct != null
+    ? num(rec.savedPct)
+    : rec.reductionPct != null
+      ? num(rec.reductionPct)
+      : baseline > 0 ? (saved / baseline) * 100 : 0;
+  return {
+    ts: rec.ts || null,
+    op: normalizeOp(rec.op),
+    baseline,
+    actual,
+    saved,
+    savedPct: clamp(savedPct, 0, 100),
+    durationMs: num(rec.durationMs),
+    model: rec.model || null,
+  };
+}
+
+function normalizeOp(op) {
+  if (!op) return 'generate';
+  return String(op);
+}
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse a --since value into a cutoff Date (or null for "all time").
+ * Accepts: "7d", "30d", "12h", or an ISO date "2026-06-01".
+ * @param {string} since
+ * @param {number} [nowMs] - injectable clock for tests
+ * @returns {Date|null}
+ */
+function parseSince(since, nowMs) {
+  if (!since) return null;
+  const now = nowMs != null ? nowMs : Date.now();
+  const rel = /^(\d+)([dhw])$/.exec(String(since).trim());
+  if (rel) {
+    const n = parseInt(rel[1], 10);
+    const unit = rel[2];
+    const ms = unit === 'h' ? 3.6e6 : unit === 'w' ? 6.048e8 : 8.64e7;
+    return new Date(now - n * ms);
+  }
+  const d = new Date(since);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Bucket records by calendar granularity.
+ * @param {object[]} records - normalized records
+ * @param {'day'|'week'|'month'} granularity
+ * @returns {Array<{key,count,baseline,actual,saved,savedPct,ms}>} ascending by key
+ */
+function bucketBy(records, granularity) {
+  const map = new Map();
+  for (const r of records) {
+    if (!r.ts) continue;
+    const key = bucketKey(r.ts, granularity);
+    if (!key) continue;
+    let b = map.get(key);
+    if (!b) { b = { key, count: 0, baseline: 0, actual: 0, saved: 0, ms: 0 }; map.set(key, b); }
+    b.count += 1;
+    b.baseline += r.baseline;
+    b.actual += r.actual;
+    b.saved += r.saved;
+    b.ms += r.durationMs;
+  }
+  return [...map.values()]
+    .map((b) => ({ ...b, savedPct: b.baseline > 0 ? clamp((b.saved / b.baseline) * 100, 0, 100) : 0 }))
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}
+
+function bucketKey(ts, granularity) {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  if (granularity === 'month') return `${y}-${m}`;
+  if (granularity === 'week') {
+    // ISO-ish: key by the Monday (UTC) of that week.
+    const tmp = new Date(Date.UTC(y, d.getUTCMonth(), d.getUTCDate()));
+    const dow = (tmp.getUTCDay() + 6) % 7; // 0 = Monday
+    tmp.setUTCDate(tmp.getUTCDate() - dow);
+    return `${tmp.getUTCFullYear()}-${String(tmp.getUTCMonth() + 1).padStart(2, '0')}-${String(tmp.getUTCDate()).padStart(2, '0')}`;
+  }
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Full aggregation for the `gain` dashboard.
+ * @param {object[]} rawRecords
+ * @param {object} [opts]
+ * @param {string} [opts.model]   pricing model
+ * @param {string} [opts.since]   window filter
+ * @param {number} [opts.top]     limit byOp rows (0 = all)
+ * @param {number} [opts.nowMs]   injectable clock
+ * @returns {object}
+ */
+function aggregate(rawRecords, opts = {}) {
+  const price = resolvePrice(opts.model);
+  const cutoff = parseSince(opts.since, opts.nowMs);
+
+  let records = (rawRecords || []).map(normalize);
+  if (cutoff) records = records.filter((r) => r.ts && new Date(r.ts) >= cutoff);
+
+  const totals = {
+    count: records.length,
+    baseline: 0,
+    actual: 0,
+    saved: 0,
+    totalMs: 0,
+    savedPct: 0,
+    avgMs: 0,
+    usdSaved: 0,
+    firstTs: null,
+    lastTs: null,
+  };
+
+  const opMap = new Map();
+  for (const r of records) {
+    totals.baseline += r.baseline;
+    totals.actual += r.actual;
+    totals.saved += r.saved;
+    totals.totalMs += r.durationMs;
+    if (r.ts) {
+      if (!totals.firstTs || r.ts < totals.firstTs) totals.firstTs = r.ts;
+      if (!totals.lastTs || r.ts > totals.lastTs) totals.lastTs = r.ts;
+    }
+    let o = opMap.get(r.op);
+    if (!o) { o = { op: r.op, count: 0, baseline: 0, saved: 0, ms: 0 }; opMap.set(r.op, o); }
+    o.count += 1;
+    o.baseline += r.baseline;
+    o.saved += r.saved;
+    o.ms += r.durationMs;
+  }
+
+  totals.savedPct = totals.baseline > 0 ? clamp((totals.saved / totals.baseline) * 100, 0, 100) : 0;
+  totals.avgMs = totals.count > 0 ? Math.round(totals.totalMs / totals.count) : 0;
+  totals.usdSaved = totals.saved * price.perToken;
+
+  let byOp = [...opMap.values()].map((o) => ({
+    op: o.op,
+    count: o.count,
+    saved: o.saved,
+    avgPct: o.baseline > 0 ? clamp((o.saved / o.baseline) * 100, 0, 100) : 0,
+    avgMs: o.count > 0 ? Math.round(o.ms / o.count) : 0,
+    usdSaved: o.saved * price.perToken,
+    sharePct: totals.saved > 0 ? (o.saved / totals.saved) * 100 : 0,
+  })).sort((a, b) => b.saved - a.saved);
+
+  if (opts.top && opts.top > 0) byOp = byOp.slice(0, opts.top);
+
+  return {
+    price,
+    totals,
+    byOp,
+    buckets: {
+      daily: bucketBy(records, 'day'),
+      weekly: bucketBy(records, 'week'),
+      monthly: bucketBy(records, 'month'),
+    },
+  };
+}
+
+module.exports = { aggregate, bucketBy, parseSince, normalize };

--- a/src/tracking/logger.js
+++ b/src/tracking/logger.js
@@ -18,6 +18,9 @@ const fs = require('fs');
 const path = require('path');
 
 const LOG_FILE = path.join('.context', 'usage.ndjson');
+// Dedicated log for the `gain` dashboard (extended schema). Kept separate from
+// usage.ndjson so the legacy health/nudge history never collides with it.
+const GAIN_FILE = path.join('.context', 'gain.ndjson');
 
 /**
  * Append one run entry to the usage log.
@@ -74,6 +77,25 @@ function readLog(cwd) {
 }
 
 /**
+ * Read and parse all `gain` dashboard records (oldest first).
+ * @param {string} cwd
+ * @returns {object[]}
+ */
+function readGainLog(cwd) {
+  try {
+    const logPath = path.join(cwd, GAIN_FILE);
+    if (!fs.existsSync(logPath)) return [];
+    return fs.readFileSync(logPath, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => { try { return JSON.parse(line); } catch (_) { return null; } })
+      .filter(Boolean);
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
  * Compute summary statistics from an array of log records.
  * @param {object[]} entries
  * @returns {object} Summary stats
@@ -112,4 +134,64 @@ function summarize(entries) {
   };
 }
 
-module.exports = { logRun, readLog, summarize };
+/**
+ * Whether `gain` savings capture is enabled. Default: ON (privacy-safe,
+ * local-only, counts only — no paths, source, or query text). This is
+ * intentionally decoupled from the legacy `config.tracking` flag (which gates
+ * the usage.ndjson health log and defaults OFF). Opt out of gain capture via:
+ *   config.gainTracking === false   ·   --no-track   ·   SIGMAP_NO_TRACK=1
+ * @param {object} [config]
+ * @param {string[]} [argv]
+ * @returns {boolean}
+ */
+function isTrackingEnabled(config, argv) {
+  const a = argv || (typeof process !== 'undefined' ? process.argv : []);
+  if (process.env && process.env.SIGMAP_NO_TRACK) return false;
+  if (a && a.includes('--no-track')) return false;
+  if (config && config.gainTracking === false) return false;
+  return true;
+}
+
+/**
+ * Append one operation to the usage log using the extended `gain` schema.
+ * Reuses the same NDJSON file as logRun and is tolerant of partial input.
+ * Never throws — tracking must never break the main process.
+ *
+ * @param {object} entry
+ * @param {string} entry.op             e.g. 'ask' | 'generate' | 'query' | 'mcp:get_map'
+ * @param {number} entry.baselineTokens whole-file / candidate baseline (counterfactual)
+ * @param {number} entry.actualTokens   tokens SigMap actually emitted
+ * @param {number} [entry.durationMs]
+ * @param {string} [entry.model]
+ * @param {string} [entry.version]
+ * @param {string} cwd
+ */
+function recordUsage(entry, cwd) {
+  try {
+    const logPath = path.join(cwd, GAIN_FILE);
+    const dir = path.dirname(logPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+    const baseline = Math.max(0, Number(entry.baselineTokens) || 0);
+    const actual = Math.max(0, Number(entry.actualTokens) || 0);
+    const saved = Math.max(0, baseline - actual);
+    const record = {
+      ts: new Date().toISOString(),
+      v: entry.version || '0.9.0',
+      op: entry.op || 'generate',
+      baselineTokens: baseline,
+      actualTokens: actual,
+      savedTokens: saved,
+      savedPct: baseline > 0 ? parseFloat(((saved / baseline) * 100).toFixed(1)) : 0,
+      durationMs: Math.max(0, Math.round(Number(entry.durationMs) || 0)),
+      model: entry.model || null,
+      ok: entry.ok !== false,
+    };
+    fs.appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf8');
+  } catch (err) {
+    // Never crash the main process — tracking is optional.
+    if (process.stderr) process.stderr.write(`[sigmap] tracking: could not write log: ${err.message}\n`);
+  }
+}
+
+module.exports = { logRun, recordUsage, readLog, readGainLog, summarize, isTrackingEnabled, GAIN_FILE };

--- a/src/tracking/pricing.js
+++ b/src/tracking/pricing.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * SigMap pricing table — input-token $/Mtok assumptions for the `gain` dashboard.
+ *
+ * These are ASSUMPTIONS used only to translate "tokens saved" into an estimated
+ * dollar figure. They are deliberately conservative and configurable via
+ *   --model <name>   or   config.pricingModel
+ * The `gain` views always print the model + rate inline so the $ is never
+ * presented as exact. Zero npm dependencies.
+ */
+
+// USD per 1,000,000 input tokens.
+const PRICES = {
+  'claude-sonnet': 3.0,
+  'claude-opus': 15.0,
+  'claude-haiku': 0.8,
+  'gpt-4o': 2.5,
+  'gpt-4o-mini': 0.15,
+  'gemini-1.5-pro': 1.25,
+  'gemini-1.5-flash': 0.075,
+};
+
+const DEFAULT_MODEL = 'claude-sonnet';
+
+/**
+ * Resolve a price (USD per token) for a model name.
+ * @param {string} [model]
+ * @returns {{ model: string, perMtok: number, perToken: number }}
+ */
+function resolvePrice(model) {
+  const key = (model || DEFAULT_MODEL).toLowerCase();
+  const perMtok = PRICES[key] != null ? PRICES[key] : PRICES[DEFAULT_MODEL];
+  const resolved = PRICES[key] != null ? key : DEFAULT_MODEL;
+  return { model: resolved, perMtok, perToken: perMtok / 1_000_000 };
+}
+
+/** @returns {string[]} known model keys */
+function listModels() {
+  return Object.keys(PRICES);
+}
+
+module.exports = { PRICES, DEFAULT_MODEL, resolvePrice, listModels };

--- a/test/integration/gain.test.js
+++ b/test/integration/gain.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+/**
+ * Unit tests for the `gain` dashboard data layer (aggregate + pricing).
+ * Zero-dependency, plain Node assertions. Run: node test/integration/gain.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { aggregate, bucketBy, parseSince, normalize } = require('../../src/tracking/aggregate');
+const { resolvePrice } = require('../../src/tracking/pricing');
+const { recordUsage, readGainLog, isTrackingEnabled } = require('../../src/tracking/logger');
+const gt = require('../../src/format/gain-terminal');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+// ── normalize: tolerates both schemas ──────────────────────────────────────
+test('normalize: new schema passes through', () => {
+  const r = normalize({ ts: '2026-06-16T00:00:00Z', op: 'ask', baselineTokens: 1000, actualTokens: 100 });
+  assert.strictEqual(r.saved, 900);
+  assert.strictEqual(r.savedPct, 90);
+  assert.strictEqual(r.op, 'ask');
+});
+
+test('normalize: legacy schema (rawTokens/finalTokens) maps correctly', () => {
+  const r = normalize({ ts: '2026-06-16T00:00:00Z', rawTokens: 2000, finalTokens: 200, reductionPct: 90 });
+  assert.strictEqual(r.baseline, 2000);
+  assert.strictEqual(r.actual, 200);
+  assert.strictEqual(r.saved, 1800);
+  assert.strictEqual(r.op, 'generate'); // default when op missing
+});
+
+test('normalize: savedPct clamps to 0..100', () => {
+  assert.strictEqual(normalize({ baselineTokens: 100, actualTokens: 0, savedPct: 150 }).savedPct, 100);
+  assert.strictEqual(normalize({ baselineTokens: 0, actualTokens: 0, savedPct: -5 }).savedPct, 0);
+});
+
+// ── aggregate: totals + byOp ───────────────────────────────────────────────
+const sample = [
+  { ts: '2026-06-14T10:00:00Z', op: 'ask', baselineTokens: 10000, actualTokens: 1000 },
+  { ts: '2026-06-15T10:00:00Z', op: 'ask', baselineTokens: 10000, actualTokens: 500 },
+  { ts: '2026-06-15T11:00:00Z', op: 'mcp:get_map', baselineTokens: 20000, actualTokens: 1000 },
+];
+
+test('aggregate: totals sum correctly', () => {
+  const a = aggregate(sample, { model: 'claude-sonnet' });
+  assert.strictEqual(a.totals.count, 3);
+  assert.strictEqual(a.totals.baseline, 40000);
+  assert.strictEqual(a.totals.saved, 37500);
+  assert.strictEqual(Math.round(a.totals.savedPct), 94);
+});
+
+test('aggregate: byOp sorted by saved desc + share sums ~100', () => {
+  const a = aggregate(sample);
+  assert.strictEqual(a.byOp[0].op, 'mcp:get_map'); // 19000 saved > 18500 ask
+  const shareSum = a.byOp.reduce((s, o) => s + o.sharePct, 0);
+  assert.ok(Math.abs(shareSum - 100) < 0.01, `share sum ${shareSum}`);
+});
+
+test('aggregate: usdSaved tracks the pricing model', () => {
+  const sonnet = aggregate(sample, { model: 'claude-sonnet' }).totals.usdSaved;
+  const opus = aggregate(sample, { model: 'claude-opus' }).totals.usdSaved;
+  assert.ok(opus > sonnet, 'opus should cost more per token');
+  assert.ok(Math.abs(sonnet - 37500 * 3 / 1e6) < 1e-9);
+});
+
+test('aggregate: top limits byOp rows', () => {
+  const a = aggregate(sample, { top: 1 });
+  assert.strictEqual(a.byOp.length, 1);
+});
+
+test('aggregate: empty log yields zeroed totals, no throw', () => {
+  const a = aggregate([]);
+  assert.strictEqual(a.totals.count, 0);
+  assert.strictEqual(a.totals.savedPct, 0);
+  assert.deepStrictEqual(a.byOp, []);
+});
+
+// ── buckets ────────────────────────────────────────────────────────────────
+test('bucketBy: day groups by calendar day', () => {
+  const b = bucketBy(sample.map(normalize), 'day');
+  assert.strictEqual(b.length, 2);
+  assert.strictEqual(b[0].key, '2026-06-14');
+  assert.strictEqual(b[1].count, 2);
+});
+
+test('bucketBy: month groups by YYYY-MM', () => {
+  const b = bucketBy(sample.map(normalize), 'month');
+  assert.strictEqual(b.length, 1);
+  assert.strictEqual(b[0].key, '2026-06');
+});
+
+// ── since ──────────────────────────────────────────────────────────────────
+test('parseSince: relative + ISO', () => {
+  const now = Date.parse('2026-06-16T00:00:00Z');
+  assert.strictEqual(parseSince('7d', now).toISOString(), '2026-06-09T00:00:00.000Z');
+  assert.strictEqual(parseSince(null, now), null);
+  assert.ok(parseSince('2026-06-01', now) instanceof Date);
+});
+
+test('aggregate: --since filters records', () => {
+  const now = Date.parse('2026-06-16T00:00:00Z');
+  const a = aggregate(sample, { since: '1d', nowMs: now });
+  assert.strictEqual(a.totals.count, 2); // only the two 06-15 records
+});
+
+// ── pricing ──────────────────────────────────────────────────────────────
+test('resolvePrice: unknown model falls back to default', () => {
+  assert.strictEqual(resolvePrice('not-a-model').model, 'claude-sonnet');
+  assert.strictEqual(resolvePrice('gpt-4o').perMtok, 2.5);
+});
+
+// ── formatters ─────────────────────────────────────────────────────────────
+test('humanTokens / fmtDuration / fmtUSD', () => {
+  assert.strictEqual(gt.humanTokens(1500000), '1.5M');
+  assert.strictEqual(gt.humanTokens(735), '735');
+  assert.strictEqual(gt.fmtDuration(41), '41ms');
+  assert.strictEqual(gt.fmtDuration(2500), '2.5s');
+  assert.strictEqual(gt.fmtUSD(386.79), '$386.79');
+});
+
+// ── tracking gate (gain capture is default-on, opt-out only) ────────────────
+test('isTrackingEnabled: default on, decoupled from config.tracking', () => {
+  assert.strictEqual(isTrackingEnabled({}, []), true);
+  assert.strictEqual(isTrackingEnabled({ tracking: false }, []), true); // legacy flag does NOT disable gain
+  assert.strictEqual(isTrackingEnabled({ gainTracking: false }, []), false);
+  assert.strictEqual(isTrackingEnabled({}, ['--no-track']), false);
+});
+
+test('recordUsage → readGainLog round-trips into gain.ndjson', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-gain-'));
+  try {
+    recordUsage({ op: 'ask', baselineTokens: 5000, actualTokens: 200, durationMs: 12, model: 'gpt-4o' }, dir);
+    assert.ok(fs.existsSync(path.join(dir, '.context', 'gain.ndjson')), 'gain.ndjson written');
+    const recs = readGainLog(dir);
+    assert.strictEqual(recs.length, 1);
+    assert.strictEqual(recs[0].op, 'ask');
+    assert.strictEqual(recs[0].savedTokens, 4800);
+    // privacy: record carries no file paths / source / query text
+    const keys = Object.keys(recs[0]);
+    assert.ok(!keys.some((k) => /path|file|query|source/i.test(k)), 'no leaky fields');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── real CLI capture: generate run feeds `sigmap gain` ──────────────────────
+test('CLI: a real generate run is captured and surfaced by `gain --json`', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-gain-proj-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'),
+      'function alpha(x){return x+1;}\nclass Beta{ go(){return 2;} }\nmodule.exports={alpha,Beta};\n');
+    execFileSync(process.execPath, [GEN_CONTEXT], { cwd: dir, stdio: 'ignore' });
+    const out = execFileSync(process.execPath, [GEN_CONTEXT, 'gain', '--json'], { cwd: dir, encoding: 'utf8' });
+    const agg = JSON.parse(out);
+    assert.ok(agg.totals.count >= 1, 'at least one captured op');
+    assert.ok(agg.byOp.some((o) => o.op === 'generate'), 'generate op present');
+    assert.ok(agg.totals.saved >= 0, 'saved is non-negative');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: --no-track suppresses gain capture', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-gain-off-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'), 'function a(){return 1;}\nmodule.exports={a};\n');
+    execFileSync(process.execPath, [GEN_CONTEXT, '--no-track'], { cwd: dir, stdio: 'ignore' });
+    assert.ok(!fs.existsSync(path.join(dir, '.context', 'gain.ndjson')), 'no gain log when --no-track');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+console.log(`\ngain: ${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.1",
+  "version": "7.1.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.1.0** to main: the `sigmap gain` token-savings dashboard (#260) plus the prepared release commit (changelog, version sync, docs).

## Changes
- `src/tracking/`, `src/format/gain-terminal.js`, `gen-context.js` — gain capture + aggregate + render + command
- `CHANGELOG.md`, `version.json`, `package.json` ×3, `gen-context.js`, `src/mcp/server.js` — 7.0.1 → 7.1.0
- `docs-vp/` (cli, config, roadmap, index) + regenerated `llms.txt`/`llms-full.txt`

## Test plan
- [x] `node test/integration/all.js` — 72/72
- [x] `npm test` — 23/23
- [x] Supply-chain gate (PR #261)

After merge: tag `v7.1.0` on the main merge commit → triggers npm publish + release binaries.