### PR TITLE
feat(mcp): read-time self-heal (IMPL.md Layer 1 safety net)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -20,6 +20,132 @@ function __require(key) {
 }
 
 
+// ── ./src/cache/freshen ──
+__factories["./src/cache/freshen"] = function(module, exports) {
+  
+  /**
+   * Read-time self-heal (IMPL.md Layer 1, "safety net" tier).
+   *
+   * Keeps the sig-cache in line with the current source tree so the index reflects
+   * on-disk reality even when no write hook was called. Re-extracts files modified
+   * since the context file was generated (bounded to actual session edits, not the
+   * whole tree), drops cache entries for deleted files, and persists. buildSigIndex
+   * already merges the cache, so the next read is fresh.
+   *
+   * Throttled per cwd. Skips entirely when there is no generated index to heal
+   * (a cold repo should run `generate` or use the notify hooks).
+   *
+   * Zero-dependency, bundle-safe (fs + dispatch + sig-cache).
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { loadCache, saveCache, getChangedFiles } = __require('./src/cache/sig-cache');
+  const { extractFile, langFor } = __require('./src/extractors/dispatch');
+
+  const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'packages', 'services', 'api'];
+  const DEFAULT_EXCLUDE = [
+    'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+    '.next', 'coverage', 'target', 'vendor', '.context',
+  ];
+  const CONTEXT_PATHS = [
+    ['.github', 'copilot-instructions.md'],
+    ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+  ];
+  const THROTTLE_MS = 1500;
+  const _lastRun = new Map();
+
+  function _readConfig(cwd) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+      return cfg && typeof cfg === 'object' ? cfg : {};
+    } catch (_) { return {}; }
+  }
+
+  function _pkgVersion(cwd) {
+    try { return JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).version || '0.0.0'; }
+    catch (_) { return '0.0.0'; }
+  }
+
+  /** Newest mtime among existing generated context files, or 0 if none. */
+  function _contextMtime(cwd) {
+    let newest = 0;
+    for (const parts of CONTEXT_PATHS) {
+      try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+    }
+    return newest;
+  }
+
+  function _walk(dir, exclude, out, depth, maxDepth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    for (const e of entries) {
+      if (exclude.has(e.name)) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) _walk(full, exclude, out, depth + 1, maxDepth);
+      else if (e.isFile() && langFor(e.name)) out.push(full);
+    }
+  }
+
+  /**
+   * Re-extract source files changed since the last generate; drop deleted files.
+   * @param {string} cwd
+   * @param {{force?:boolean, now?:number}} [opts]
+   * @returns {number} cache entries touched
+   */
+  function freshen(cwd, opts = {}) {
+    const now = opts.now != null ? opts.now : Date.now();
+    if (!opts.force) {
+      if (now - (_lastRun.get(cwd) || 0) < THROTTLE_MS) return 0;
+    }
+    _lastRun.set(cwd, now);
+
+    try {
+      const version = _pkgVersion(cwd);
+      const cache = loadCache(cwd, version);
+      const ctxMtime = _contextMtime(cwd);
+      // Nothing to heal: no generated context AND no live cache overlay.
+      if (ctxMtime === 0 && cache.size === 0) return 0;
+
+      const cfg = _readConfig(cwd);
+      const srcDirs = Array.isArray(cfg.srcDirs) && cfg.srcDirs.length ? cfg.srcDirs : DEFAULT_SRC_DIRS;
+      const exclude = new Set([...DEFAULT_EXCLUDE, ...(Array.isArray(cfg.exclude) ? cfg.exclude : [])]);
+      const maxDepth = Number.isFinite(cfg.maxDepth) ? cfg.maxDepth : 8;
+
+      const files = [];
+      for (const d of srcDirs) {
+        const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+        if (fs.existsSync(abs)) _walk(abs, exclude, files, 0, maxDepth);
+      }
+
+      // Candidates = files modified since the context was generated, or not yet cached.
+      const candidates = files.filter((f) => {
+        try { return fs.statSync(f).mtimeMs > ctxMtime || !cache.has(f); } catch (_) { return false; }
+      });
+      const { changed } = getChangedFiles(candidates, cache);
+
+      let touched = 0;
+      for (const f of changed) {
+        try {
+          const sigs = extractFile(f, fs.readFileSync(f, 'utf8'));
+          cache.set(f, { mtime: fs.statSync(f).mtimeMs, sigs });
+          touched++;
+        } catch (_) {}
+      }
+      // Note: deletions are NOT swept here — a cache entry may be a `notify`
+      // overlay for a file not yet on disk. Explicit removal is `notify_file_deleted`.
+
+      if (touched > 0) saveCache(cwd, version, cache);
+      return touched;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  module.exports = { freshen };
+  
+};
 // ── ./src/extractors/dispatch ──
 __factories["./src/extractors/dispatch"] = function(module, exports) {
   
@@ -5717,6 +5843,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
 
     const query = args.query.toLowerCase();
     try {
+      try { __require('./src/cache/freshen').freshen(cwd); } catch (_) {}
       const { buildSigIndex } = __require('./src/retrieval/ranker');
       const index = buildSigIndex(cwd);
       if (index.size === 0) {
@@ -6204,6 +6331,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     }
 
     try {
+      try { __require('./src/cache/freshen').freshen(cwd); } catch (_) {}
       const { buildSigIndex } = __require('./src/retrieval/ranker');
       const { buildSymbolCandidates, closestMatch, formatSuggestion } = __require('./src/verify/closest-match');
       const index = buildSigIndex(cwd);

--- a/src/cache/freshen.js
+++ b/src/cache/freshen.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Read-time self-heal (IMPL.md Layer 1, "safety net" tier).
+ *
+ * Keeps the sig-cache in line with the current source tree so the index reflects
+ * on-disk reality even when no write hook was called. Re-extracts files modified
+ * since the context file was generated (bounded to actual session edits, not the
+ * whole tree), drops cache entries for deleted files, and persists. buildSigIndex
+ * already merges the cache, so the next read is fresh.
+ *
+ * Throttled per cwd. Skips entirely when there is no generated index to heal
+ * (a cold repo should run `generate` or use the notify hooks).
+ *
+ * Zero-dependency, bundle-safe (fs + dispatch + sig-cache).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadCache, saveCache, getChangedFiles } = require('./sig-cache');
+const { extractFile, langFor } = require('../extractors/dispatch');
+
+const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'packages', 'services', 'api'];
+const DEFAULT_EXCLUDE = [
+  'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+  '.next', 'coverage', 'target', 'vendor', '.context',
+];
+const CONTEXT_PATHS = [
+  ['.github', 'copilot-instructions.md'],
+  ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+];
+const THROTTLE_MS = 1500;
+const _lastRun = new Map();
+
+function _readConfig(cwd) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+    return cfg && typeof cfg === 'object' ? cfg : {};
+  } catch (_) { return {}; }
+}
+
+function _pkgVersion(cwd) {
+  try { return JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).version || '0.0.0'; }
+  catch (_) { return '0.0.0'; }
+}
+
+/** Newest mtime among existing generated context files, or 0 if none. */
+function _contextMtime(cwd) {
+  let newest = 0;
+  for (const parts of CONTEXT_PATHS) {
+    try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+  }
+  return newest;
+}
+
+function _walk(dir, exclude, out, depth, maxDepth) {
+  if (depth > maxDepth) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+  for (const e of entries) {
+    if (exclude.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) _walk(full, exclude, out, depth + 1, maxDepth);
+    else if (e.isFile() && langFor(e.name)) out.push(full);
+  }
+}
+
+/**
+ * Re-extract source files changed since the last generate; drop deleted files.
+ * @param {string} cwd
+ * @param {{force?:boolean, now?:number}} [opts]
+ * @returns {number} cache entries touched
+ */
+function freshen(cwd, opts = {}) {
+  const now = opts.now != null ? opts.now : Date.now();
+  if (!opts.force) {
+    if (now - (_lastRun.get(cwd) || 0) < THROTTLE_MS) return 0;
+  }
+  _lastRun.set(cwd, now);
+
+  try {
+    const version = _pkgVersion(cwd);
+    const cache = loadCache(cwd, version);
+    const ctxMtime = _contextMtime(cwd);
+    // Nothing to heal: no generated context AND no live cache overlay.
+    if (ctxMtime === 0 && cache.size === 0) return 0;
+
+    const cfg = _readConfig(cwd);
+    const srcDirs = Array.isArray(cfg.srcDirs) && cfg.srcDirs.length ? cfg.srcDirs : DEFAULT_SRC_DIRS;
+    const exclude = new Set([...DEFAULT_EXCLUDE, ...(Array.isArray(cfg.exclude) ? cfg.exclude : [])]);
+    const maxDepth = Number.isFinite(cfg.maxDepth) ? cfg.maxDepth : 8;
+
+    const files = [];
+    for (const d of srcDirs) {
+      const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+      if (fs.existsSync(abs)) _walk(abs, exclude, files, 0, maxDepth);
+    }
+
+    // Candidates = files modified since the context was generated, or not yet cached.
+    const candidates = files.filter((f) => {
+      try { return fs.statSync(f).mtimeMs > ctxMtime || !cache.has(f); } catch (_) { return false; }
+    });
+    const { changed } = getChangedFiles(candidates, cache);
+
+    let touched = 0;
+    for (const f of changed) {
+      try {
+        const sigs = extractFile(f, fs.readFileSync(f, 'utf8'));
+        cache.set(f, { mtime: fs.statSync(f).mtimeMs, sigs });
+        touched++;
+      } catch (_) {}
+    }
+    // Note: deletions are NOT swept here — a cache entry may be a `notify`
+    // overlay for a file not yet on disk. Explicit removal is `notify_file_deleted`.
+
+    if (touched > 0) saveCache(cwd, version, cache);
+    return touched;
+  } catch (_) {
+    return 0;
+  }
+}
+
+module.exports = { freshen };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -72,6 +72,7 @@ function searchSignatures(args, cwd) {
 
   const query = args.query.toLowerCase();
   try {
+    try { require('../cache/freshen').freshen(cwd); } catch (_) {}
     const { buildSigIndex } = require('../retrieval/ranker');
     const index = buildSigIndex(cwd);
     if (index.size === 0) {
@@ -559,6 +560,7 @@ function getCalleeSignatures(args, cwd) {
   }
 
   try {
+    try { require('../cache/freshen').freshen(cwd); } catch (_) {}
     const { buildSigIndex } = require('../retrieval/ranker');
     const { buildSymbolCandidates, closestMatch, formatSuggestion } = require('../verify/closest-match');
     const index = buildSigIndex(cwd);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -170,6 +170,27 @@ test('get_callee_signatures errors on missing symbols arg', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// Gate 2bb: read-time self-heal — disk edits reflected without a hook
+// ─────────────────────────────────────────────────────────────
+test('self-heal: a file written on disk (no hook) is resolvable on read', () => {
+  withTempProject((dir) => {
+    seedContextFile(dir); // gives a context-file mtime baseline
+    const f = path.join(dir, 'src', 'healed.js');
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, 'function selfHealed(a, b){ return a + b; }\nmodule.exports = { selfHealed };\n');
+    const future = Date.now() / 1000 + 30;
+    fs.utimesSync(f, future, future); // ensure mtime > context, defeat ms granularity
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 30,
+        params: { name: 'get_callee_signatures', arguments: { symbols: ['selfHealed'] } } },
+      dir
+    );
+    assert.ok(/selfHealed\(a, b\)/.test(res.result.content[0].text),
+      `disk edit should self-heal into the index: ${res.result.content[0].text}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
 // Gate 2c: Layer 1 write hooks — live index for agent-created code
 // ─────────────────────────────────────────────────────────────
 test('notify_file_created makes a new symbol live (same session)', () => {


### PR DESCRIPTION
Closes #290. Completes **Layer 1** freshness — the §2 "safety net" tier that removes the write-hooks' agent-cooperation single point of failure.

## Summary
The v7.4.0 write hooks keep the index live *only if the agent calls them*. Now the read tools reconcile the index with the source tree on read, so **on-disk edits are reflected even when no hook fired**.

## Changes
- **src/cache/freshen.js** (new): `freshen(cwd)` re-extracts source files modified since the context was generated (bounded to session edits, not the whole tree) via the bundle-safe `extractFile`, persists to the sig-cache (which `buildSigIndex` merges). **Throttled** per cwd; **skips** when there's no generated index to heal.
- **search_signatures / get_callee_signatures** call `freshen` before `buildSigIndex`.
- **No deletion sweep** — a cache entry may be a `notify` overlay for a file not yet on disk; explicit removal stays `notify_file_deleted`. (This avoids regressing the v7.4.0 notify-with-content flow.)

## Verified
- Standalone bundle: a file written on disk with **no hook** is resolvable by `get_callee_signatures`.
- `node test/integration/all.js` — 75/75 · `npm test` — pass · check-bundle + version-meta green · no regression to notify tests.

## Scope / follow-ups
Remaining Layer-1 tier: the **event-driven watcher floor**. Plus import-graph incremental updates and full removal of context-baked symbols. Per IMPL.md, the **grounding-ablation benchmark (the GATE)** is the next priority before Layers 3–4.

## Supply-chain
No shell · main exports API · tarball 358KB/128 files (freshen.js +1).