### PR TITLE
Release v7.5.0 — read-time self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.5.0] — 2026-06-17
+
+Minor release — read-time self-heal completes Layer 1 freshness.
+
+### Added
+- **Read-time self-heal — live index without agent hooks (#290):** the v7.4.0 write hooks kept the index fresh only if the agent called them; now `search_signatures` / `get_callee_signatures` reconcile the index with the source tree *on read*, so on-disk edits show up even when no hook fired — closing that single point of failure. New `src/cache/freshen.js` re-extracts files modified since the last `generate` (bounded to actual session edits, not the whole tree), persists to the sig-cache (which `buildSigIndex` merges), and is throttled per repo. Deletions stay the job of `sigmap_notify_file_deleted` (a cache entry may be a notify overlay for a not-yet-on-disk file). Verified end-to-end in the standalone bundle.
+
+---
+
 ## [7.4.0] — 2026-06-17
 
 Minor release — live-index write hooks (grounded codegen, Layer 1).

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.4.0, with recent releases adding live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.5.0, with recent releases adding read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Sixty-six versions shipped. MIT open source from day one.
+Sixty-seven versions shipped. MIT open source from day one.
 
 **Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.5.0 — Read-time self-heal ✓ (2026-06-17)
+
+**Minor release — completes Layer 1 freshness.** The v7.4.0 write hooks kept the index live *only if the agent called them*; this removes that single point of failure. `search_signatures` / `get_callee_signatures` now reconcile the index with the source tree **on read** — `src/cache/freshen.js` re-extracts files modified since the last `generate` (bounded to actual session edits, not the whole tree; throttled per repo) and persists to the sig-cache, which `buildSigIndex` merges. So on-disk edits show up even when no hook fired. Deletions stay explicit (`sigmap_notify_file_deleted`), since a cache entry can be a notify overlay for a not-yet-on-disk file. Verified end-to-end in the standalone bundle.
+
+**Tags:** `read-time-self-heal` · `freshen` · `live-index` · `no-cooperation` · `grounded-codegen` · `#290`
+
+**Impact:** Layer 1 freshness is now robust (write hooks + self-heal) — the index reflects reality without depending on the agent.
+
+---
+
 ### v7.4.0 — Live-index MCP write hooks ✓ (2026-06-17)
 
 **Minor release — grounded codegen, Layer 1.** Three new MCP tools — `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, `sigmap_notify_file_deleted` — keep the index fresh while an agent creates/modifies/deletes files mid-session, so a freshly-written symbol is immediately resolvable by `search_signatures` / `get_callee_signatures` instead of being re-hallucinated. They update the persisted sig-cache (which `buildSigIndex` already merges), so changes are live on the next read. New bundle-safe `src/extractors/dispatch.js` (static extractor dispatch). Also fixes a pre-existing standalone-bundle bug: the `ranker` factory had a raw `require('../cache/sig-cache')` never rewritten to `__require`, so the cache merge silently failed in the SEA binary — regenerated, and the full create→resolve→delete cycle now works from the bundle with no `src/`.
@@ -900,7 +910,7 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.5+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.6+ (PR verification + Interactive Context Explorer)
 
 v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.4.0</span>
+  <span><strong>Release:</strong> v7.5.0</span>
   <span>·</span>
-  <span>New MCP write hooks (15 tools) — the index stays live as an agent creates/changes files, so freshly-written symbols are instantly resolvable, not re-hallucinated</span>
+  <span>Read-time self-heal — the index reconciles with the source tree on read, so on-disk edits are reflected even when no write hook fired (Layer 1 freshness complete)</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.4.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.4.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6626,7 +6626,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.4.0',
+    version: '7.5.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -12304,7 +12304,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.4.0';
+const VERSION = '7.5.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -20,6 +20,132 @@ function __require(key) {
 }
 
 
+// ── ./src/cache/freshen ──
+__factories["./src/cache/freshen"] = function(module, exports) {
+  
+  /**
+   * Read-time self-heal (IMPL.md Layer 1, "safety net" tier).
+   *
+   * Keeps the sig-cache in line with the current source tree so the index reflects
+   * on-disk reality even when no write hook was called. Re-extracts files modified
+   * since the context file was generated (bounded to actual session edits, not the
+   * whole tree), drops cache entries for deleted files, and persists. buildSigIndex
+   * already merges the cache, so the next read is fresh.
+   *
+   * Throttled per cwd. Skips entirely when there is no generated index to heal
+   * (a cold repo should run `generate` or use the notify hooks).
+   *
+   * Zero-dependency, bundle-safe (fs + dispatch + sig-cache).
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { loadCache, saveCache, getChangedFiles } = __require('./src/cache/sig-cache');
+  const { extractFile, langFor } = __require('./src/extractors/dispatch');
+
+  const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'packages', 'services', 'api'];
+  const DEFAULT_EXCLUDE = [
+    'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+    '.next', 'coverage', 'target', 'vendor', '.context',
+  ];
+  const CONTEXT_PATHS = [
+    ['.github', 'copilot-instructions.md'],
+    ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+  ];
+  const THROTTLE_MS = 1500;
+  const _lastRun = new Map();
+
+  function _readConfig(cwd) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+      return cfg && typeof cfg === 'object' ? cfg : {};
+    } catch (_) { return {}; }
+  }
+
+  function _pkgVersion(cwd) {
+    try { return JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).version || '0.0.0'; }
+    catch (_) { return '0.0.0'; }
+  }
+
+  /** Newest mtime among existing generated context files, or 0 if none. */
+  function _contextMtime(cwd) {
+    let newest = 0;
+    for (const parts of CONTEXT_PATHS) {
+      try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+    }
+    return newest;
+  }
+
+  function _walk(dir, exclude, out, depth, maxDepth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    for (const e of entries) {
+      if (exclude.has(e.name)) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) _walk(full, exclude, out, depth + 1, maxDepth);
+      else if (e.isFile() && langFor(e.name)) out.push(full);
+    }
+  }
+
+  /**
+   * Re-extract source files changed since the last generate; drop deleted files.
+   * @param {string} cwd
+   * @param {{force?:boolean, now?:number}} [opts]
+   * @returns {number} cache entries touched
+   */
+  function freshen(cwd, opts = {}) {
+    const now = opts.now != null ? opts.now : Date.now();
+    if (!opts.force) {
+      if (now - (_lastRun.get(cwd) || 0) < THROTTLE_MS) return 0;
+    }
+    _lastRun.set(cwd, now);
+
+    try {
+      const version = _pkgVersion(cwd);
+      const cache = loadCache(cwd, version);
+      const ctxMtime = _contextMtime(cwd);
+      // Nothing to heal: no generated context AND no live cache overlay.
+      if (ctxMtime === 0 && cache.size === 0) return 0;
+
+      const cfg = _readConfig(cwd);
+      const srcDirs = Array.isArray(cfg.srcDirs) && cfg.srcDirs.length ? cfg.srcDirs : DEFAULT_SRC_DIRS;
+      const exclude = new Set([...DEFAULT_EXCLUDE, ...(Array.isArray(cfg.exclude) ? cfg.exclude : [])]);
+      const maxDepth = Number.isFinite(cfg.maxDepth) ? cfg.maxDepth : 8;
+
+      const files = [];
+      for (const d of srcDirs) {
+        const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+        if (fs.existsSync(abs)) _walk(abs, exclude, files, 0, maxDepth);
+      }
+
+      // Candidates = files modified since the context was generated, or not yet cached.
+      const candidates = files.filter((f) => {
+        try { return fs.statSync(f).mtimeMs > ctxMtime || !cache.has(f); } catch (_) { return false; }
+      });
+      const { changed } = getChangedFiles(candidates, cache);
+
+      let touched = 0;
+      for (const f of changed) {
+        try {
+          const sigs = extractFile(f, fs.readFileSync(f, 'utf8'));
+          cache.set(f, { mtime: fs.statSync(f).mtimeMs, sigs });
+          touched++;
+        } catch (_) {}
+      }
+      // Note: deletions are NOT swept here — a cache entry may be a `notify`
+      // overlay for a file not yet on disk. Explicit removal is `notify_file_deleted`.
+
+      if (touched > 0) saveCache(cwd, version, cache);
+      return touched;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  module.exports = { freshen };
+  
+};
 // ── ./src/extractors/dispatch ──
 __factories["./src/extractors/dispatch"] = function(module, exports) {
   
@@ -5717,6 +5843,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
 
     const query = args.query.toLowerCase();
     try {
+      try { __require('./src/cache/freshen').freshen(cwd); } catch (_) {}
       const { buildSigIndex } = __require('./src/retrieval/ranker');
       const index = buildSigIndex(cwd);
       if (index.size === 0) {
@@ -6204,6 +6331,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     }
 
     try {
+      try { __require('./src/cache/freshen').freshen(cwd); } catch (_) {}
       const { buildSigIndex } = __require('./src/retrieval/ranker');
       const { buildSymbolCandidates, closestMatch, formatSuggestion } = __require('./src/verify/closest-match');
       const index = buildSigIndex(cwd);

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.4.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.4.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/cache/freshen.js
+++ b/src/cache/freshen.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Read-time self-heal (IMPL.md Layer 1, "safety net" tier).
+ *
+ * Keeps the sig-cache in line with the current source tree so the index reflects
+ * on-disk reality even when no write hook was called. Re-extracts files modified
+ * since the context file was generated (bounded to actual session edits, not the
+ * whole tree), drops cache entries for deleted files, and persists. buildSigIndex
+ * already merges the cache, so the next read is fresh.
+ *
+ * Throttled per cwd. Skips entirely when there is no generated index to heal
+ * (a cold repo should run `generate` or use the notify hooks).
+ *
+ * Zero-dependency, bundle-safe (fs + dispatch + sig-cache).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadCache, saveCache, getChangedFiles } = require('./sig-cache');
+const { extractFile, langFor } = require('../extractors/dispatch');
+
+const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'packages', 'services', 'api'];
+const DEFAULT_EXCLUDE = [
+  'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+  '.next', 'coverage', 'target', 'vendor', '.context',
+];
+const CONTEXT_PATHS = [
+  ['.github', 'copilot-instructions.md'],
+  ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+];
+const THROTTLE_MS = 1500;
+const _lastRun = new Map();
+
+function _readConfig(cwd) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+    return cfg && typeof cfg === 'object' ? cfg : {};
+  } catch (_) { return {}; }
+}
+
+function _pkgVersion(cwd) {
+  try { return JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).version || '0.0.0'; }
+  catch (_) { return '0.0.0'; }
+}
+
+/** Newest mtime among existing generated context files, or 0 if none. */
+function _contextMtime(cwd) {
+  let newest = 0;
+  for (const parts of CONTEXT_PATHS) {
+    try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+  }
+  return newest;
+}
+
+function _walk(dir, exclude, out, depth, maxDepth) {
+  if (depth > maxDepth) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+  for (const e of entries) {
+    if (exclude.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) _walk(full, exclude, out, depth + 1, maxDepth);
+    else if (e.isFile() && langFor(e.name)) out.push(full);
+  }
+}
+
+/**
+ * Re-extract source files changed since the last generate; drop deleted files.
+ * @param {string} cwd
+ * @param {{force?:boolean, now?:number}} [opts]
+ * @returns {number} cache entries touched
+ */
+function freshen(cwd, opts = {}) {
+  const now = opts.now != null ? opts.now : Date.now();
+  if (!opts.force) {
+    if (now - (_lastRun.get(cwd) || 0) < THROTTLE_MS) return 0;
+  }
+  _lastRun.set(cwd, now);
+
+  try {
+    const version = _pkgVersion(cwd);
+    const cache = loadCache(cwd, version);
+    const ctxMtime = _contextMtime(cwd);
+    // Nothing to heal: no generated context AND no live cache overlay.
+    if (ctxMtime === 0 && cache.size === 0) return 0;
+
+    const cfg = _readConfig(cwd);
+    const srcDirs = Array.isArray(cfg.srcDirs) && cfg.srcDirs.length ? cfg.srcDirs : DEFAULT_SRC_DIRS;
+    const exclude = new Set([...DEFAULT_EXCLUDE, ...(Array.isArray(cfg.exclude) ? cfg.exclude : [])]);
+    const maxDepth = Number.isFinite(cfg.maxDepth) ? cfg.maxDepth : 8;
+
+    const files = [];
+    for (const d of srcDirs) {
+      const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+      if (fs.existsSync(abs)) _walk(abs, exclude, files, 0, maxDepth);
+    }
+
+    // Candidates = files modified since the context was generated, or not yet cached.
+    const candidates = files.filter((f) => {
+      try { return fs.statSync(f).mtimeMs > ctxMtime || !cache.has(f); } catch (_) { return false; }
+    });
+    const { changed } = getChangedFiles(candidates, cache);
+
+    let touched = 0;
+    for (const f of changed) {
+      try {
+        const sigs = extractFile(f, fs.readFileSync(f, 'utf8'));
+        cache.set(f, { mtime: fs.statSync(f).mtimeMs, sigs });
+        touched++;
+      } catch (_) {}
+    }
+    // Note: deletions are NOT swept here — a cache entry may be a `notify`
+    // overlay for a file not yet on disk. Explicit removal is `notify_file_deleted`.
+
+    if (touched > 0) saveCache(cwd, version, cache);
+    return touched;
+  } catch (_) {
+    return 0;
+  }
+}
+
+module.exports = { freshen };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -72,6 +72,7 @@ function searchSignatures(args, cwd) {
 
   const query = args.query.toLowerCase();
   try {
+    try { require('../cache/freshen').freshen(cwd); } catch (_) {}
     const { buildSigIndex } = require('../retrieval/ranker');
     const index = buildSigIndex(cwd);
     if (index.size === 0) {
@@ -559,6 +560,7 @@ function getCalleeSignatures(args, cwd) {
   }
 
   try {
+    try { require('../cache/freshen').freshen(cwd); } catch (_) {}
     const { buildSigIndex } = require('../retrieval/ranker');
     const { buildSymbolCandidates, closestMatch, formatSuggestion } = require('../verify/closest-match');
     const index = buildSigIndex(cwd);

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.4.0',
+  version: '7.5.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -170,6 +170,27 @@ test('get_callee_signatures errors on missing symbols arg', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// Gate 2bb: read-time self-heal — disk edits reflected without a hook
+// ─────────────────────────────────────────────────────────────
+test('self-heal: a file written on disk (no hook) is resolvable on read', () => {
+  withTempProject((dir) => {
+    seedContextFile(dir); // gives a context-file mtime baseline
+    const f = path.join(dir, 'src', 'healed.js');
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, 'function selfHealed(a, b){ return a + b; }\nmodule.exports = { selfHealed };\n');
+    const future = Date.now() / 1000 + 30;
+    fs.utimesSync(f, future, future); // ensure mtime > context, defeat ms granularity
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 30,
+        params: { name: 'get_callee_signatures', arguments: { symbols: ['selfHealed'] } } },
+      dir
+    );
+    assert.ok(/selfHealed\(a, b\)/.test(res.result.content[0].text),
+      `disk edit should self-heal into the index: ${res.result.content[0].text}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
 // Gate 2c: Layer 1 write hooks — live index for agent-created code
 // ─────────────────────────────────────────────────────────────
 test('notify_file_created makes a new symbol live (same session)', () => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.4.0",
+  "version": "7.5.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.5.0** to main: read-time self-heal (#290/#291) + version/changelog/docs prep (#292).

## Test plan
- [x] node test/integration/all.js — 75/75
- [x] gates green (check-bundle, check-version-meta)

After merge: tag v7.5.0 on the main merge commit → npm + binaries.