### PR TITLE
chore(release): v7.2.0 — release-pipeline robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.2.0] — 2026-06-17
+
+Minor release — release-pipeline robustness. Hardens the bundle/release machinery that produced the v7.1.0 binary failure, with no user-facing CLI changes.
+
+### Added
+- **Bundle integrity check (#266):** `scripts/check-bundle.mjs` verifies every `src/` module is registered in `gen-context.js` `__factories` (the standalone/SEA-binary code path). Runs in CI on every PR (Node 18/20/22) and in `prepublishOnly`; `--fix` inserts missing factories from source. `build-binary.mjs` reuses the same check. Catches — before merge — the gap that broke the v7.1.0 binaries.
+- **version.json metadata gate (#268):** `scripts/check-version-meta.mjs` derives `mcp_tools` (from `src/mcp/tools.js`) and `tests` (test-file count) and fails on drift; wired into `prepublishOnly`. `languages` stays editorial. Corrected stale `tests` count.
+- **Standalone-bundle smoke test (#274):** runs `gen-context.js` from a temp dir with no `src/` present (the binary path) — `generate` + `--health` + `gain` — in the Node 18/20/22 matrix. Functional complement to the presence check.
+- **`docs/RELEASING.md` (#274):** documents the release flow, branch model, tag triggers, and the prepublish/CI gates.
+
+### Fixed
+- **`--health` clarity (#270):** the per-repo "extractor coverage" line (languages present in this repo ÷ supported) read as contradictory beside a 100/100 score. Relabeled as informational ("repo languages … not scored") with a "score basis" line. The `--health --json` `extractorCoverage` field is unchanged.
+
+### Changed
+- **Repo declutter (#272):** removed the committed, unreferenced `TESTING_IMPORT_GRAPH.md` (gitignored); stale planning docs archived out of the repo. `PROJECT_MAP.md` kept (live generated artifact).
+
+---
+
 ## [7.1.0] — 2026-06-16
 
 Minor release — a token-savings dashboard in the terminal, plus domain and sponsorship docs.

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.1.0, with recent releases adding the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, full-signatures-under-budget, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.2.0, with recent releases adding release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Sixty-two versions shipped. MIT open source from day one.
+Sixty-three versions shipped. MIT open source from day one.
 
 **Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.2.0 — Release-pipeline robustness ✓ (2026-06-17)
+
+**Minor release — build/release hardening, no user-facing CLI changes.** Closes the gap that broke the v7.1.0 standalone binaries (a `src/` module missing from the bundle `__factories`). New **bundle integrity check** (`scripts/check-bundle.mjs`, #266) verifies every `src/` module is registered, runs on every PR (Node 18/20/22) + `prepublishOnly` + the binary preflight, and `--fix` inserts missing factories from source. A **version.json metadata gate** (`scripts/check-version-meta.mjs`, #268) derives `mcp_tools`/`tests` and fails on drift. A **standalone-bundle smoke test** (#274) runs `gen-context.js` with no `src/` present (the binary code path) across the matrix, and **`docs/RELEASING.md`** documents the whole flow. Also: `--health` relabels its informational "extractor coverage" line so it no longer reads as contradictory beside a 100/100 score (#270), and the root was decluttered (#272).
+
+**Tags:** `check-bundle` · `check-version-meta` · `bundle-smoke` · `__factories` · `prepublishOnly-gates` · `RELEASING.md` · `--health-clarity` · `#266` · `#268` · `#270` · `#272` · `#274`
+
+**Impact:** the bundle-drift class of release failures is now caught pre-merge and pre-publish (presence + functional smoke); release flow documented; version.json metadata self-checks.
+
+---
+
 ### v7.1.0 — Token-savings dashboard (sigmap gain) ✓ (2026-06-16)
 
 **Minor release.** New **`sigmap gain`** (#260) surfaces cumulative token savings right in the terminal — total tokens saved, % efficiency, estimated dollars, average latency, and a per-operation breakdown — with `gain --all` for daily / weekly / monthly trends. Savings are captured automatically: every `ask` and `generate` run appends a counts-only record to a dedicated local log `.context/gain.ndjson` (no file paths, source, or query text). Capture is **default-on** and privacy-safe; opt out with `--no-track`, `SIGMAP_NO_TRACK=1`, or `config.gainTracking:false`, and the legacy `usage.ndjson` / `--track` health log is untouched. New zero-dep `src/tracking/{aggregate,pricing}.js` and `src/format/gain-terminal.js` (ANSI renderer, `NO_COLOR`/non-TTY safe). "Saved" is labeled everywhere as an estimate vs the whole-file baseline. Also in this release: docs served at the sigmap.io root (#258) and a transparent Sponsor section (#257).
@@ -860,7 +870,7 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.2+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.3+ (PR verification + Interactive Context Explorer)
 
 v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.1.0</span>
+  <span><strong>Release:</strong> v7.2.0</span>
   <span>·</span>
-  <span>New <code>sigmap gain</code> — terminal token-savings dashboard (tokens saved, %, est. $, daily/weekly/monthly trends), privacy-safe and local-only</span>
+  <span>Release-pipeline robustness — bundle integrity check + version.json gate + standalone-bundle smoke test guard every release; <code>sigmap gain</code> dashboard (v7.1.0) still shipping</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6254,7 +6254,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.1.0',
+  version: '7.2.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 
@@ -11499,7 +11499,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.1.0';
+const VERSION = '7.2.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.1.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.1.0',
+  version: '7.2.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.0",
+  "version": "7.2.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
Release prep for **v7.2.0** (via `/update-docs`). `/ship` will tag + publish after merge.

## Version
- **7.1.0 → 7.2.0** (minor — three `feat:` commits since v7.1.0). Synced across package.json ×3, gen-context.js, src/mcp/server.js; version.json version bumped.

## What's in it (all internal hardening — no user-facing CLI changes)
- Bundle integrity check (#266), version.json metadata gate (#268), standalone-bundle smoke test + `docs/RELEASING.md` (#274), `--health` clarity (#270), root declutter (#272).

## Docs
- CHANGELOG v7.2.0; roadmap v7.2.0 entry + milestone → v7.3+; index release banner; regenerated llms.txt/llms-full.txt.
- Phases 2 (CLI ref) & 4 (config) were no-ops — no new `sigmap` commands or config keys.

## Benchmarks
Re-run and **reproduced** (no extraction/ranking changes): 97% token reduction, 75.6% hit@5 (13.6% baseline), 39% prompt reduction. version.json metrics + benchmark_date unchanged.

## Next
Merge into develop, then `/ship` to tag v7.2.0 + cut the release.