### PR TITLE
feat(ci): bundle integrity check — catch missing __factories pre-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+      - name: Bundle integrity (src/ modules present in gen-context.js __factories)
+        run: node scripts/check-bundle.mjs
       - name: Run unit tests
         run: node test/run.js
       - name: Run integration tests

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "health": "node gen-context.js --health",
     "map": "node gen-project-map.js",
     "mcp": "node gen-context.js --mcp",
+    "check:bundle": "node scripts/check-bundle.mjs",
     "build:binary": "node scripts/build-binary.mjs",
     "verify:binary": "node scripts/verify-binary.mjs",
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:llms": "node scripts/generate-llms.mjs",
     "validate:llms": "node scripts/validate-llms.mjs",
-    "prepublishOnly": "node scripts/generate-llms.mjs"
+    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/generate-llms.mjs"
   },
   "files": [
     "gen-context.js",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -50,32 +50,12 @@ log('── Phase A: build standalone binary ───────────�
 
 // 1. Pre-flight: ensure all src/ modules are present in gen-context.js __factories
 {
-  const { readdirSync, readFileSync } = await import('fs');
-  const { join: pjoin } = await import('path');
-  const bundle = readFileSync(join(ROOT, 'gen-context.js'), 'utf8');
-
-  function walkSrc(dir) {
-    const entries = readdirSync(dir, { withFileTypes: true });
-    const files = [];
-    for (const e of entries) {
-      const full = pjoin(dir, e.name);
-      if (e.isDirectory()) files.push(...walkSrc(full));
-      else if (e.isFile() && e.name.endsWith('.js')) files.push(full);
-    }
-    return files;
-  }
-
-  const srcDir = join(ROOT, 'src');
-  const missing = [];
-  for (const file of walkSrc(srcDir)) {
-    const key = './' + file.slice(ROOT.length).replace(/\.js$/, '').replace(/\\/g, '/');
-    if (!bundle.includes(`"${key}"`)) missing.push(key);
-  }
-
+  const { findMissingFactories } = await import('./check-bundle.mjs');
+  const missing = findMissingFactories(ROOT);
   if (missing.length > 0) {
     console.error('\nERROR: The following src/ modules are missing from gen-context.js __factories:');
     for (const m of missing) console.error(`  ${m}`);
-    console.error('\nAdd them to gen-context.js before building the binary.');
+    console.error('\nRun `node scripts/check-bundle.mjs --fix` to add them, then commit gen-context.js.');
     process.exit(1);
   }
   ok('bundle pre-flight: all src/ modules present in gen-context.js');

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * check-bundle.mjs — bundle integrity gate
+ *
+ * The shipped `gen-context.js` embeds a `__factories` copy of every `src/`
+ * module so it can run standalone (no `src/` present) — e.g. the SEA binaries.
+ * A new `src/` module that isn't registered there breaks the standalone build.
+ * This script verifies every `src/` module is present in `__factories`.
+ *
+ * Usage:
+ *   node scripts/check-bundle.mjs          # check; exit 1 if any module is missing
+ *   node scripts/check-bundle.mjs --fix    # generate + insert factories for missing modules
+ *
+ * Exit codes: 0 = in sync, 1 = missing factories (check mode) or write error.
+ *
+ * Zero dependencies. Used by CI (every PR), prepublishOnly, and build-binary.mjs.
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const BUNDLE = join(ROOT, 'gen-context.js');
+
+/** Recursively list .js files under a directory. */
+function walk(dir) {
+  const out = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (e.isFile() && e.name.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+/** Bundle key for a src file relative to `root`, e.g. "./src/tracking/logger". */
+function keyFor(file, root) {
+  return './' + file.slice(root.length).replace(/\.js$/, '').replace(/\\/g, '/').replace(/^\//, '');
+}
+
+/**
+ * Return the list of src/ module keys missing from gen-context.js __factories.
+ * @param {string} [root]
+ * @returns {string[]}
+ */
+export function findMissingFactories(root = ROOT) {
+  const bundle = readFileSync(join(root, 'gen-context.js'), 'utf8');
+  const missing = [];
+  for (const file of walk(join(root, 'src'))) {
+    const key = keyFor(file, root);
+    if (!bundle.includes(`"${key}"`)) missing.push(key);
+  }
+  return missing;
+}
+
+/** Generate a factory block for a module key, from its source file. */
+export function generateFactory(key) {
+  const file = join(ROOT, key.replace(/^\.\//, '') + '.js');
+  let body = readFileSync(file, 'utf8');
+  body = body.replace(/^'use strict';\s*\n+/, '');
+  const dir = dirname(key); // e.g. ./src/tracking
+  // Rewrite local (./ or ../) requires to bundle __require keys.
+  body = body.replace(/require\((['"])(\.\.?\/[^'"]+)\1\)/g, (_m, _q, rel) => {
+    const parts = (dir + '/' + rel).split('/');
+    const resolved = [];
+    for (const p of parts) {
+      if (p === '.' || p === '') continue;
+      if (p === '..') resolved.pop();
+      else resolved.push(p);
+    }
+    return `__require('./${resolved.join('/')}')`;
+  });
+  body = body.replace(/\s+$/, '');
+  const indented = body.split('\n').map((l) => (l.length ? '  ' + l : l)).join('\n');
+  return `// ── ${key} ──\n__factories["${key}"] = function(module, exports) {\n  \n${indented}\n  \n};`;
+}
+
+/** Insert factory blocks for the given missing keys into gen-context.js. */
+function insertFactories(missing) {
+  let content = readFileSync(BUNDLE, 'utf8');
+  // Anchor: insert right before the last factory's closing so new blocks land
+  // inside the factory section. Use the first factory header as the anchor and
+  // prepend new blocks just after it.
+  const anchor = content.indexOf('\n__factories[');
+  if (anchor === -1) throw new Error('no __factories section found in gen-context.js');
+  const blocks = missing.map(generateFactory).join('\n\n');
+  content = content.slice(0, anchor + 1) + blocks + '\n\n' + content.slice(anchor + 1);
+  writeFileSync(BUNDLE, content);
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main() {
+  const fix = process.argv.includes('--fix');
+  const missing = findMissingFactories();
+
+  if (missing.length === 0) {
+    console.log('✓ bundle integrity: all src/ modules present in gen-context.js __factories');
+    return 0;
+  }
+
+  if (fix) {
+    insertFactories(missing);
+    console.log(`✓ bundle: inserted ${missing.length} missing factor${missing.length === 1 ? 'y' : 'ies'}:`);
+    for (const k of missing) console.log(`    + ${k}`);
+    // re-check
+    const still = findMissingFactories();
+    if (still.length) {
+      console.error('ERROR: still missing after --fix:', still.join(', '));
+      return 1;
+    }
+    return 0;
+  }
+
+  console.error('ERROR: the following src/ modules are missing from gen-context.js __factories:');
+  for (const k of missing) console.error(`  ${k}`);
+  console.error('\nRun `node scripts/check-bundle.mjs --fix` to add them, then commit gen-context.js.');
+  return 1;
+}
+
+// Run as CLI only when invoked directly (not when imported).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main());
+}

--- a/test/integration/bundle-integrity.test.js
+++ b/test/integration/bundle-integrity.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Bundle integrity check (scripts/check-bundle.mjs).
+ * Guards the gap that broke the v7.1.0 binaries: a src/ module not registered
+ * in gen-context.js __factories. Run: node test/integration/bundle-integrity.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'scripts', 'check-bundle.mjs');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+(async () => {
+  const mod = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
+  const { findMissingFactories, generateFactory } = mod;
+
+  // ── current bundle is in sync (acceptance: passes on current) ──────────────
+  test('findMissingFactories: real bundle has no missing src/ modules', () => {
+    assert.deepStrictEqual(findMissingFactories(ROOT), []);
+  });
+
+  test('CLI: check passes (exit 0) on the current repo', () => {
+    const out = execFileSync(process.execPath, [SCRIPT], { cwd: ROOT, encoding: 'utf8' });
+    assert.ok(/all src\/ modules present/.test(out), out);
+  });
+
+  // ── detects a missing module (hermetic temp root) ──────────────────────────
+  test('findMissingFactories: detects a src/ module absent from __factories', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-bundle-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'src', 'sub'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src', 'a.js'), 'module.exports={};\n');
+      fs.writeFileSync(path.join(dir, 'src', 'sub', 'b.js'), 'module.exports={};\n');
+      // bundle registers only a, not sub/b
+      fs.writeFileSync(path.join(dir, 'gen-context.js'),
+        '__factories["./src/a"] = function(module, exports) {};\n');
+      const missing = findMissingFactories(dir);
+      assert.deepStrictEqual(missing, ['./src/sub/b']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── generated factory is loadable + rewrites local requires (--fix output) ──
+  test('generateFactory: produces a working factory with __require rewrites', () => {
+    // aggregate requires ./pricing — both must load via the bundle harness.
+    const harness = `
+      const __factories = {}; const __cache = {};
+      function __require(key){
+        if (__cache[key]) return __cache[key].exports;
+        const m = { exports: {} }; __cache[key] = m; __factories[key](m, m.exports);
+        return m.exports;
+      }
+      ${generateFactory('./src/tracking/pricing')}
+      ${generateFactory('./src/tracking/aggregate')}
+      module.exports = __require('./src/tracking/aggregate');
+    `;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-fac-'));
+    try {
+      const f = path.join(dir, 'harness.js');
+      fs.writeFileSync(f, harness);
+      const agg = require(f);
+      assert.strictEqual(typeof agg.aggregate, 'function', 'aggregate export missing');
+      // exercise it — proves __require('./pricing') rewrite resolved
+      const out = agg.aggregate([{ ts: '2026-01-01T00:00:00Z', op: 'ask', baselineTokens: 100, actualTokens: 10 }]);
+      assert.strictEqual(out.totals.saved, 90);
+      assert.ok(out.price && out.price.perMtok > 0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  console.log(`\nbundle-integrity: ${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();


### PR DESCRIPTION
Closes #266.

## Summary
Prevents the failure that broke v7.1.0's binaries: a new `src/` module not registered in `gen-context.js` `__factories` was only caught by the **Release Binaries** workflow at tag time. This moves the gate to **every PR** + `prepublishOnly`.

## Changes
- **scripts/check-bundle.mjs** (new): verifies every `src/` module is in `__factories`; exit 1 with a clear report if any are missing. `--fix` generates + inserts factories from source (rewriting local `require` → `__require`).
- **.github/workflows/ci.yml**: runs `check-bundle` on every PR (Node 18/20/22) — fail fast, pre-merge.
- **package.json**: `check:bundle` script; `prepublishOnly` runs it before publish.
- **scripts/build-binary.mjs**: reuses the shared `findMissingFactories` (single source of truth, no duplicated walk logic).
- **test/integration/bundle-integrity.test.js**: present / missing-detection / generated-factory-loads coverage.

## Scope note
This is the safe, high-value slice of IMPROVEMENT_PLAN P0. Full byte-for-byte bundle *regeneration* was evaluated and rejected — only 6/108 hand-maintained factories reproduce byte-identically, so wholesale regen would churn massively and risk the working bundle. The **missing-factory check is exactly the gap that failed**, and is low-risk. Remaining P0/P1/P2 items (version.json auto-gen, branch pruning, health-score clarity, GIF slimming, RELEASING.md) stay as follow-ups.

## Test plan
- [x] `node test/integration/bundle-integrity.test.js` — 4/4
- [x] `node test/integration/all.js` — 73/73
- [x] `npm test` — 23/23
- [x] `node scripts/check-bundle.mjs` exit 0; `--fix` inserts a working factory
- [x] build-binary preflight passes via shared check
- [x] Supply-chain gate: no shell in published surface, scripts/ not packaged