### PR TITLE
fix(health): label extractor coverage as informational

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -14914,7 +14914,8 @@ function main() {
       console.log(`  p50 token count : ${result.p50TokenCount}`);
       console.log(`  p95 token count : ${result.p95TokenCount}`);
       console.log(`  overbudget streak: ${result.overBudgetStreak}`);
-      console.log(`  extractor cover.: ${result.extractorCoverage}%`);
+      console.log(`  repo languages  : ${result.extractorCoverage}% of supported langs used here (informational — not scored)`);
+      console.log(`  ${'score basis'.padEnd(16)}: staleness · token reduction · over-budget rate`);
     }
     process.exit(0);
   }


### PR DESCRIPTION
Closes #270.

## Summary
`sigmap --health` showed `score: 100/100` next to `extractor cover.: 9.5%` — contradictory at a glance. That number is (languages present in this repo) / (all supported languages), which is healthy-but-low for a single-language project and is **not** part of the score. Relabel it and state the score basis.

## Changes
- `gen-context.js` (--health display): `extractor cover.: 9.5%` → `repo languages: 9.5% of supported langs used here (informational — not scored)`, plus a `score basis: staleness · token reduction · over-budget rate` line.
- `--health --json` `extractorCoverage` field unchanged (consumer contract).

## Test plan
- [x] `node test/integration/all.js` — 74/74 · `npm test` — 23/23
- [x] dashboard test (extractorCoverage json contract) passes
- [x] `--health` exits 0; output now self-explanatory

IMPROVEMENT_PLAN P2 (item 1 of 2).