### PR TITLE
fix(ask): realistic baseline — surfaced files, not the whole repo

### DIFF
--- a/docs-vp/guide/ask.md
+++ b/docs-vp/guide/ask.md
@@ -27,7 +27,7 @@ Intent      : debug
 Context     : .context/query-context.md
 Coverage    : 96%
 Risk        : LOW
-Cost        : saved 98%
+Cost        : saved 92%
 Top files   : src/auth/service.js, src/auth/token.js, src/http/middleware.js
 ```
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -13807,7 +13807,15 @@ function main() {
     let coveragePct = 0;
     try { coveragePct = coverageScore(cwd, fakeEntries, config).score; } catch (_) {}
 
-    const rawTok = getRawTokenCount(cwd, config);
+    // Realistic baseline: the full content of the files SigMap actually surfaced
+    // for this query. Without SigMap you'd read these files in full; SigMap gives
+    // you their signatures instead — so this is the true per-query saving. Falls
+    // back to the whole-repo count only if nothing ranked.
+    let rawTok = 0;
+    for (const r of ranked) {
+      try { rawTok += estimateTokens(fs.readFileSync(path.join(cwd, r.file), 'utf8')); } catch (_) {}
+    }
+    if (rawTok === 0) rawTok = getRawTokenCount(cwd, config);
     const savings = rawTok > 0 ? Math.round((1 - ctxTok / rawTok) * 100) : 0;
     const model = args[args.indexOf('--model') + 1] || 'gpt-4o';
     const rateK = MODEL_COSTS[model] || MODEL_COSTS['gpt-4o'];


### PR DESCRIPTION
Closes #278.

## Summary
`sigmap gain` baseline read too high (e.g. 124 ops → 15.6M) because every `ask` assumed feeding the **whole repo** (~127K tok) and summed it per run. Now the `ask` baseline is the **full content of the files SigMap actually surfaced** for that query — the real counterfactual: without SigMap you'd read those files in full; SigMap gives you their signatures.

## Changes
- `gen-context.js` (ask handler): baseline = Σ full-file tokens of the ranked top-K files (fallback to whole-repo only if nothing ranked). Drives the cost line, `--json savingsPct`, and the gain record.
- `generate` baseline unchanged (whole-repo — it indexes every file → signatures).
- `docs-vp/guide/ask.md`: example updated to a realistic %.

## Before / after (this repo)
- ask cost line: `was $0.61 · saved 99%` → `was $0.017 · saved ~92%` (real)
- gain 3-ask baseline: ~380K → **23.3K**; per-op baseline ~127K → ~8K

## Test plan
- [x] real `ask` runs show relevant-file baseline + 90–95% saved
- [x] `node test/integration/all.js` — 75/75 · `npm test` — pass
- [x] savingsPct stays in [0,100] (intent-detection test)
- [x] gain aggregate tests unaffected (synthetic records)