### PR TITLE
feat(ci): standalone-bundle smoke test + RELEASING.md

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing SigMap
+
+The release pipeline is split between two skills and the branch model. **Run order is always `/update-docs` → `/ship`.**
+
+## Branch model
+
+```
+feature/fix branches ──PR──▶ develop ──PR──▶ main ──tag vX.Y.Z──▶ npm + binaries
+```
+
+- Contributor work targets **`develop`** (the integration branch).
+- `develop` is promoted to **`main`** via PR; the **tag is cut on `main`'s merge commit**.
+- Both branches are protected (PR + status checks). Merge protected branches as the **owner** (ruleset bypass) or via PR — never the `github-actions[bot]` token.
+- Auto-delete-head-branches is enabled, so merged PR branches clean themselves up.
+
+## Step 1 — `/update-docs` (version + changelog authority)
+
+Run on `develop` (or a `docs/release-vX.Y.Z` branch cut from it). It owns the version number and `CHANGELOG.md`:
+
+1. Detects everything merged into `develop` since the last tag (including external PRs).
+2. Computes the semver bump (`feat:` → minor, `fix:`/`chore:` → patch, `!`/`BREAKING` → major).
+3. Writes the `CHANGELOG.md` entry and syncs every version-bearing file via `scripts/sync-versions.mjs` (`package.json` ×3, `gen-context.js` `VERSION`, `src/mcp/server.js`). Sets `version.json` `version`.
+4. Runs benchmarks and refreshes docs (`docs-vp/`, README, SVGs) + regenerates `llms.txt` / `llms-full.txt`.
+5. Commits as `chore(release): vX.Y.Z …` and pushes (owner or `docs/release-vX.Y.Z` PR into `develop`).
+
+`version.json` numeric metadata (`mcp_tools`, `tests`) is derived — `scripts/check-version-meta.mjs` keeps it honest. `languages` is editorial (the extractor files include non-language helpers/dupes).
+
+## Step 2 — `/ship` (tag, PR, release)
+
+`/ship` does **not** bump the version or write the changelog — it ships what `/update-docs` prepared:
+
+1. **Detects the prepared release**: if `package.json` version === top `CHANGELOG.md` version and no `vX.Y.Z` tag exists → PREPARED (skip any bump). If a tag already exists → already shipped, stop.
+2. Confirms a clean tree and a green suite.
+3. Lands the release commit on `main` (PR `develop` → `main`, merged by the owner).
+4. **Tags the `main` merge commit** (`git tag -a vX.Y.Z <merge-commit>`) and pushes the tag.
+5. Creates the GitHub Release from the `CHANGELOG.md` section (a tag-triggered workflow may auto-create it).
+
+## What the tag triggers
+
+Pushing `vX.Y.Z` fires two workflows in parallel:
+
+- **`npm-publish.yml`** — publishes to npm (`--provenance`) + GitHub Packages. ⚠️ No "already-published" guard: re-pushing an existing version's tag makes this job fail. The GIFs are excluded from the tarball (only the `files` allowlist ships).
+- **`release-binaries.yml`** — builds standalone SEA binaries (darwin-arm64, linux-x64, win32-x64) via `scripts/build-binary.mjs` and attaches them + checksums to the Release.
+
+## Gates (must stay green)
+
+| Gate | Where | Catches |
+|---|---|---|
+| `scripts/check-bundle.mjs` | CI (every PR) + `prepublishOnly` + `build-binary` preflight | a `src/` module missing from `gen-context.js` `__factories` (breaks the standalone binary) |
+| `scripts/check-version-meta.mjs` | `prepublishOnly` | stale `version.json` metadata |
+| unit + integration (`test/integration/all.js`) | CI on Node 18/20/22 | regressions; includes a **standalone-bundle smoke test** that runs `gen-context.js` with no `src/` present |
+
+## Re-tagging (recovery only)
+
+Only delete + recreate a pushed tag when the prior pipeline failed **and** the maintainer asks. Tag the fixed, merged `main` commit. Expect `npm-publish` to fail (the version is already on npm) — that job is cosmetic on a re-tag; the goal is rebuilding the binaries.
+
+## The bundle (`gen-context.js`)
+
+The shipped CLI is a single 569 KB file: hand-authored CLI logic + a `__factories` copy of every `src/` (and `packages/adapters/`) module so it runs with no `src/` present (npx ships `src/` too; the SEA binaries do not). When you add a `src/` module, register it: `node scripts/check-bundle.mjs --fix`, then commit `gen-context.js`. Full byte-level regeneration is intentionally not automated — the factory bodies are hand-maintained and only the *presence* check is enforced.

