### PR TITLE
feat(release): derive version.json metadata + gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "map": "node gen-project-map.js",
     "mcp": "node gen-context.js --mcp",
     "check:bundle": "node scripts/check-bundle.mjs",
+    "check:version-meta": "node scripts/check-version-meta.mjs",
     "build:binary": "node scripts/build-binary.mjs",
     "verify:binary": "node scripts/verify-binary.mjs",
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:llms": "node scripts/generate-llms.mjs",
     "validate:llms": "node scripts/validate-llms.mjs",
-    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/generate-llms.mjs"
+    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/check-version-meta.mjs && node scripts/generate-llms.mjs"
   },
   "files": [
     "gen-context.js",

--- a/scripts/check-version-meta.mjs
+++ b/scripts/check-version-meta.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * check-version-meta.mjs — keep version.json's derived counts honest.
+ *
+ * `version.json` carries metadata that must match the source of truth:
+ *   - mcp_tools : number of MCP tools (src/mcp/tools.js `TOOLS`)
+ *   - tests     : number of test files (test/**\/*.test.js + tests/**\/*.py)
+ *
+ * `languages` is intentionally NOT derived — the extractor files include
+ * non-language helpers (line-anchor, prdiff, todos, deps…) and dupes, so the
+ * curated language count is editorial and stays hand-maintained.
+ *
+ * Usage:
+ *   node scripts/check-version-meta.mjs        # check; exit 1 on drift
+ *   node scripts/check-version-meta.mjs --fix  # write derived values
+ *
+ * Zero dependencies. Wired into prepublishOnly so a stale value blocks publish.
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const require = createRequire(import.meta.url);
+
+/** Count files under `dir` (recursive) whose name matches `re`. */
+function countFiles(dir, re) {
+  let n = 0;
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return 0; }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) n += countFiles(full, re);
+    else if (e.isFile() && re.test(e.name)) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Compute the derived metadata from source.
+ * @param {string} [root]
+ * @returns {{ mcp_tools: number, tests: number }}
+ */
+export function computeMeta(root = ROOT) {
+  const { TOOLS } = require(join(root, 'src/mcp/tools.js'));
+  const tests =
+    countFiles(join(root, 'test'), /\.test\.js$/) +
+    countFiles(join(root, 'tests'), /\.py$/);
+  return { mcp_tools: TOOLS.length, tests };
+}
+
+/** Fields that are derived and gated. */
+const DERIVED = ['mcp_tools', 'tests'];
+
+function readVersionJson(root) {
+  return JSON.parse(readFileSync(join(root, 'version.json'), 'utf8'));
+}
+
+/**
+ * Return drift entries where version.json disagrees with computed values.
+ * @param {string} [root]
+ * @returns {Array<{field:string, actual:number, expected:number}>}
+ */
+export function findMetaDrift(root = ROOT) {
+  const vj = readVersionJson(root);
+  const meta = computeMeta(root);
+  const drift = [];
+  for (const f of DERIVED) {
+    if (vj[f] !== meta[f]) drift.push({ field: f, actual: vj[f], expected: meta[f] });
+  }
+  return drift;
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main() {
+  const fix = process.argv.includes('--fix');
+  const drift = findMetaDrift();
+
+  if (drift.length === 0) {
+    const m = computeMeta();
+    console.log(`✓ version.json metadata current (mcp_tools=${m.mcp_tools}, tests=${m.tests})`);
+    return 0;
+  }
+
+  if (fix) {
+    // Preserve formatting/order: only rewrite the drifted numeric fields in place.
+    let raw = readFileSync(join(ROOT, 'version.json'), 'utf8');
+    for (const d of drift) {
+      const re = new RegExp(`("${d.field}"\\s*:\\s*)\\d+`);
+      raw = raw.replace(re, `$1${d.expected}`);
+    }
+    writeFileSync(join(ROOT, 'version.json'), raw);
+    console.log('✓ version.json updated:');
+    for (const d of drift) console.log(`    ${d.field}: ${d.actual} → ${d.expected}`);
+    return 0;
+  }
+
+  console.error('ERROR: version.json metadata is stale:');
+  for (const d of drift) console.error(`  ${d.field}: ${d.actual} (source says ${d.expected})`);
+  console.error('\nRun `node scripts/check-version-meta.mjs --fix` to update it, then commit version.json.');
+  return 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main());
+}

--- a/test/integration/version-meta.test.js
+++ b/test/integration/version-meta.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * version.json metadata gate (scripts/check-version-meta.mjs).
+ * Ensures derived counts (mcp_tools, tests) stay in sync with source.
+ * Run: node test/integration/version-meta.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'scripts', 'check-version-meta.mjs');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+(async () => {
+  const mod = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
+  const { computeMeta, findMetaDrift } = mod;
+
+  test('computeMeta: mcp_tools matches TOOLS length', () => {
+    const { TOOLS } = require(path.join(ROOT, 'src/mcp/tools.js'));
+    assert.strictEqual(computeMeta(ROOT).mcp_tools, TOOLS.length);
+  });
+
+  test('computeMeta: tests count is a positive integer', () => {
+    const { tests } = computeMeta(ROOT);
+    assert.ok(Number.isInteger(tests) && tests > 0, `tests=${tests}`);
+  });
+
+  test('version.json is in sync (no drift) on the committed repo', () => {
+    assert.deepStrictEqual(findMetaDrift(ROOT), []);
+  });
+
+  test('CLI: check passes (exit 0) on the current repo', () => {
+    const out = execFileSync(process.execPath, [SCRIPT], { cwd: ROOT, encoding: 'utf8' });
+    assert.ok(/metadata current/.test(out), out);
+  });
+
+  test('findMetaDrift: detects a tampered version.json (hermetic temp root)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-vmeta-'));
+    try {
+      // minimal fake repo: src/mcp/tools.js with 2 tools, one test file
+      fs.mkdirSync(path.join(dir, 'src', 'mcp'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src', 'mcp', 'tools.js'),
+        'module.exports = { TOOLS: [{name:"a"},{name:"b"}] };\n');
+      fs.writeFileSync(path.join(dir, 'test', 'x.test.js'), '// test\n');
+      fs.writeFileSync(path.join(dir, 'version.json'),
+        JSON.stringify({ version: '1.0.0', mcp_tools: 99, tests: 1, languages: 31 }, null, 2));
+      const drift = findMetaDrift(dir);
+      const fields = drift.map((d) => d.field).sort();
+      assert.deepStrictEqual(fields, ['mcp_tools']); // tests=1 matches, mcp_tools 99≠2
+      assert.strictEqual(drift[0].expected, 2);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('languages is left editorial (not in derived drift set)', () => {
+    const drift = findMetaDrift(ROOT);
+    assert.ok(!drift.some((d) => d.field === 'languages'));
+  });
+
+  console.log(`\nversion-meta: ${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 11,
-  "tests": 60,
+  "tests": 80,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #268.

## Summary
`version.json` carried hand-typed counts that drift (`tests: 60` was stale). This derives them from source and gates them so a release can't ship stale metadata.

## Changes
- **scripts/check-version-meta.mjs** (new): derives `mcp_tools` (from `src/mcp/tools.js` `TOOLS`) and `tests` (test-file count); `--fix` writes them, default exits 1 on drift.
- **package.json**: `check:version-meta` script; `prepublishOnly` runs it before publish.
- **version.json**: `tests` 60 → 80 (corrected).
- **test/integration/version-meta.test.js**: derivation + tampered-drift coverage.

## Scope note
`languages` (31) is left editorial — the 41 extractor files include non-language helpers (line-anchor, prdiff, todos, deps…) and dupes, so it's a curated count, not auto-derivable. The audit's '31 vs 41' was a false-positive; not changed.

## Test plan
- [x] `node test/integration/version-meta.test.js` — 6/6
- [x] `node test/integration/all.js` — 74/74 · `npm test` — 23/23
- [x] check exits 1 on drift, 0 when current; `--fix` corrects
- [x] Supply-chain gate clean (scripts/ not packaged)

Part of IMPROVEMENT_PLAN P1. The other P1 item (branch hygiene) is done directly: auto-delete-on-merge enabled, remote pruned to 3 branches, 41 merged locals removed.