### PR TITLE
Release v7.2.1 — realistic per-query savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.2.1] — 2026-06-17
+
+Patch release — realistic per-query savings.
+
+### Fixed
+- **`ask` / `gain` baseline reflects real usage (#278):** `sigmap ask` measured savings against the *whole repo* (every query assumed feeding the entire source tree), which inflated the `gain` dashboard (cumulative baselines in the millions) and showed ~99% per query. The baseline is now the full content of the files SigMap actually surfaced for the query (the ranked top-K) — the true counterfactual: without SigMap you'd read those files in full; SigMap gives you their signatures. Drives the `ask` cost line, `--json savingsPct`, and the `gain` record. `generate` keeps the whole-repo baseline (it genuinely indexes every file → signatures).
+
+---
+
 ## [7.2.0] — 2026-06-17
 
 Minor release — release-pipeline robustness. Hardens the bundle/release machinery that produced the v7.1.0 binary failure, with no user-facing CLI changes.

--- a/docs-vp/guide/ask.md
+++ b/docs-vp/guide/ask.md
@@ -27,7 +27,7 @@ Intent      : debug
 Context     : .context/query-context.md
 Coverage    : 96%
 Risk        : LOW
-Cost        : saved 98%
+Cost        : saved 92%
 Top files   : src/auth/service.js, src/auth/token.js, src/http/middleware.js
 ```
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.2.0, with recent releases adding release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.2.1, with recent releases adding realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Sixty-three versions shipped. MIT open source from day one.
+Sixty-four versions shipped. MIT open source from day one.
 
 **Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -825,6 +825,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 **Tags:** `verify-ai-output` · `fake-test-file` · `fake-npm-script` · `closest-match` · `--report` · `note` · `status` · `read_memory` · `11 MCP tools` · `PR #232` · `PR #233`
 
 **Impact:** 5-detector Hallucination Guard + heuristic suggestions; 11 MCP tools (was 10); 42 new tests (29 verify + 13 memory); 949 tests passing.
+
+---
+
+### v7.2.1 — Realistic per-query savings ✓ (2026-06-17)
+
+**Patch release.** `sigmap ask` (and the `gain` dashboard) measured savings against the *whole repo* — every query assumed feeding the entire source tree — which inflated `gain` (cumulative baselines in the millions) and showed ~99% per query. The baseline is now the full content of the files SigMap actually surfaced for the query (the ranked top-K): without SigMap you'd read those files in full; SigMap gives you their signatures. Drives the `ask` cost line, `--json savingsPct`, and the `gain` record. `generate` keeps the whole-repo baseline (it genuinely indexes every file → signatures).
+
+**Tags:** `realistic-baseline` · `gain` · `ask` · `surfaced-files` · `#278`
+
+**Impact:** `gain` reports honest savings (e.g. per-`ask` baseline ~127K → ~8K on this repo); per-query reduction now ~90–95% (signatures vs full relevant files) instead of ~99% vs the whole repo.
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.2.0</span>
+  <span><strong>Release:</strong> v7.2.1</span>
   <span>·</span>
-  <span>Release-pipeline robustness — bundle integrity check + version.json gate + standalone-bundle smoke test guard every release; <code>sigmap gain</code> dashboard (v7.1.0) still shipping</span>
+  <span><code>sigmap gain</code> now reports realistic per-query savings (baseline = the files SigMap surfaced, not the whole repo); release-pipeline robustness gates from v7.2.0</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6254,7 +6254,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.2.0',
+  version: '7.2.1',
   description: 'SigMap MCP server — code signatures on demand',
 };
 
@@ -11499,7 +11499,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.2.0';
+const VERSION = '7.2.1';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -13807,7 +13807,15 @@ function main() {
     let coveragePct = 0;
     try { coveragePct = coverageScore(cwd, fakeEntries, config).score; } catch (_) {}
 
-    const rawTok = getRawTokenCount(cwd, config);
+    // Realistic baseline: the full content of the files SigMap actually surfaced
+    // for this query. Without SigMap you'd read these files in full; SigMap gives
+    // you their signatures instead — so this is the true per-query saving. Falls
+    // back to the whole-repo count only if nothing ranked.
+    let rawTok = 0;
+    for (const r of ranked) {
+      try { rawTok += estimateTokens(fs.readFileSync(path.join(cwd, r.file), 'utf8')); } catch (_) {}
+    }
+    if (rawTok === 0) rawTok = getRawTokenCount(cwd, config);
     const savings = rawTok > 0 ? Math.round((1 - ctxTok / rawTok) * 100) : 0;
     const model = args[args.indexOf('--model') + 1] || 'gpt-4o';
     const rateK = MODEL_COSTS[model] || MODEL_COSTS['gpt-4o'];

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.2.0',
+  version: '7.2.1',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.2.0",
+  "version": "7.2.1",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.2.1** to main: `ask`/`gain` realistic baseline (#278), version/changelog/docs prep (#280).

## Test plan
- [x] `node test/integration/all.js` — 75/75
- [x] gates green (check-bundle, check-version-meta)

After merge: tag v7.2.1 on the main merge commit → npm + binaries.