### PR TITLE
Release v7.3.0 — get_callee_signatures MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.3.0] — 2026-06-17
+
+Minor release — a 12th MCP tool that gives agents exact callee signatures before they write.
+
+### Added
+- **`get_callee_signatures` MCP tool (#282):** returns the exact current signature(s) of named symbols (functions, classes, methods) from the index, so an agent never guesses a callee's parameter types from training memory — the highest-ROI step toward grounded code generation. Input `{ symbols: string[] }`; unknown names get a closest-match suggestion (reuses `verify/closest-match`). Brings the MCP server to **12 tools**. Wired into the standalone bundle (regenerated `mcp/*` factories) and validated end-to-end via the bundle-driven MCP test.
+
+---
+
 ## [7.2.1] — 2026-06-17
 
 Patch release — realistic per-query savings.

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,13 +1,13 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 11 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 12 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
       content: "SigMap MCP Server — on-demand codebase context"
   - - meta
     - property: og:description
-      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 11 MCP tools over stdio."
+      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 12 MCP tools over stdio."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/mcp"
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 11 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 12 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 11 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 12 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.2.1, with recent releases adding realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.3.0, with recent releases adding the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Sixty-four versions shipped. MIT open source from day one.
+Sixty-five versions shipped. MIT open source from day one.
 
 **Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.3.0 — `get_callee_signatures` MCP tool ✓ (2026-06-17)
+
+**Minor release.** A 12th MCP tool, `get_callee_signatures`, returns the **exact current signature(s)** of named symbols (functions, classes, methods) from the index — so an agent never guesses a callee's parameter types from training memory. This is the highest-ROI step toward grounded code generation (Layer 2 of the zero-hallucination plan): call it before writing code that uses a symbol. Input `{ symbols: string[] }`; unknown names get a closest-match suggestion. Works against the current index today (Layer 1 live-freshness makes it live later). Wired into the standalone bundle (regenerated `mcp/*` factories) and validated end-to-end via the bundle-driven MCP test.
+
+**Tags:** `get_callee_signatures` · `mcp` · `grounded-codegen` · `callee-signatures` · `closest-match` · `12-tools` · `#282`
+
+**Impact:** MCP server 11 → 12 tools; attacks the #1 code-gen hallucination (wrong parameter types) with ground-truth signatures before write.
+
+---
+
 ### v7.2.1 — Realistic per-query savings ✓ (2026-06-17)
 
 **Patch release.** `sigmap ask` (and the `gain` dashboard) measured savings against the *whole repo* — every query assumed feeding the entire source tree — which inflated `gain` (cumulative baselines in the millions) and showed ~99% per query. The baseline is now the full content of the files SigMap actually surfaced for the query (the ranked top-K): without SigMap you'd read those files in full; SigMap gives you their signatures. Drives the `ask` cost line, `--json savingsPct`, and the `gain` record. `generate` keeps the whole-repo baseline (it genuinely indexes every file → signatures).
@@ -880,7 +890,7 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.3+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.4+ (PR verification + Interactive Context Explorer)
 
 v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.2.1</span>
+  <span><strong>Release:</strong> v7.3.0</span>
   <span>·</span>
-  <span><code>sigmap gain</code> now reports realistic per-query savings (baseline = the files SigMap surfaced, not the whole repo); release-pipeline robustness gates from v7.2.0</span>
+  <span>New <code>get_callee_signatures</code> MCP tool (12 tools) — exact callee signatures from the index before an agent writes a call, so it can't guess parameter types</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -24,7 +24,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 52.2% |
 | Prompts per task | 2.84 | 1.72 (39.4% fewer) |
 | Supported languages | — | 31 |
-| MCP tools | — | 11 |
+| MCP tools | — | 12 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -114,7 +114,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 11 tools
+## MCP server — 12 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -208,6 +208,14 @@ Recall the project decision log — recent notes left by humans or agents across
 
 ```
 Input:  { limit?: number }
+```
+
+### get_callee_signatures
+
+Return the EXACT current signature(s) of named symbols (functions, classes, methods) from the index — so an agent never guesses a callee's parameter types from training memory. Call this before writing code that uses a symbol. Unknown names get a closest-match suggestion.
+
+```
+Input:  { symbols: array }
 ```
 
 ---

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.3.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -27,7 +27,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 52.2% vs 10% without SigMap
 - Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 31 supported · MCP tools: 11
+- Languages: 31 supported · MCP tools: 12
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.3.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -5528,552 +5528,605 @@ __factories["./src/graph/impact"] = function(module, exports) {
 
 // ── ./src/mcp/handlers ──
 __factories["./src/mcp/handlers"] = function(module, exports) {
-'use strict';
+  
+  const fs   = require('fs');
+  const path = require('path');
+  const { git } = __require('./src/util/git');
 
-const fs   = require('fs');
-const path = require('path');
+  const CONTEXT_FILE = path.join('.github', 'copilot-instructions.md');
+  const CONTEXT_COLD_FILE = path.join('.github', 'context-cold.md');
 
-const CONTEXT_FILE = path.join('.github', 'copilot-instructions.md');
-const CONTEXT_COLD_FILE = path.join('.github', 'context-cold.md');
-
-function _readContextFiles(cwd) {
-  const paths = [path.join(cwd, CONTEXT_FILE), path.join(cwd, CONTEXT_COLD_FILE)];
-  const chunks = [];
-  for (const p of paths) {
-    if (fs.existsSync(p)) chunks.push(fs.readFileSync(p, 'utf8'));
-  }
-  return chunks.join('\n');
-}
-
-// Section header keywords in PROJECT_MAP.md
-const MAP_SECTIONS = {
-  imports: '### Import graph',
-  classes: '### Class hierarchy',
-  routes: '### Route table',
-};
-
-/**
- * read_context({ module? }) → string
- *
- * Returns the full context file, or just the sections whose file paths
- * contain the given module substring.
- */
-function readContext(args, cwd) {
-  const content = _readContextFiles(cwd);
-  if (!content) {
-    return 'No context file found. Run: node gen-context.js';
-  }
-
-  if (!args || !args.module) return content;
-
-  const mod = args.module.replace(/\\/g, '/').replace(/\/$/, '');
-  const lines = content.split('\n');
-  const result = [];
-  let capturing = false;
-
-  for (const line of lines) {
-    if (line.startsWith('### ')) {
-      const filePath = line.slice(4).trim().replace(/\\/g, '/');
-      // Match if file path starts with mod or contains /mod/ or /mod
-      capturing =
-        filePath === mod ||
-        filePath.startsWith(mod + '/') ||
-        filePath.includes('/' + mod + '/') ||
-        filePath.includes('/' + mod);
-      if (capturing) result.push(line);
-      continue;
+  function _readContextFiles(cwd) {
+    const paths = [path.join(cwd, CONTEXT_FILE), path.join(cwd, CONTEXT_COLD_FILE)];
+    const chunks = [];
+    for (const p of paths) {
+      if (fs.existsSync(p)) chunks.push(fs.readFileSync(p, 'utf8'));
     }
-    if (capturing) result.push(line);
+    return chunks.join('\n');
   }
 
-  if (result.length === 0) return `No signatures found for module: ${mod}`;
-  return result.join('\n');
-}
+  // Section header keywords in PROJECT_MAP.md
+  const MAP_SECTIONS = {
+    imports: '### Import graph',
+    classes: '### Class hierarchy',
+    routes: '### Route table',
+  };
 
-/**
- * search_signatures({ query }) → string
- *
- * Case-insensitive search through all signature lines.
- * Returns matching lines grouped by file path.
- */
-function searchSignatures(args, cwd) {
-  if (!args || !args.query) return 'Missing required argument: query';
-
-  const query = args.query.toLowerCase();
-  try {
-    const { buildSigIndex } = __require('./src/retrieval/ranker');
-    const index = buildSigIndex(cwd);
-    if (index.size === 0) {
+  /**
+   * read_context({ module? }) → string
+   *
+   * Returns the full context file, or just the sections whose file paths
+   * contain the given module substring.
+   */
+  function readContext(args, cwd) {
+    const content = _readContextFiles(cwd);
+    if (!content) {
       return 'No context file found. Run: node gen-context.js';
     }
 
+    if (!args || !args.module) return content;
+
+    const mod = args.module.replace(/\\/g, '/').replace(/\/$/, '');
+    const lines = content.split('\n');
     const result = [];
-    for (const [file, sigs] of index.entries()) {
-      const hits = sigs.filter((s) => s.toLowerCase().includes(query));
-      if (hits.length === 0) continue;
-      if (result.length > 0) result.push('');
-      result.push(`### ${file}`);
-      result.push(...hits);
+    let capturing = false;
+
+    for (const line of lines) {
+      if (line.startsWith('### ')) {
+        const filePath = line.slice(4).trim().replace(/\\/g, '/');
+        // Match if file path starts with mod or contains /mod/ or /mod
+        capturing =
+          filePath === mod ||
+          filePath.startsWith(mod + '/') ||
+          filePath.includes('/' + mod + '/') ||
+          filePath.includes('/' + mod);
+        if (capturing) result.push(line);
+        continue;
+      }
+      if (capturing) result.push(line);
     }
 
-    if (result.length === 0) return `No signatures found matching: ${args.query}`;
+    if (result.length === 0) return `No signatures found for module: ${mod}`;
     return result.join('\n');
-  } catch (err) {
-    return `_search_signatures failed: ${err.message}_`;
-  }
-}
-
-/**
- * get_map({ type }) → string
- *
- * Returns a section from PROJECT_MAP.md.
- * type: 'imports' | 'classes' | 'routes'
- */
-function getMap(args, cwd) {
-  if (!args || !args.type) return 'Missing required argument: type';
-
-  const header = MAP_SECTIONS[args.type];
-  if (!header) {
-    return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
   }
 
-  const mapPath = path.join(cwd, 'PROJECT_MAP.md');
-  if (!fs.existsSync(mapPath)) {
-    return 'PROJECT_MAP.md not found. Run: node gen-project-map.js';
-  }
+  /**
+   * search_signatures({ query }) → string
+   *
+   * Case-insensitive search through all signature lines.
+   * Returns matching lines grouped by file path.
+   */
+  function searchSignatures(args, cwd) {
+    if (!args || !args.query) return 'Missing required argument: query';
 
-  const content = fs.readFileSync(mapPath, 'utf8');
-  const idx = content.indexOf(header);
-  if (idx === -1) {
-    return `Section "${header}" not found in PROJECT_MAP.md`;
-  }
+    const query = args.query.toLowerCase();
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const index = buildSigIndex(cwd);
+      if (index.size === 0) {
+        return 'No context file found. Run: node gen-context.js';
+      }
 
-  // Extract from this header to the next ### header
-  const after = content.slice(idx);
-  const nextMatch = after.slice(header.length).search(/\n###\s/);
-  return nextMatch === -1 ? after : after.slice(0, header.length + nextMatch);
-}
+      const result = [];
+      for (const [file, sigs] of index.entries()) {
+        const hits = sigs.filter((s) => s.toLowerCase().includes(query));
+        if (hits.length === 0) continue;
+        if (result.length > 0) result.push('');
+        result.push(`### ${file}`);
+        result.push(...hits);
+      }
 
-/**
- * create_checkpoint({ note? }) → string
- *
- * Returns a markdown checkpoint summarising current project state:
- * - Timestamp and optional user note
- * - Active git branch + last 5 commit messages
- * - Token count of current context file
- * - List of modules present in the context
- * - Route count (if PROJECT_MAP.md exists)
- */
-function createCheckpoint(args, cwd) {
-  const note = (args && args.note) ? args.note.trim() : '';
-  const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
-  const lines = [
-    '# SigMap Checkpoint',
-    `**Created:** ${now}`,
-  ];
-
-  if (note) lines.push(`**Note:** ${note}`);
-  lines.push('');
-
-  // ── Git info ────────────────────────────────────────────────────────────
-  lines.push('## Git state');
-  try {
-    const branch = __git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd }).trim();
-    lines.push(`**Branch:** ${branch}`);
-  } catch (_) {
-    lines.push('**Branch:** (not a git repo)');
-  }
-
-  try {
-    const log = __git(['log', '--oneline', '-5', '--no-decorate'], { cwd }).trim();
-    if (log) {
-      lines.push('');
-      lines.push('**Recent commits:**');
-      for (const l of log.split('\n')) lines.push(`- ${l}`);
-    }
-  } catch (_) {} // ignore — not every project uses git
-  lines.push('');
-
-  // ── Context stats ────────────────────────────────────────────────────────
-  lines.push('## Context snapshot');
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (fs.existsSync(contextPath)) {
-    const content = fs.readFileSync(contextPath, 'utf8');
-    const tokens = Math.ceil(content.length / 4);
-
-    // Count modules (### headers are file paths)
-    const modules = content.split('\n').filter((l) => l.startsWith('### ')).map((l) => l.slice(4).trim());
-    lines.push(`**Token count:** ~${tokens}`);
-    lines.push(`**Modules in context:** ${modules.length}`);
-
-    if (modules.length > 0) {
-      lines.push('');
-      lines.push('**Modules:**');
-      for (const m of modules.slice(0, 20)) lines.push(`- ${m}`);
-      if (modules.length > 20) lines.push(`- … and ${modules.length - 20} more`);
-    }
-  } else {
-    lines.push('_No context file found. Run: node gen-context.js_');
-  }
-  lines.push('');
-
-  // ── Route summary ────────────────────────────────────────────────────────
-  const mapPath = path.join(cwd, 'PROJECT_MAP.md');
-  if (fs.existsSync(mapPath)) {
-    const mapContent = fs.readFileSync(mapPath, 'utf8');
-    const routeLines = mapContent.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---'));
-    if (routeLines.length > 0) {
-      lines.push('## Routes');
-      lines.push(`**Total routes detected:** ${routeLines.length}`);
-      lines.push('');
-      for (const r of routeLines.slice(0, 10)) lines.push(r);
-      if (routeLines.length > 10) lines.push(`| … | +${routeLines.length - 10} more | |`);
-      lines.push('');
+      if (result.length === 0) return `No signatures found matching: ${args.query}`;
+      return result.join('\n');
+    } catch (err) {
+      return `_search_signatures failed: ${err.message}_`;
     }
   }
 
-  lines.push('---');
-  lines.push('_Generated by SigMap `create_checkpoint`_');
+  /**
+   * get_map({ type }) → string
+   *
+   * Returns a section from PROJECT_MAP.md.
+   * type: 'imports' | 'classes' | 'routes'
+   */
+  function getMap(args, cwd) {
+    if (!args || !args.type) return 'Missing required argument: type';
 
-  return lines.join('\n');
-}
+    const header = MAP_SECTIONS[args.type];
+    if (!header) {
+      return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
+    }
 
-/**
- * get_routing({}) → string
- *
- * Reads the current context file, classifies all indexed files by complexity,
- * and returns a formatted markdown routing guide showing which files belong
- * to the fast/balanced/powerful model tier.
- */
-function getRouting(args, cwd) {
-  const contextPath = path.join(cwd, CONTEXT_FILE);
-  if (!fs.existsSync(contextPath)) {
-    return (
-      '_No context file found. Run `node gen-context.js --routing` first._\n\n' +
-      'This generates routing hints that map each file to a model tier:\n' +
-      '- **fast** (haiku/gpt-4o-mini) — config, markup, trivial utilities\n' +
-      '- **balanced** (sonnet/gpt-4o) — standard application code\n' +
-      '- **powerful** (opus/gpt-4-turbo) — complex, security-critical, or large modules'
-    );
+    const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+    if (!fs.existsSync(mapPath)) {
+      return 'PROJECT_MAP.md not found. Run: node gen-project-map.js';
+    }
+
+    const content = fs.readFileSync(mapPath, 'utf8');
+    const idx = content.indexOf(header);
+    if (idx === -1) {
+      return `Section "${header}" not found in PROJECT_MAP.md`;
+    }
+
+    // Extract from this header to the next ### header
+    const after = content.slice(idx);
+    const nextMatch = after.slice(header.length).search(/\n###\s/);
+    return nextMatch === -1 ? after : after.slice(0, header.length + nextMatch);
   }
 
-  // Parse file list from context (### headings are file paths)
-  const content = fs.readFileSync(contextPath, 'utf8');
-  const fileRels = content.split('\n')
-    .filter((l) => l.startsWith('### '))
-    .map((l) => l.slice(4).trim());
+  /**
+   * create_checkpoint({ note? }) → string
+   *
+   * Returns a markdown checkpoint summarising current project state:
+   * - Timestamp and optional user note
+   * - Active git branch + last 5 commit messages
+   * - Token count of current context file
+   * - List of modules present in the context
+   * - Route count (if PROJECT_MAP.md exists)
+   */
+  function createCheckpoint(args, cwd) {
+    const note = (args && args.note) ? args.note.trim() : '';
+    const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+    const lines = [
+      '# SigMap Checkpoint',
+      `**Created:** ${now}`,
+    ];
 
-  // Build synthetic fileEntries for the classifier
-  // We don't have live sig arrays here, so rebuild from the context blocks
-  const entries = [];
-  const blocks = content.split(/^### /m).slice(1); // slice past the header
-  for (const block of blocks) {
-    const firstLine = block.split('\n')[0].trim();
-    const codeBlock = block.match(/```\n([\s\S]*?)```/);
-    const sigs = codeBlock ? codeBlock[1].trim().split('\n').filter(Boolean) : [];
-    entries.push({ filePath: path.join(cwd, firstLine), sigs });
-  }
+    if (note) lines.push(`**Note:** ${note}`);
+    lines.push('');
 
-  try {
-    const { classifyAll } = __require('./src/routing/classifier');
-    const { formatRoutingSection } = __require('./src/routing/hints');
-    const groups = classifyAll(entries, cwd);
-    return formatRoutingSection(groups);
-  } catch (err) {
-    return `_Routing classification failed: ${err.message}_`;
-  }
-}
+    // ── Git info ────────────────────────────────────────────────────────────
+    lines.push('## Git state');
+    try {
+      const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd }).trim();
+      lines.push(`**Branch:** ${branch}`);
+    } catch (_) {
+      lines.push('**Branch:** (not a git repo)');
+    }
 
-/**
- * explain_file({ path }) → string
- *
- * Returns a file's signatures, its direct imports, and files that import it.
- * path: relative path from project root (e.g. 'src/services/auth.ts')
- */
-function explainFile(args, cwd) {
-  if (!args || !args.path) return 'Missing required argument: path';
+    try {
+      const log = git(['log', '--oneline', '-5', '--no-decorate'], { cwd }).trim();
+      if (log) {
+        lines.push('');
+        lines.push('**Recent commits:**');
+        for (const l of log.split('\n')) lines.push(`- ${l}`);
+      }
+    } catch (_) {} // ignore — not every project uses git
+    lines.push('');
 
-  const targetRel = args.path.replace(/\\/g, '/').replace(/^\//, '');
-  const targetAbs = path.resolve(cwd, targetRel);
-  const contextPath = path.join(cwd, CONTEXT_FILE);
+    // ── Context stats ────────────────────────────────────────────────────────
+    lines.push('## Context snapshot');
+    const contextPath = path.join(cwd, CONTEXT_FILE);
+    if (fs.existsSync(contextPath)) {
+      const content = fs.readFileSync(contextPath, 'utf8');
+      const tokens = Math.ceil(content.length / 4);
 
-  const lines = ['# explain_file: ' + targetRel, ''];
+      // Count modules (### headers are file paths)
+      const modules = content.split('\n').filter((l) => l.startsWith('### ')).map((l) => l.slice(4).trim());
+      lines.push(`**Token count:** ~${tokens}`);
+      lines.push(`**Modules in context:** ${modules.length}`);
 
-  // ── Signatures (hot + cold + cache via buildSigIndex) ───────────────────
-  lines.push('## Signatures');
-  let indexedFiles = [];
+      if (modules.length > 0) {
+        lines.push('');
+        lines.push('**Modules:**');
+        for (const m of modules.slice(0, 20)) lines.push(`- ${m}`);
+        if (modules.length > 20) lines.push(`- … and ${modules.length - 20} more`);
+      }
+    } else {
+      lines.push('_No context file found. Run: node gen-context.js_');
+    }
+    lines.push('');
 
-  try {
-    const { buildSigIndex } = __require('./src/retrieval/ranker');
-    const index = buildSigIndex(cwd);
-    let sigs = index.get(targetRel);
-    if (!sigs) {
-      for (const [file, fileSigs] of index.entries()) {
-        if (file === targetRel || file.endsWith('/' + targetRel) || targetRel.endsWith('/' + file)) {
-          sigs = fileSigs;
-          break;
-        }
+    // ── Route summary ────────────────────────────────────────────────────────
+    const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+    if (fs.existsSync(mapPath)) {
+      const mapContent = fs.readFileSync(mapPath, 'utf8');
+      const routeLines = mapContent.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---'));
+      if (routeLines.length > 0) {
+        lines.push('## Routes');
+        lines.push(`**Total routes detected:** ${routeLines.length}`);
+        lines.push('');
+        for (const r of routeLines.slice(0, 10)) lines.push(r);
+        if (routeLines.length > 10) lines.push(`| … | +${routeLines.length - 10} more | |`);
+        lines.push('');
       }
     }
-    if (sigs && sigs.length > 0) {
-      lines.push(...sigs);
-    } else {
-      lines.push('_No signatures indexed for this file. Run: node gen-context.js_');
-    }
-    indexedFiles = [...index.keys()].map((rel) => path.resolve(cwd, rel));
-  } catch (_) {
-    lines.push('_No context file found. Run: node gen-context.js_');
-  }
 
-  if (!fs.existsSync(targetAbs)) {
-    lines.push('');
-    lines.push('> File not found on disk: ' + targetRel);
+    lines.push('---');
+    lines.push('_Generated by SigMap `create_checkpoint`_');
+
     return lines.join('\n');
   }
 
-  lines.push('');
-
-  // ── Direct imports ────────────────────────────────────────────────────────
-  lines.push('## Imports (direct dependencies)');
-  try {
-    const { extractImports } = __require('./src/map/import-graph');
-    const fileContent = fs.readFileSync(targetAbs, 'utf8');
-    const fileSet = new Set(indexedFiles);
-    fileSet.add(targetAbs);
-    const imports = extractImports(targetAbs, fileContent, fileSet);
-    if (imports.length > 0) {
-      for (const imp of imports) lines.push('- ' + path.relative(cwd, imp).replace(/\\/g, '/'));
-    } else {
-      lines.push('_No resolvable relative imports found._');
-    }
-  } catch (err) {
-    lines.push('_Could not analyze imports: ' + err.message + '_');
-  }
-
-  lines.push('');
-
-  // ── Callers (reverse-import lookup) ──────────────────────────────────────
-  lines.push('## Callers (files that import this file)');
-  try {
-    const { extractImports } = __require('./src/map/import-graph');
-    const fileSet = new Set(indexedFiles);
-    fileSet.add(targetAbs);
-    const callers = [];
-    for (const f of indexedFiles) {
-      if (f === targetAbs || !fs.existsSync(f)) continue;
-      try {
-        const fc = fs.readFileSync(f, 'utf8');
-        const imps = extractImports(f, fc, fileSet);
-        if (imps.includes(targetAbs)) callers.push(path.relative(cwd, f).replace(/\\/g, '/'));
-      } catch (_) {}
-    }
-    if (callers.length > 0) {
-      for (const c of callers) lines.push('- ' + c);
-    } else {
-      lines.push('_No indexed files import this file._');
-    }
-  } catch (err) {
-    lines.push('_Could not analyze callers: ' + err.message + '_');
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * list_modules({}) → string
- *
- * Lists all srcDir modules present in the context file, sorted by token count
- * descending. Helps agents decide which module to query with read_context.
- */
-function listModules(args, cwd) {
-  try {
-    const { buildSigIndex } = __require('./src/retrieval/ranker');
-    const index = buildSigIndex(cwd);
-    if (index.size === 0) {
-      return 'No context file found. Run: node gen-context.js';
+  /**
+   * get_routing({}) → string
+   *
+   * Reads the current context file, classifies all indexed files by complexity,
+   * and returns a formatted markdown routing guide showing which files belong
+   * to the fast/balanced/powerful model tier.
+   */
+  function getRouting(args, cwd) {
+    const contextPath = path.join(cwd, CONTEXT_FILE);
+    if (!fs.existsSync(contextPath)) {
+      return (
+        '_No context file found. Run `node gen-context.js --routing` first._\n\n' +
+        'This generates routing hints that map each file to a model tier:\n' +
+        '- **fast** (haiku/gpt-4o-mini) — config, markup, trivial utilities\n' +
+        '- **balanced** (sonnet/gpt-4o) — standard application code\n' +
+        '- **powerful** (opus/gpt-4-turbo) — complex, security-critical, or large modules'
+      );
     }
 
-    const groups = {};
-    for (const [rel, sigs] of index.entries()) {
-      const parts = rel.replace(/\\/g, '/').split('/');
-      const mod = parts.length > 1 ? parts[0] : '.';
-      if (!groups[mod]) groups[mod] = { fileCount: 0, tokenCount: 0 };
-      groups[mod].fileCount++;
-      groups[mod].tokenCount += Math.ceil(sigs.join('\n').length / 4);
+    // Parse file list from context (### headings are file paths)
+    const content = fs.readFileSync(contextPath, 'utf8');
+    const fileRels = content.split('\n')
+      .filter((l) => l.startsWith('### '))
+      .map((l) => l.slice(4).trim());
+
+    // Build synthetic fileEntries for the classifier
+    // We don't have live sig arrays here, so rebuild from the context blocks
+    const entries = [];
+    const blocks = content.split(/^### /m).slice(1); // slice past the header
+    for (const block of blocks) {
+      const firstLine = block.split('\n')[0].trim();
+      const codeBlock = block.match(/```\n([\s\S]*?)```/);
+      const sigs = codeBlock ? codeBlock[1].trim().split('\n').filter(Boolean) : [];
+      entries.push({ filePath: path.join(cwd, firstLine), sigs });
     }
 
-  const sorted = Object.entries(groups)
-    .map(([mod, data]) => ({ module: mod, fileCount: data.fileCount, tokenCount: data.tokenCount }))
-    .sort((a, b) => b.tokenCount - a.tokenCount);
-
-  if (sorted.length === 0) return 'No modules found in context file.';
-
-  const total = sorted.reduce((s, m) => s + m.tokenCount, 0);
-
-  return [
-    '# Modules',
-    '',
-    '| Module | Files | Tokens |',
-    '|--------|-------|--------|',
-    ...sorted.map((m) => `| ${m.module} | ${m.fileCount} | ~${m.tokenCount} |`),
-    '',
-    `**Total context tokens: ~${total}**`,
-    '',
-    '_Use `read_context({ module: "name" })` to get signatures for a specific module._',
-  ].join('\n');
-  } catch (err) {
-    return `_list_modules failed: ${err.message}_`;
-  }
-}
-
-/**
- * query_context({ query, topK? }) → string
- *
- * Ranks context-file entries by relevance to the query and returns the
- * top-K most relevant files with their signatures and scores.
- */
-function queryContext(args, cwd) {
-  if (!args || !args.query) return 'Missing required argument: query';
-
-  try {
-    const { rank, buildSigIndex, formatRankTable } = __require('./src/retrieval/ranker');
-    const { buildFromCwd } = __require('./src/graph/builder');
-    const index = buildSigIndex(cwd);
-    if (index.size === 0) return 'No signatures indexed. Run: node gen-context.js';
-
-    const topK = Math.min(Math.max(1, parseInt(args.topK, 10) || 10), 25);
-    // Build dependency graph for neighbor boost — non-fatal if it fails
-    let graph = null;
-    try { graph = buildFromCwd(cwd); } catch (_) {}
-    const results = rank(args.query, index, { topK, cwd, graph });
-    return formatRankTable(results, args.query);
-  } catch (err) {
-    return `_query_context failed: ${err.message}_`;
-  }
-}
-
-/**
- * get_impact({ file, depth? }) → string
- *
- * Returns a formatted markdown impact report for the given file:
- * direct importers, transitive importers, affected tests, affected routes.
- */
-function getImpact(args, cwd) {
-  if (!args || !args.file) return 'Missing required argument: file';
-
-  try {
-    const { analyzeImpact, formatImpact } = __require('./src/graph/impact');
-    const depth = Math.max(0, parseInt(args.depth, 10) || 3);
-    const results = analyzeImpact(args.file, cwd, { depth });
-    if (results.length === 0) return `No impact data for: ${args.file}`;
-    return results.map((r) => formatImpact(r.impact)).join('\n\n---\n\n');
-  } catch (err) {
-    return `_get_impact failed: ${err.message}_`;
-  }
-}
-
-/**
- * get_lines({ file, start, end }) → string
- *
- * Surgical Context demand-driven fetch: returns an exact, clamped line range from a
- * source file. The path is resolved inside the project root (no traversal escape) and
- * the returned lines are secret-scanned via the same redactor used for signatures.
- */
-function getLines(args, cwd) {
-  if (!args || !args.file) return 'Missing required argument: file';
-
-  const rel = String(args.file).replace(/\\/g, '/').replace(/^\//, '');
-  const abs = path.resolve(cwd, rel);
-
-  // Sandbox: refuse paths that resolve outside the project root.
-  const root = path.resolve(cwd);
-  if (abs !== root && !abs.startsWith(root + path.sep)) {
-    return `Refused: ${rel} resolves outside the project root`;
-  }
-  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
-    return `File not found: ${rel}`;
+    try {
+      const { classifyAll } = __require('./src/routing/classifier');
+      const { formatRoutingSection } = __require('./src/routing/hints');
+      const groups = classifyAll(entries, cwd);
+      return formatRoutingSection(groups);
+    } catch (err) {
+      return `_Routing classification failed: ${err.message}_`;
+    }
   }
 
-  const start = parseInt(args.start, 10);
-  const end = parseInt(args.end, 10);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
-    return 'Arguments "start" and "end" must be numbers (1-based line numbers).';
-  }
+  /**
+   * explain_file({ path }) → string
+   *
+   * Returns a file's signatures, its direct imports, and files that import it.
+   * path: relative path from project root (e.g. 'src/services/auth.ts')
+   */
+  function explainFile(args, cwd) {
+    if (!args || !args.path) return 'Missing required argument: path';
 
-  let lines;
-  try {
-    lines = fs.readFileSync(abs, 'utf8').split('\n');
-  } catch (err) {
-    return `Could not read ${rel}: ${err.message}`;
-  }
+    const targetRel = args.path.replace(/\\/g, '/').replace(/^\//, '');
+    const targetAbs = path.resolve(cwd, targetRel);
+    const contextPath = path.join(cwd, CONTEXT_FILE);
 
-  const total = lines.length;
-  const from = Math.max(1, Math.min(start, end));
-  const to = Math.min(total, Math.max(start, end));
-  if (from > total) return `${rel} has only ${total} lines; requested ${start}-${end}`;
+    const lines = ['# explain_file: ' + targetRel, ''];
 
-  const slice = lines.slice(from - 1, to);
+    // ── Signatures (hot + cold + cache via buildSigIndex) ───────────────────
+    lines.push('## Signatures');
+    let indexedFiles = [];
 
-  // Redaction scan: reuse the signature secret scanner line-by-line.
-  let safeLines = slice;
-  try {
-    const { scan } = __require('./src/security/scanner');
-    safeLines = scan(slice, rel).safe;
-  } catch (_) {} // non-fatal: fall back to raw slice
-
-  return [
-    `# ${rel}:${from}-${to}`,
-    '```',
-    ...safeLines,
-    '```',
-  ].join('\n');
-}
-
-/**
- * read_memory({ limit? }) → string
- *
- * Recall the cross-session decision log (notes) plus the last ranking-session
- * focus, formatted for an agent to consume at the start of a task.
- */
-function readMemory(args, cwd) {
-  let limit = parseInt(args && args.limit, 10);
-  if (!Number.isFinite(limit) || limit <= 0) limit = 10;
-  limit = Math.min(limit, 50);
-
-  const out = ['# SigMap memory'];
-
-  let notes = [];
-  try {
-    const { readNotes, formatNotes } = __require('./src/session/notes');
-    notes = readNotes(cwd, limit);
-    out.push('');
-    out.push(`## Recent notes (${notes.length})`);
-    // Most recent first for quick scanning.
-    out.push(formatNotes(notes.slice().reverse()));
-  } catch (_) {
-    out.push('');
-    out.push('_No notes available._');
-  }
-
-  // Last ranking-session focus (if any) — extends src/session/memory.js.
-  try {
-    const { loadSession } = __require('./src/session/memory');
-    const s = loadSession(cwd);
-    if (s && (s.lastQuery || (s.topFiles && s.topFiles.length))) {
-      out.push('');
-      out.push('## Last session');
-      if (s.lastQuery) out.push(`**Last query:** ${s.lastQuery}`);
-      if (s.topFiles && s.topFiles.length) {
-        out.push(`**Focus files:** ${s.topFiles.map((f) => f.file).slice(0, 5).join(', ')}`);
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const index = buildSigIndex(cwd);
+      let sigs = index.get(targetRel);
+      if (!sigs) {
+        for (const [file, fileSigs] of index.entries()) {
+          if (file === targetRel || file.endsWith('/' + targetRel) || targetRel.endsWith('/' + file)) {
+            sigs = fileSigs;
+            break;
+          }
+        }
       }
+      if (sigs && sigs.length > 0) {
+        lines.push(...sigs);
+      } else {
+        lines.push('_No signatures indexed for this file. Run: node gen-context.js_');
+      }
+      indexedFiles = [...index.keys()].map((rel) => path.resolve(cwd, rel));
+    } catch (_) {
+      lines.push('_No context file found. Run: node gen-context.js_');
     }
-  } catch (_) { /* session optional */ }
 
-  return out.join('\n');
-}
+    if (!fs.existsSync(targetAbs)) {
+      lines.push('');
+      lines.push('> File not found on disk: ' + targetRel);
+      return lines.join('\n');
+    }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory };
+    lines.push('');
 
+    // ── Direct imports ────────────────────────────────────────────────────────
+    lines.push('## Imports (direct dependencies)');
+    try {
+      const { extractImports } = __require('./src/map/import-graph');
+      const fileContent = fs.readFileSync(targetAbs, 'utf8');
+      const fileSet = new Set(indexedFiles);
+      fileSet.add(targetAbs);
+      const imports = extractImports(targetAbs, fileContent, fileSet);
+      if (imports.length > 0) {
+        for (const imp of imports) lines.push('- ' + path.relative(cwd, imp).replace(/\\/g, '/'));
+      } else {
+        lines.push('_No resolvable relative imports found._');
+      }
+    } catch (err) {
+      lines.push('_Could not analyze imports: ' + err.message + '_');
+    }
+
+    lines.push('');
+
+    // ── Callers (reverse-import lookup) ──────────────────────────────────────
+    lines.push('## Callers (files that import this file)');
+    try {
+      const { extractImports } = __require('./src/map/import-graph');
+      const fileSet = new Set(indexedFiles);
+      fileSet.add(targetAbs);
+      const callers = [];
+      for (const f of indexedFiles) {
+        if (f === targetAbs || !fs.existsSync(f)) continue;
+        try {
+          const fc = fs.readFileSync(f, 'utf8');
+          const imps = extractImports(f, fc, fileSet);
+          if (imps.includes(targetAbs)) callers.push(path.relative(cwd, f).replace(/\\/g, '/'));
+        } catch (_) {}
+      }
+      if (callers.length > 0) {
+        for (const c of callers) lines.push('- ' + c);
+      } else {
+        lines.push('_No indexed files import this file._');
+      }
+    } catch (err) {
+      lines.push('_Could not analyze callers: ' + err.message + '_');
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * list_modules({}) → string
+   *
+   * Lists all srcDir modules present in the context file, sorted by token count
+   * descending. Helps agents decide which module to query with read_context.
+   */
+  function listModules(args, cwd) {
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const index = buildSigIndex(cwd);
+      if (index.size === 0) {
+        return 'No context file found. Run: node gen-context.js';
+      }
+
+      const groups = {};
+      for (const [rel, sigs] of index.entries()) {
+        const parts = rel.replace(/\\/g, '/').split('/');
+        const mod = parts.length > 1 ? parts[0] : '.';
+        if (!groups[mod]) groups[mod] = { fileCount: 0, tokenCount: 0 };
+        groups[mod].fileCount++;
+        groups[mod].tokenCount += Math.ceil(sigs.join('\n').length / 4);
+      }
+
+    const sorted = Object.entries(groups)
+      .map(([mod, data]) => ({ module: mod, fileCount: data.fileCount, tokenCount: data.tokenCount }))
+      .sort((a, b) => b.tokenCount - a.tokenCount);
+
+    if (sorted.length === 0) return 'No modules found in context file.';
+
+    const total = sorted.reduce((s, m) => s + m.tokenCount, 0);
+
+    return [
+      '# Modules',
+      '',
+      '| Module | Files | Tokens |',
+      '|--------|-------|--------|',
+      ...sorted.map((m) => `| ${m.module} | ${m.fileCount} | ~${m.tokenCount} |`),
+      '',
+      `**Total context tokens: ~${total}**`,
+      '',
+      '_Use `read_context({ module: "name" })` to get signatures for a specific module._',
+    ].join('\n');
+    } catch (err) {
+      return `_list_modules failed: ${err.message}_`;
+    }
+  }
+
+  /**
+   * query_context({ query, topK? }) → string
+   *
+   * Ranks context-file entries by relevance to the query and returns the
+   * top-K most relevant files with their signatures and scores.
+   */
+  function queryContext(args, cwd) {
+    if (!args || !args.query) return 'Missing required argument: query';
+
+    try {
+      const { rank, buildSigIndex, formatRankTable } = __require('./src/retrieval/ranker');
+      const { buildFromCwd } = __require('./src/graph/builder');
+      const index = buildSigIndex(cwd);
+      if (index.size === 0) return 'No signatures indexed. Run: node gen-context.js';
+
+      const topK = Math.min(Math.max(1, parseInt(args.topK, 10) || 10), 25);
+      // Build dependency graph for neighbor boost — non-fatal if it fails
+      let graph = null;
+      try { graph = buildFromCwd(cwd); } catch (_) {}
+      const results = rank(args.query, index, { topK, cwd, graph });
+      return formatRankTable(results, args.query);
+    } catch (err) {
+      return `_query_context failed: ${err.message}_`;
+    }
+  }
+
+  /**
+   * get_impact({ file, depth? }) → string
+   *
+   * Returns a formatted markdown impact report for the given file:
+   * direct importers, transitive importers, affected tests, affected routes.
+   */
+  function getImpact(args, cwd) {
+    if (!args || !args.file) return 'Missing required argument: file';
+
+    try {
+      const { analyzeImpact, formatImpact } = __require('./src/graph/impact');
+      const depth = Math.max(0, parseInt(args.depth, 10) || 3);
+      const results = analyzeImpact(args.file, cwd, { depth });
+      if (results.length === 0) return `No impact data for: ${args.file}`;
+      return results.map((r) => formatImpact(r.impact)).join('\n\n---\n\n');
+    } catch (err) {
+      return `_get_impact failed: ${err.message}_`;
+    }
+  }
+
+  /**
+   * get_lines({ file, start, end }) → string
+   *
+   * Surgical Context demand-driven fetch: returns an exact, clamped line range from a
+   * source file. The path is resolved inside the project root (no traversal escape) and
+   * the returned lines are secret-scanned via the same redactor used for signatures.
+   */
+  function getLines(args, cwd) {
+    if (!args || !args.file) return 'Missing required argument: file';
+
+    const rel = String(args.file).replace(/\\/g, '/').replace(/^\//, '');
+    const abs = path.resolve(cwd, rel);
+
+    // Sandbox: refuse paths that resolve outside the project root.
+    const root = path.resolve(cwd);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      return `Refused: ${rel} resolves outside the project root`;
+    }
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+      return `File not found: ${rel}`;
+    }
+
+    const start = parseInt(args.start, 10);
+    const end = parseInt(args.end, 10);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      return 'Arguments "start" and "end" must be numbers (1-based line numbers).';
+    }
+
+    let lines;
+    try {
+      lines = fs.readFileSync(abs, 'utf8').split('\n');
+    } catch (err) {
+      return `Could not read ${rel}: ${err.message}`;
+    }
+
+    const total = lines.length;
+    const from = Math.max(1, Math.min(start, end));
+    const to = Math.min(total, Math.max(start, end));
+    if (from > total) return `${rel} has only ${total} lines; requested ${start}-${end}`;
+
+    const slice = lines.slice(from - 1, to);
+
+    // Redaction scan: reuse the signature secret scanner line-by-line.
+    let safeLines = slice;
+    try {
+      const { scan } = __require('./src/security/scanner');
+      safeLines = scan(slice, rel).safe;
+    } catch (_) {} // non-fatal: fall back to raw slice
+
+    return [
+      `# ${rel}:${from}-${to}`,
+      '```',
+      ...safeLines,
+      '```',
+    ].join('\n');
+  }
+
+  /**
+   * read_memory({ limit? }) → string
+   *
+   * Recall the cross-session decision log (notes) plus the last ranking-session
+   * focus, formatted for an agent to consume at the start of a task.
+   */
+  function readMemory(args, cwd) {
+    let limit = parseInt(args && args.limit, 10);
+    if (!Number.isFinite(limit) || limit <= 0) limit = 10;
+    limit = Math.min(limit, 50);
+
+    const out = ['# SigMap memory'];
+
+    let notes = [];
+    try {
+      const { readNotes, formatNotes } = __require('./src/session/notes');
+      notes = readNotes(cwd, limit);
+      out.push('');
+      out.push(`## Recent notes (${notes.length})`);
+      // Most recent first for quick scanning.
+      out.push(formatNotes(notes.slice().reverse()));
+    } catch (_) {
+      out.push('');
+      out.push('_No notes available._');
+    }
+
+    // Last ranking-session focus (if any) — extends src/session/memory.js.
+    try {
+      const { loadSession } = __require('./src/session/memory');
+      const s = loadSession(cwd);
+      if (s && (s.lastQuery || (s.topFiles && s.topFiles.length))) {
+        out.push('');
+        out.push('## Last session');
+        if (s.lastQuery) out.push(`**Last query:** ${s.lastQuery}`);
+        if (s.topFiles && s.topFiles.length) {
+          out.push(`**Focus files:** ${s.topFiles.map((f) => f.file).slice(0, 5).join(', ')}`);
+        }
+      }
+    } catch (_) { /* session optional */ }
+
+    return out.join('\n');
+  }
+
+  /**
+   * get_callee_signatures — return the exact defining signature(s) of named
+   * symbols from the index, so an agent never guesses a callee's parameter types.
+   * Unknown names get a closest-match suggestion.
+   * @param {{symbols:string[]}} args
+   * @param {string} cwd
+   */
+  function getCalleeSignatures(args, cwd) {
+    const symbols = args && Array.isArray(args.symbols)
+      ? args.symbols.map((s) => String(s).trim()).filter(Boolean)
+      : null;
+    if (!symbols || symbols.length === 0) {
+      return 'Missing required argument: symbols (non-empty string[])';
+    }
+
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const { buildSymbolCandidates, closestMatch, formatSuggestion } = __require('./src/verify/closest-match');
+      const index = buildSigIndex(cwd);
+      if (index.size === 0) return 'No context file found. Run: node gen-context.js';
+
+      // Extract the defining symbol name from a signature line (same rules as
+      // buildSymbolCandidates) so we match definitions, not param occurrences.
+      const defName = (sig) => {
+        const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+        const m = cleaned.match(/\b(?:async\s+function|function|class|def|interface|type|enum|const|let|var)\s+([A-Za-z_$][\w$]*)/)
+          || cleaned.match(/([A-Za-z_$][\w$]*)\s*\(/);
+        return m ? m[1] : null;
+      };
+
+      const candidates = buildSymbolCandidates(index);
+      const blocks = [];
+      for (const symbol of symbols) {
+        const matches = [];
+        for (const [file, sigs] of index.entries()) {
+          for (const sig of sigs) {
+            if (defName(sig) === symbol) matches.push(`${sig}    (${file})`);
+          }
+        }
+        if (matches.length === 0) {
+          const cm = closestMatch(symbol, candidates);
+          const hint = cm ? ' — ' + formatSuggestion(cm) : '';
+          blocks.push(`### ${symbol}\n_not found in index${hint}_`);
+        } else {
+          blocks.push(`### ${symbol}\n${matches.join('\n')}`);
+        }
+      }
+      return blocks.join('\n\n');
+    } catch (err) {
+      return `_get_callee_signatures failed: ${err.message}_`;
+    }
+  }
+
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures };
+  
 };
 // ── ./src/learning/weights ──
 __factories["./src/learning/weights"] = function(module, exports) {
@@ -6234,363 +6287,382 @@ __factories["./src/learning/weights"] = function(module, exports) {
 
 // ── ./src/mcp/server ──
 __factories["./src/mcp/server"] = function(module, exports) {
-'use strict';
+  
+  /**
+   * SigMap MCP server — zero npm dependencies.
+   *
+   * Wire protocol: JSON-RPC 2.0 over stdio.
+   * One JSON object per line on both stdin and stdout.
+   *
+   * Supported methods:
+   *   initialize        → serverInfo + capabilities
+   *   tools/list        → 11 tool definitions
+   *   tools/call        → dispatch to handler, return result
+   */
 
-/**
- * SigMap MCP server — zero npm dependencies.
- *
- * Wire protocol: JSON-RPC 2.0 over stdio.
- * One JSON object per line on both stdin and stdout.
- *
- * Supported methods:
- *   initialize        → serverInfo + capabilities
- *   tools/list        → 11 tool definitions
- *   tools/call        → dispatch to handler, return result
- */
+  const readline = require('readline');
+  const { TOOLS } = __require('./src/mcp/tools');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures } = __require('./src/mcp/handlers');
 
-const readline = require('readline');
-const { TOOLS } = __require('./src/mcp/tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory } = __require('./src/mcp/handlers');
+  const SERVER_INFO = {
+    name: 'sigmap',
+    version: '7.2.1',
+    description: 'SigMap MCP server — code signatures on demand',
+  };
 
-const SERVER_INFO = {
-  name: 'sigmap',
-  version: '7.2.1',
-  description: 'SigMap MCP server — code signatures on demand',
-};
-
-// ---------------------------------------------------------------------------
-// JSON-RPC helpers
-// ---------------------------------------------------------------------------
-function respond(id, result) {
-  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
-}
-
-function respondError(id, code, message) {
-  process.stdout.write(
-    JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n'
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Method dispatcher
-// ---------------------------------------------------------------------------
-function dispatch(msg, cwd) {
-  const { method, id, params } = msg;
-
-  // Notifications (no id) need no response
-  if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
-    return;
+  // ---------------------------------------------------------------------------
+  // JSON-RPC helpers
+  // ---------------------------------------------------------------------------
+  function respond(id, result) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
   }
 
-  if (method === 'initialize') {
-    respond(id, {
-      protocolVersion: (params && params.protocolVersion) || '2024-11-05',
-      serverInfo: SERVER_INFO,
-      capabilities: { tools: {} },
-    });
-    return;
+  function respondError(id, code, message) {
+    process.stdout.write(
+      JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n'
+    );
   }
 
-  if (method === 'tools/list') {
-    respond(id, { tools: TOOLS });
-    return;
-  }
+  // ---------------------------------------------------------------------------
+  // Method dispatcher
+  // ---------------------------------------------------------------------------
+  function dispatch(msg, cwd) {
+    const { method, id, params } = msg;
 
-  if (method === 'tools/call') {
-    const name = params && params.name;
-    const args = (params && params.arguments) || {};
+    // Notifications (no id) need no response
+    if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
+      return;
+    }
 
-    let text;
-    try {
-      if (name === 'read_context') text = readContext(args, cwd);
-      else if (name === 'search_signatures') text = searchSignatures(args, cwd);
-      else if (name === 'get_map') text = getMap(args, cwd);
-      else if (name === 'create_checkpoint') text = createCheckpoint(args, cwd);
-      else if (name === 'get_routing') text = getRouting(args, cwd);
-      else if (name === 'explain_file') text = explainFile(args, cwd);
-      else if (name === 'list_modules') text = listModules(args, cwd);
-      else if (name === 'query_context') text = queryContext(args, cwd);
-      else if (name === 'get_impact') text = getImpact(args, cwd);
-      else if (name === 'get_lines') text = getLines(args, cwd);
-      else if (name === 'read_memory') text = readMemory(args, cwd);
-      else {
-        respondError(id, -32601, `Unknown tool: ${name}`);
+    if (method === 'initialize') {
+      respond(id, {
+        protocolVersion: (params && params.protocolVersion) || '2024-11-05',
+        serverInfo: SERVER_INFO,
+        capabilities: { tools: {} },
+      });
+      return;
+    }
+
+    if (method === 'tools/list') {
+      respond(id, { tools: TOOLS });
+      return;
+    }
+
+    if (method === 'tools/call') {
+      const name = params && params.name;
+      const args = (params && params.arguments) || {};
+
+      let text;
+      try {
+        if (name === 'read_context') text = readContext(args, cwd);
+        else if (name === 'search_signatures') text = searchSignatures(args, cwd);
+        else if (name === 'get_map') text = getMap(args, cwd);
+        else if (name === 'create_checkpoint') text = createCheckpoint(args, cwd);
+        else if (name === 'get_routing') text = getRouting(args, cwd);
+        else if (name === 'explain_file') text = explainFile(args, cwd);
+        else if (name === 'list_modules') text = listModules(args, cwd);
+        else if (name === 'query_context') text = queryContext(args, cwd);
+        else if (name === 'get_impact') text = getImpact(args, cwd);
+        else if (name === 'get_lines') text = getLines(args, cwd);
+        else if (name === 'read_memory') text = readMemory(args, cwd);
+        else if (name === 'get_callee_signatures') text = getCalleeSignatures(args, cwd);
+        else {
+          respondError(id, -32601, `Unknown tool: ${name}`);
+          return;
+        }
+      } catch (err) {
+        respondError(id, -32603, `Tool error: ${err.message}`);
         return;
       }
-    } catch (err) {
-      respondError(id, -32603, `Tool error: ${err.message}`);
+
+      respond(id, {
+        content: [{ type: 'text', text: String(text) }],
+      });
       return;
     }
 
-    respond(id, {
-      content: [{ type: 'text', text: String(text) }],
+    // Unknown method
+    if (id !== undefined && id !== null) {
+      respondError(id, -32601, `Method not found: ${method}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Server entry point
+  // ---------------------------------------------------------------------------
+  function start(cwd) {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+
+      let msg;
+      try {
+        msg = JSON.parse(trimmed);
+      } catch (_) {
+        // Cannot respond without a valid id — ignore malformed input
+        return;
+      }
+
+      try {
+        dispatch(msg, cwd);
+      } catch (err) {
+        const id = (msg && msg.id) != null ? msg.id : null;
+        respondError(id, -32603, `Internal error: ${err.message}`);
+      }
     });
-    return;
+
+    rl.on('close', () => {
+      process.exit(0);
+    });
   }
 
-  // Unknown method
-  if (id !== undefined && id !== null) {
-    respondError(id, -32601, `Method not found: ${method}`);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Server entry point
-// ---------------------------------------------------------------------------
-function start(cwd) {
-  const rl = readline.createInterface({ input: process.stdin, terminal: false });
-
-  rl.on('line', (line) => {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-
-    let msg;
-    try {
-      msg = JSON.parse(trimmed);
-    } catch (_) {
-      // Cannot respond without a valid id — ignore malformed input
-      return;
-    }
-
-    try {
-      dispatch(msg, cwd);
-    } catch (err) {
-      const id = (msg && msg.id) != null ? msg.id : null;
-      respondError(id, -32603, `Internal error: ${err.message}`);
-    }
-  });
-
-  rl.on('close', () => {
-    process.exit(0);
-  });
-}
-
-module.exports = { start };
-
+  module.exports = { start };
+  
 };
 // ── ./src/mcp/tools ──
 __factories["./src/mcp/tools"] = function(module, exports) {
-'use strict';
+  
+  /**
+   * MCP tool definitions for SigMap (12 tools).
+   * read_context, search_signatures, get_map, create_checkpoint, get_routing,
+   * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
+   * get_callee_signatures.
+   */
 
-/**
- * MCP tool definitions for SigMap (11 tools).
- * read_context, search_signatures, get_map, create_checkpoint, get_routing,
- * explain_file, list_modules, query_context, get_impact, get_lines, read_memory.
- */
+  const TOOLS = [
+    {
+      name: 'read_context',
+      description:
+        'Read extracted code signatures for the project or a specific module path. ' +
+        'Returns the full copilot-instructions.md content (~500–4K tokens) or a ' +
+        'filtered subset when a module path is provided (~50–500 tokens).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          module: {
+            type: 'string',
+            description:
+              'Optional subdirectory path to scope results (e.g. "src/services"). ' +
+              'Omit to get the full codebase context.',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'search_signatures',
+      description:
+        'Search extracted code signatures for a keyword, function name, or class name. ' +
+        'Returns matching signature lines with their file paths.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Keyword to search for in signatures (case-insensitive).',
+          },
+        },
+        required: ['query'],
+      },
+    },
+    {
+      name: 'get_map',
+      description:
+        'Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. ' +
+        'Requires gen-project-map.js to have been run first.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['imports', 'classes', 'routes'],
+            description: 'Which section to retrieve: imports, classes, or routes.',
+          },
+        },
+        required: ['type'],
+      },
+    },
+    {
+      name: 'create_checkpoint',
+      description:
+        'Create a session checkpoint summarising current project state. ' +
+        'Returns recent git commits, active branch, token count, and a ' +
+        'compact snapshot of the codebase context — ideal for session handoffs ' +
+        'or periodic saves during long coding sessions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          note: {
+            type: 'string',
+            description: 'Optional free-text note to include in the checkpoint (e.g. what you were working on).',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'get_routing',
+      description:
+        'Get model routing hints for this project — which files belong to which complexity ' +
+        'tier (fast/balanced/powerful) and which AI model to use for each type of task. ' +
+        'Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: 'explain_file',
+      description:
+        'Explain a specific file: returns its extracted signatures, direct imports ' +
+        '(files it depends on), and callers (files that import it). ' +
+        'Ideal for understanding a file in isolation without reading raw source. ' +
+        'Requires the context file to have been generated first.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description:
+              'Relative path from the project root (e.g. "src/services/auth.ts"). ' +
+              'Use the paths shown in read_context output.',
+          },
+        },
+        required: ['path'],
+      },
+    },
+    {
+      name: 'list_modules',
+      description:
+        'List all top-level modules (srcDirs) present in the context file, ' +
+        'sorted by token count descending. Use this to decide which module to ' +
+        'pass to read_context before querying a specific area of the codebase.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: 'query_context',
+      description:
+        'Rank and return the most relevant files for a specific task or question. ' +
+        'Uses keyword + symbol + path scoring to surface only the top-K files relevant ' +
+        'to the query — much cheaper than reading all context. ' +
+        'Returns ranked file list with signatures and relevance scores.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description:
+              'Natural language task description or keyword(s) to rank files against. ' +
+              'E.g. "add a new language extractor", "fix secret scanning", "auth module".',
+          },
+          topK: {
+            type: 'number',
+            description: 'Maximum number of files to return (default: 10, max: 25).',
+          },
+        },
+        required: ['query'],
+      },
+    },
+    {
+      name: 'get_impact',
+      description:
+        'Show every file that is impacted when a given file changes — direct importers, ' +
+        'transitive importers, affected tests, and affected routes/controllers. ' +
+        'Gives agents instant blast-radius awareness before making a change. ' +
+        'Handles circular dependencies safely (no infinite loops).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file: {
+            type: 'string',
+            description:
+              'Relative path from the project root of the file that changed ' +
+              '(e.g. "src/extractors/python.js"). Use forward slashes.',
+          },
+          depth: {
+            type: 'number',
+            description: 'BFS traversal depth limit (default: 3). Use 0 for unlimited.',
+          },
+        },
+        required: ['file'],
+      },
+    },
+    {
+      name: 'get_lines',
+      description:
+        'Fetch an exact line range from a source file on demand — the Surgical Context ' +
+        'workhorse. Signatures carry `path:start-end` anchors; call this to read just those ' +
+        'lines instead of re-opening the whole file. Lines are clamped to the file bounds and ' +
+        'secret-scanned (redacted) before return. Path is sandboxed to the project root.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file: {
+            type: 'string',
+            description:
+              'Relative path from the project root (e.g. "src/config/loader.js"). ' +
+              'Use the path shown in a signature anchor. Use forward slashes.',
+          },
+          start: {
+            type: 'number',
+            description: '1-based start line (inclusive). Clamped to the file bounds.',
+          },
+          end: {
+            type: 'number',
+            description: '1-based end line (inclusive). Clamped to the file bounds.',
+          },
+        },
+        required: ['file', 'start', 'end'],
+      },
+    },
+    {
+      name: 'read_memory',
+      description:
+        'Recall the project decision log — recent notes left by humans or agents ' +
+        'across sessions (via `sigmap note`), plus the last ranking-session focus. ' +
+        'Call this at the start of a task to kill cold-start: it answers ' +
+        '"what were we doing and why" without re-reading the whole codebase.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'number',
+            description: 'How many of the most recent notes to return (default: 10, max: 50).',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'get_callee_signatures',
+      description:
+        'Return the EXACT current signature(s) of named symbols (functions, classes, ' +
+        "methods) from the index — so an agent never guesses a callee's parameter types " +
+        'from training memory. Call this before writing code that uses a symbol. ' +
+        'Unknown names get a closest-match suggestion.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          symbols: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Symbol names to resolve (e.g. ["validateToken", "UserService"]).',
+          },
+        },
+        required: ['symbols'],
+      },
+    },
+  ];
 
-const TOOLS = [
-  {
-    name: 'read_context',
-    description:
-      'Read extracted code signatures for the project or a specific module path. ' +
-      'Returns the full copilot-instructions.md content (~500–4K tokens) or a ' +
-      'filtered subset when a module path is provided (~50–500 tokens).',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        module: {
-          type: 'string',
-          description:
-            'Optional subdirectory path to scope results (e.g. "src/services"). ' +
-            'Omit to get the full codebase context.',
-        },
-      },
-      required: [],
-    },
-  },
-  {
-    name: 'search_signatures',
-    description:
-      'Search extracted code signatures for a keyword, function name, or class name. ' +
-      'Returns matching signature lines with their file paths.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: {
-          type: 'string',
-          description: 'Keyword to search for in signatures (case-insensitive).',
-        },
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'get_map',
-    description:
-      'Read a section from PROJECT_MAP.md — import graph, class hierarchy, or route table. ' +
-      'Requires gen-project-map.js to have been run first.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        type: {
-          type: 'string',
-          enum: ['imports', 'classes', 'routes'],
-          description: 'Which section to retrieve: imports, classes, or routes.',
-        },
-      },
-      required: ['type'],
-    },
-  },
-  {
-    name: 'create_checkpoint',
-    description:
-      'Create a session checkpoint summarising current project state. ' +
-      'Returns recent git commits, active branch, token count, and a ' +
-      'compact snapshot of the codebase context — ideal for session handoffs ' +
-      'or periodic saves during long coding sessions.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        note: {
-          type: 'string',
-          description: 'Optional free-text note to include in the checkpoint (e.g. what you were working on).',
-        },
-      },
-      required: [],
-    },
-  },
-  {
-    name: 'get_routing',
-    description:
-      'Get model routing hints for this project — which files belong to which complexity ' +
-      'tier (fast/balanced/powerful) and which AI model to use for each type of task. ' +
-      'Helps reduce API costs by 40–80% by routing simple tasks to cheaper models.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: 'explain_file',
-    description:
-      'Explain a specific file: returns its extracted signatures, direct imports ' +
-      '(files it depends on), and callers (files that import it). ' +
-      'Ideal for understanding a file in isolation without reading raw source. ' +
-      'Requires the context file to have been generated first.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string',
-          description:
-            'Relative path from the project root (e.g. "src/services/auth.ts"). ' +
-            'Use the paths shown in read_context output.',
-        },
-      },
-      required: ['path'],
-    },
-  },
-  {
-    name: 'list_modules',
-    description:
-      'List all top-level modules (srcDirs) present in the context file, ' +
-      'sorted by token count descending. Use this to decide which module to ' +
-      'pass to read_context before querying a specific area of the codebase.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: 'query_context',
-    description:
-      'Rank and return the most relevant files for a specific task or question. ' +
-      'Uses keyword + symbol + path scoring to surface only the top-K files relevant ' +
-      'to the query — much cheaper than reading all context. ' +
-      'Returns ranked file list with signatures and relevance scores.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: {
-          type: 'string',
-          description:
-            'Natural language task description or keyword(s) to rank files against. ' +
-            'E.g. "add a new language extractor", "fix secret scanning", "auth module".',
-        },
-        topK: {
-          type: 'number',
-          description: 'Maximum number of files to return (default: 10, max: 25).',
-        },
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'get_impact',
-    description:
-      'Show every file that is impacted when a given file changes — direct importers, ' +
-      'transitive importers, affected tests, and affected routes/controllers. ' +
-      'Gives agents instant blast-radius awareness before making a change. ' +
-      'Handles circular dependencies safely (no infinite loops).',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          description:
-            'Relative path from the project root of the file that changed ' +
-            '(e.g. "src/extractors/python.js"). Use forward slashes.',
-        },
-        depth: {
-          type: 'number',
-          description: 'BFS traversal depth limit (default: 3). Use 0 for unlimited.',
-        },
-      },
-      required: ['file'],
-    },
-  },
-  {
-    name: 'get_lines',
-    description:
-      'Fetch an exact line range from a source file on demand — the Surgical Context ' +
-      'workhorse. Signatures carry `path:start-end` anchors; call this to read just those ' +
-      'lines instead of re-opening the whole file. Lines are clamped to the file bounds and ' +
-      'secret-scanned (redacted) before return. Path is sandboxed to the project root.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          description:
-            'Relative path from the project root (e.g. "src/config/loader.js"). ' +
-            'Use the path shown in a signature anchor. Use forward slashes.',
-        },
-        start: {
-          type: 'number',
-          description: '1-based start line (inclusive). Clamped to the file bounds.',
-        },
-        end: {
-          type: 'number',
-          description: '1-based end line (inclusive). Clamped to the file bounds.',
-        },
-      },
-      required: ['file', 'start', 'end'],
-    },
-  },
-  {
-    name: 'read_memory',
-    description:
-      'Recall the project decision log — recent notes left by humans or agents ' +
-      'across sessions (via `sigmap note`), plus the last ranking-session focus. ' +
-      'Call this at the start of a task to kill cold-start: it answers ' +
-      '"what were we doing and why" without re-reading the whole codebase.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        limit: {
-          type: 'number',
-          description: 'How many of the most recent notes to return (default: 10, max: 50).',
-        },
-      },
-      required: [],
-    },
-  },
-];
-
-module.exports = { TOOLS };
-
+  module.exports = { TOOLS };
+  
 };
 // ── ./src/routing/classifier ──
 __factories["./src/routing/classifier"] = function(module, exports) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -6306,7 +6306,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.2.1',
+    version: '7.3.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -11571,7 +11571,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.2.1';
+const VERSION = '7.3.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,7 +24,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 52.2% |
 | Prompts per task | 2.84 | 1.72 (39.4% fewer) |
 | Supported languages | — | 31 |
-| MCP tools | — | 11 |
+| MCP tools | — | 12 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -114,7 +114,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 11 tools
+## MCP server — 12 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -208,6 +208,14 @@ Recall the project decision log — recent notes left by humans or agents across
 
 ```
 Input:  { limit?: number }
+```
+
+### get_callee_signatures
+
+Return the EXACT current signature(s) of named symbols (functions, classes, methods) from the index — so an agent never guesses a callee's parameter types from training memory. Call this before writing code that uses a symbol. Unknown names get a closest-match suggestion.
+
+```
+Input:  { symbols: array }
 ```
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.3.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 52.2% vs 10% without SigMap
 - Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 31 supported · MCP tools: 11
+- Languages: 31 supported · MCP tools: 12
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.2.1 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.3.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -543,4 +543,57 @@ function readMemory(args, cwd) {
   return out.join('\n');
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory };
+/**
+ * get_callee_signatures — return the exact defining signature(s) of named
+ * symbols from the index, so an agent never guesses a callee's parameter types.
+ * Unknown names get a closest-match suggestion.
+ * @param {{symbols:string[]}} args
+ * @param {string} cwd
+ */
+function getCalleeSignatures(args, cwd) {
+  const symbols = args && Array.isArray(args.symbols)
+    ? args.symbols.map((s) => String(s).trim()).filter(Boolean)
+    : null;
+  if (!symbols || symbols.length === 0) {
+    return 'Missing required argument: symbols (non-empty string[])';
+  }
+
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const { buildSymbolCandidates, closestMatch, formatSuggestion } = require('../verify/closest-match');
+    const index = buildSigIndex(cwd);
+    if (index.size === 0) return 'No context file found. Run: node gen-context.js';
+
+    // Extract the defining symbol name from a signature line (same rules as
+    // buildSymbolCandidates) so we match definitions, not param occurrences.
+    const defName = (sig) => {
+      const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+      const m = cleaned.match(/\b(?:async\s+function|function|class|def|interface|type|enum|const|let|var)\s+([A-Za-z_$][\w$]*)/)
+        || cleaned.match(/([A-Za-z_$][\w$]*)\s*\(/);
+      return m ? m[1] : null;
+    };
+
+    const candidates = buildSymbolCandidates(index);
+    const blocks = [];
+    for (const symbol of symbols) {
+      const matches = [];
+      for (const [file, sigs] of index.entries()) {
+        for (const sig of sigs) {
+          if (defName(sig) === symbol) matches.push(`${sig}    (${file})`);
+        }
+      }
+      if (matches.length === 0) {
+        const cm = closestMatch(symbol, candidates);
+        const hint = cm ? ' — ' + formatSuggestion(cm) : '';
+        blocks.push(`### ${symbol}\n_not found in index${hint}_`);
+      } else {
+        blocks.push(`### ${symbol}\n${matches.join('\n')}`);
+      }
+    }
+    return blocks.join('\n\n');
+  } catch (err) {
+    return `_get_callee_signatures failed: ${err.message}_`;
+  }
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.2.1',
+  version: '7.3.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -14,7 +14,7 @@
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -77,6 +77,7 @@ function dispatch(msg, cwd) {
       else if (name === 'get_impact') text = getImpact(args, cwd);
       else if (name === 'get_lines') text = getLines(args, cwd);
       else if (name === 'read_memory') text = readMemory(args, cwd);
+      else if (name === 'get_callee_signatures') text = getCalleeSignatures(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,9 +1,10 @@
 'use strict';
 
 /**
- * MCP tool definitions for SigMap (11 tools).
+ * MCP tool definitions for SigMap (12 tools).
  * read_context, search_signatures, get_map, create_checkpoint, get_routing,
- * explain_file, list_modules, query_context, get_impact, get_lines, read_memory.
+ * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
+ * get_callee_signatures.
  */
 
 const TOOLS = [
@@ -213,6 +214,25 @@ const TOOLS = [
         },
       },
       required: [],
+    },
+  },
+  {
+    name: 'get_callee_signatures',
+    description:
+      'Return the EXACT current signature(s) of named symbols (functions, classes, ' +
+      "methods) from the index — so an agent never guesses a callee's parameter types " +
+      'from training memory. Call this before writing code that uses a symbol. ' +
+      'Unknown names get a closest-match suggestion.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbols: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Symbol names to resolve (e.g. ["validateToken", "UserService"]).',
+        },
+      },
+      required: ['symbols'],
     },
   },
 ];

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 11 tools (not 10)', () => {
+test('mcp.md: description mentions 12 tools (not 11)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('11 tools'), 'missing "11 tools" in mcp.md');
+  assert.ok(src.includes('12 tools'), 'missing "12 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -69,9 +69,9 @@ test('version.json: languages is 31', () => {
   assert.strictEqual(v.languages, 31);
 });
 
-test('version.json: mcp_tools is 11', () => {
+test('version.json: mcp_tools is 12', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 11);
+  assert.strictEqual(v.mcp_tools, 12);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 11 tools including get_impact', () => {
+test('MCP tools/list: returns 12 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 11, `expected 11 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 12, `expected 12 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (11 tools total)', () => {
+test('get_lines is registered (12 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 11, `expected 11 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 12, `expected 12 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -99,14 +99,14 @@ test('initialize returns serverInfo', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
-// Gate 2: tools/list returns 11 tools (v6.16+)
+// Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 11 tools', () => {
+test('tools/list returns exactly 12 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 11);
+    assert.strictEqual(res.result.tools.length, 12);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');
@@ -118,6 +118,51 @@ test('tools/list returns exactly 11 tools', () => {
     assert.ok(names.includes('query_context'), 'Should have query_context');
     assert.ok(names.includes('get_impact'), 'Should have get_impact');
     assert.ok(names.includes('get_lines'), 'Should have get_lines');
+    assert.ok(names.includes('read_memory'), 'Should have read_memory');
+    assert.ok(names.includes('get_callee_signatures'), 'Should have get_callee_signatures');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Gate 2b: get_callee_signatures resolves known + unknown symbols (bundle path)
+// ─────────────────────────────────────────────────────────────
+test('get_callee_signatures returns exact signature for a known symbol', () => {
+  withTempProject((dir) => {
+    seedContextFile(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 22,
+        params: { name: 'get_callee_signatures', arguments: { symbols: ['login', 'nope_xyz'] } } },
+      dir
+    );
+    assert.ok(res.result, 'Should have result');
+    const text = res.result.content[0].text;
+    assert.ok(text.includes('login(user, pass)'), 'exact signature for login');
+    assert.ok(/nope_xyz[\s\S]*not found/.test(text), 'unknown symbol marked not found');
+  });
+});
+
+test('get_callee_signatures suggests a closest match for a near-miss', () => {
+  withTempProject((dir) => {
+    seedContextFile(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 23,
+        params: { name: 'get_callee_signatures', arguments: { symbols: ['getUsr'] } } },
+      dir
+    );
+    const text = res.result.content[0].text;
+    assert.ok(/Did you mean .*getUser/.test(text), `expected getUser suggestion, got: ${text}`);
+  });
+});
+
+test('get_callee_signatures errors on missing symbols arg', () => {
+  withTempProject((dir) => {
+    seedContextFile(dir);
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 24,
+        params: { name: 'get_callee_signatures', arguments: {} } },
+      dir
+    );
+    assert.ok(/Missing required argument: symbols/.test(res.result.content[0].text), 'should report missing arg');
   });
 });
 

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -78,17 +78,17 @@ function seedContextFile(dir) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Gate: tools/list now returns 11 tools including v6.16 read_memory
+// Gate: tools/list now returns 12 tools including get_callee_signatures
 // ─────────────────────────────────────────────────────────────
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 11 tools', () => {
+test('tools/list returns exactly 12 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 11, `Expected 11 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 12, `Expected 12 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 11);
+  assert.strictEqual(tools.length, 12);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 11 tools including query_context', () => {
+test('MCP tools/list: returns 12 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 11, `expected 11 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 12, `expected 12 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
-  "mcp_tools": 11,
+  "mcp_tools": 12,
   "tests": 81,
   "metrics": {
     "hit_at_5": 0.756,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.2.1",
+  "version": "7.3.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.3.0** to main: `get_callee_signatures` MCP tool (#282/#283) + version/changelog/docs prep (#284).

## Test plan
- [x] `node test/integration/all.js` — 75/75
- [x] gates green (check-bundle, check-version-meta)

After merge: tag v7.3.0 on the main merge commit → npm + binaries.