--- a/test/integration/bundle-smoke.test.js
+++ b/test/integration/bundle-smoke.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Standalone-bundle smoke test.
+ *
+ * Copies gen-context.js into a temp dir with NO src/ beside it, then runs it on
+ * a fixture project. This forces the bundled __factories path (the same code the
+ * SEA binaries use) instead of requireSourceOrBundled finding the repo's src/.
+ * It catches a bundle that can't actually run — the functional complement to
+ * scripts/check-bundle.mjs (which only checks factory presence).
+ *
+ * Runs in the Node 18/20/22 CI matrix via test/integration/all.js.
+ * Run directly: node test/integration/bundle-smoke.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+/** Build an isolated bundle dir (gen-context.js only) + a fixture project. */
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-smoke-'));
+  const bundle = path.join(dir, 'gen-context.js');
+  fs.copyFileSync(path.join(ROOT, 'gen-context.js'), bundle);
+  // sanity: no src/ next to the bundle → factories are the only resolution path
+  assert.ok(!fs.existsSync(path.join(dir, 'src')), 'bundle dir must not contain src/');
+
+  const proj = path.join(dir, 'proj');
+  fs.mkdirSync(path.join(proj, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(proj, 'src', 'a.js'),
+    'function alpha(x){ return x + 1; }\nclass Beta { go(){ return 2; } }\nmodule.exports = { alpha, Beta };\n');
+  fs.writeFileSync(path.join(proj, 'gen-context.config.json'),
+    JSON.stringify({ outputs: ['claude'], srcDirs: ['src'] }, null, 2));
+  return { dir, bundle, proj };
+}
+
+test('standalone bundle: generate produces output (no src/ beside bundle)', () => {
+  const { dir, bundle, proj } = setup();
+  try {
+    execFileSync(process.execPath, [bundle], { cwd: proj, stdio: 'ignore' });
+    const out = path.join(proj, 'CLAUDE.md');
+    assert.ok(fs.existsSync(out), 'CLAUDE.md not generated');
+    const body = fs.readFileSync(out, 'utf8');
+    assert.ok(/alpha|Beta/.test(body), 'generated context missing fixture signatures');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('standalone bundle: --health --json runs through factories', () => {
+  const { dir, bundle, proj } = setup();
+  try {
+    execFileSync(process.execPath, [bundle], { cwd: proj, stdio: 'ignore' }); // generate first
+    const out = execFileSync(process.execPath, [bundle, '--health', '--json'], { cwd: proj, encoding: 'utf8' });
+    const health = JSON.parse(out);
+    assert.ok(typeof health.score === 'number' && health.score >= 0 && health.score <= 100, `score=${health.score}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('standalone bundle: gain runs (gain modules load from factories)', () => {
+  const { dir, bundle, proj } = setup();
+  try {
+    execFileSync(process.execPath, [bundle], { cwd: proj, stdio: 'ignore' });
+    // gain with no log yet → empty-state, must still exit 0
+    const out = execFileSync(process.execPath, [bundle, 'gain', '--json'], { cwd: proj, encoding: 'utf8' });
+    const agg = JSON.parse(out);
+    assert.ok(agg.totals && typeof agg.totals.count === 'number', 'gain --json missing totals');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+console.log(`\nbundle-smoke: ${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 11,
-  "tests": 80,
+  "tests": 81,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #274. IMPROVEMENT_PLAN **P3** (final item).

## Summary
- **Standalone-bundle smoke test** (`test/integration/bundle-smoke.test.js`): copies `gen-context.js` to a temp dir with **no `src/` beside it** and runs `generate` + `--health --json` + `gain --json` on a fixture — exercising the `__factories` path the SEA binaries use. This is the *functional* complement to `check-bundle.mjs` (which only checks factory presence) and runs in the existing Node 18/20/22 matrix.
- **docs/RELEASING.md**: the release flow written down — branch model, `/update-docs` → `/ship`, develop→main, tag→npm+binaries, the gates, and re-tag recovery.
- **version.json**: `tests` 80 → 81 — the new test, auto-surfaced by the P1 `check-version-meta` gate (nice end-to-end proof the gate works).

## Test plan
- [x] `node test/integration/bundle-smoke.test.js` — 3/3 (runs bundle with no src/)
- [x] `node test/integration/all.js` — 75/75 · `npm test` — 23/23
- [x] `check-bundle` + `check-version-meta` gates green
- [x] Supply-chain: no shell added; `docs/` + test not shipped to npm