### PR TITLE
Release v7.6.0 — grounding benchmark (the GATE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.6.0] — 2026-06-17
+
+Minor release — the grounding benchmark (the offline GATE for grounded codegen).
+
+### Added
+- **Grounding benchmark — `npm run benchmark:grounding` (#294):** a deterministic, offline callee-grounding ablation that measures how much ground truth SigMap actually gives an agent. For each corpus repo: `coverage = grounded / universe`, where universe is every symbol defined in the source and grounded is the subset SigMap surfaces in its index (resolvable by `get_callee_signatures`); baseline is 0 (no SigMap → guess every reference). `scripts/run-hallucination-benchmark.mjs` prints per-repo + aggregate coverage; `--save` writes `benchmarks/reports/hallucination.json`; `--gate <pct>` exits non-zero below a threshold. It's an honest *ground-truth-availability proxy*, not a measured LLM hallucination rate (the LLM A/B ablation is a documented follow-up needing an API key). No LLM, no network — runs in CI.
+
+---
+
 ## [7.5.0] — 2026-06-17
 
 Minor release — read-time self-heal completes Layer 1 freshness.

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.5.0, with recent releases adding read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.6.0, with recent releases adding the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -20,7 +20,7 @@ head:
 ---
 # Roadmap
 
-Sixty-seven versions shipped. MIT open source from day one.
+Sixty-eight versions shipped. MIT open source from day one.
 
 **Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.6.0 — Grounding benchmark (the GATE) ✓ (2026-06-17)
+
+**Minor release.** A deterministic, offline **callee-grounding ablation** (`npm run benchmark:grounding`) that measures how much ground truth SigMap actually gives an agent: per corpus repo, `coverage = grounded / universe` — universe being every symbol defined in the source, grounded the subset SigMap surfaces in its index (resolvable by `get_callee_signatures`); baseline is 0 (no SigMap → guess every reference). `scripts/run-hallucination-benchmark.mjs` prints per-repo + aggregate coverage, `--save`s `hallucination.json`, and `--gate <pct>` exits non-zero below a threshold. Honestly framed as a ground-truth-availability proxy — not an LLM hallucination rate (the LLM A/B ablation is a follow-up needing an API key). This is the **decision gate** before the grounded-codegen Layers 3–4 (conventions/scaffold): measure first, then decide.
+
+**Tags:** `benchmark:grounding` · `grounding-ablation` · `the-gate` · `offline` · `hallucination.json` · `#294`
+
+**Impact:** the grounded-codegen plan now has a reproducible number behind it instead of invented percentages.
+
+---
+
 ### v7.5.0 — Read-time self-heal ✓ (2026-06-17)
 
 **Minor release — completes Layer 1 freshness.** The v7.4.0 write hooks kept the index live *only if the agent called them*; this removes that single point of failure. `search_signatures` / `get_callee_signatures` now reconcile the index with the source tree **on read** — `src/cache/freshen.js` re-extracts files modified since the last `generate` (bounded to actual session edits, not the whole tree; throttled per repo) and persists to the sig-cache, which `buildSigIndex` merges. So on-disk edits show up even when no hook fired. Deletions stay explicit (`sigmap_notify_file_deleted`), since a cache entry can be a notify overlay for a not-yet-on-disk file. Verified end-to-end in the standalone bundle.
@@ -910,7 +920,7 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.6+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.7+ (PR verification + Interactive Context Explorer)
 
 v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.5.0</span>
+  <span><strong>Release:</strong> v7.6.0</span>
   <span>·</span>
-  <span>Read-time self-heal — the index reconciles with the source tree on read, so on-disk edits are reflected even when no write hook fired (Layer 1 freshness complete)</span>
+  <span>Grounding benchmark (<code>npm run benchmark:grounding</code>) — a deterministic, offline measure of how much ground truth SigMap gives an agent vs guessing</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6626,7 +6626,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.5.0',
+    version: '7.6.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -12304,7 +12304,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.5.0';
+const VERSION = '7.6.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.5.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:llms": "node scripts/generate-llms.mjs",
     "validate:llms": "node scripts/validate-llms.mjs",
-    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/check-version-meta.mjs && node scripts/generate-llms.mjs"
+    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/check-version-meta.mjs && node scripts/generate-llms.mjs",
+    "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs"
   },
   "files": [
     "gen-context.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/scripts/run-hallucination-benchmark.mjs
+++ b/scripts/run-hallucination-benchmark.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * SigMap grounding benchmark — the offline GATE (IMPL.md §7/§9).
+ *
+ * Measures how much ground truth SigMap actually gives an agent, as a
+ * callee-grounding ablation. NO LLM, no network, deterministic — so it runs in
+ * CI and the number is reproducible.
+ *
+ *   universe  = every symbol DEFINED in a repo's source (bundle-safe extractFile)
+ *   grounded  = symbols SigMap surfaces in its index (buildSigIndex) — i.e. the
+ *               ones get_callee_signatures can return exact signatures for
+ *   coverage  = grounded / universe
+ *   baseline  = 0  (no SigMap → the agent guesses every reference)
+ *
+ * Hallucination-risk proxy = fraction of references the agent must guess:
+ *   without SigMap ≈ 100%   ·   with SigMap ≈ (1 − coverage)
+ *
+ * This is a ground-truth-availability proxy, NOT a measured LLM hallucination
+ * rate. The true LLM A/B ablation (run a model with/without context, count
+ * verify-ai-output flags) is a follow-up that requires an API key + network.
+ *
+ * Usage:
+ *   node scripts/run-hallucination-benchmark.mjs            # per-repo + aggregate table
+ *   node scripts/run-hallucination-benchmark.mjs --save     # also write benchmarks/reports/hallucination.json
+ *   node scripts/run-hallucination-benchmark.mjs --gate 50  # exit 1 if aggregate coverage < 50%
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { spawnSync } from 'child_process';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const REPOS_DIR = path.join(ROOT, 'benchmarks', 'repos');
+const REPORTS = path.join(ROOT, 'benchmarks', 'reports');
+const GEN_CTX = path.join(ROOT, 'gen-context.js');
+
+const { buildSigIndex } = require(path.join(ROOT, 'src/retrieval/ranker.js'));
+const { extractFile, langFor } = require(path.join(ROOT, 'src/extractors/dispatch.js'));
+
+const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'packages', 'services', 'api', 'lng', 'R'];
+const EXCLUDE = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+  '.next', 'coverage', 'target', 'vendor', '.context', 'test', 'tests', '__tests__',
+]);
+
+/** Defining symbol name from a signature line (same rule as the MCP handler). */
+function defName(sig) {
+  const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+  const m = cleaned.match(/\b(?:async\s+function|function|class|def|interface|type|enum|const|let|var)\s+([A-Za-z_$][\w$]*)/)
+    || cleaned.match(/([A-Za-z_$][\w$]*)\s*\(/);
+  return m ? m[1] : null;
+}
+
+function _walk(dir, out, depth) {
+  if (depth > 8) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+  for (const e of entries) {
+    if (EXCLUDE.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) _walk(full, out, depth + 1);
+    else if (e.isFile() && langFor(e.name)) out.push(full);
+  }
+}
+
+function _srcDirs(repoDir) {
+  let dirs = DEFAULT_SRC_DIRS;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(repoDir, 'gen-context.config.json'), 'utf8'));
+    if (Array.isArray(cfg.srcDirs) && cfg.srcDirs.length) dirs = cfg.srcDirs;
+  } catch (_) {}
+  return dirs;
+}
+
+/** Every symbol defined across a repo's source — the universe an agent may reference. */
+function definedNames(repoDir) {
+  const files = [];
+  for (const d of _srcDirs(repoDir)) {
+    const abs = path.join(repoDir, d);
+    if (fs.existsSync(abs)) _walk(abs, files, 0);
+  }
+  // Fallback: if no known srcDir, scan the repo root (shallow).
+  if (files.length === 0) _walk(repoDir, files, 0);
+  const names = new Set();
+  for (const f of files) {
+    try {
+      for (const sig of extractFile(f, fs.readFileSync(f, 'utf8'))) {
+        const n = defName(sig);
+        if (n) names.add(n);
+      }
+    } catch (_) {}
+  }
+  return names;
+}
+
+/** Symbols SigMap surfaces in its index (resolvable by get_callee_signatures). */
+function indexedNames(repoDir) {
+  const names = new Set();
+  try {
+    for (const sigs of buildSigIndex(repoDir).values()) {
+      for (const sig of sigs) { const n = defName(sig); if (n) names.add(n); }
+    }
+  } catch (_) {}
+  return names;
+}
+
+/**
+ * Grounding coverage for one repo.
+ * @returns {{ total:number, grounded:number, dark:number, coverage:number }}
+ */
+export function measureGrounding(repoDir) {
+  const universe = definedNames(repoDir);
+  const indexed = indexedNames(repoDir);
+  let grounded = 0;
+  for (const n of universe) if (indexed.has(n)) grounded++;
+  const total = universe.size;
+  return {
+    total,
+    grounded,
+    dark: total - grounded,
+    coverage: total > 0 ? grounded / total : 0,
+  };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main() {
+  const save = process.argv.includes('--save');
+  const gateIdx = process.argv.indexOf('--gate');
+  const gateThreshold = gateIdx !== -1 && process.argv[gateIdx + 1] ? parseFloat(process.argv[gateIdx + 1]) : null;
+
+  let repos = [];
+  try {
+    repos = fs.readdirSync(REPOS_DIR, { withFileTypes: true })
+      .filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch (_) {}
+  if (repos.length === 0) {
+    console.error('No corpus repos in benchmarks/repos. Clone them first (see run-benchmark-matrix.mjs).');
+    process.exit(1);
+  }
+
+  console.log('SigMap grounding benchmark (offline callee-grounding ablation)\n');
+  const rows = [];
+  let tTotal = 0, tGrounded = 0;
+  for (const repo of repos) {
+    const dir = path.join(REPOS_DIR, repo);
+    // Ensure an index exists (re-generate, like the quality benchmark).
+    spawnSync(process.execPath, [GEN_CTX], { cwd: dir, stdio: 'ignore' });
+    const m = measureGrounding(dir);
+    rows.push({ repo, ...m });
+    tTotal += m.total; tGrounded += m.grounded;
+    console.log(`  ${repo.padEnd(22)} ${String(m.grounded).padStart(6)}/${String(m.total).padEnd(6)} grounded  ${(m.coverage * 100).toFixed(1)}%`);
+  }
+  const aggCoverage = tTotal > 0 ? tGrounded / tTotal : 0;
+  const aggPct = (aggCoverage * 100).toFixed(1);
+  console.log('  ' + '─'.repeat(50));
+  console.log(`  AGGREGATE              ${String(tGrounded).padStart(6)}/${String(tTotal).padEnd(6)} grounded  ${aggPct}%`);
+  console.log(`\n  Ground-truth availability: ${aggPct}% with SigMap  vs  0% without (every reference guessed).`);
+  console.log('  (Proxy for hallucination risk — not a measured LLM rate. LLM A/B ablation: follow-up.)');
+
+  if (save) {
+    fs.mkdirSync(REPORTS, { recursive: true });
+    fs.writeFileSync(path.join(REPORTS, 'hallucination.json'),
+      JSON.stringify({ benchmark: 'grounding-coverage', repos: rows, aggregate: { total: tTotal, grounded: tGrounded, coverage: aggCoverage } }, null, 2));
+    console.log(`\n  saved → benchmarks/reports/hallucination.json`);
+  }
+
+  if (gateThreshold != null) {
+    if (aggCoverage * 100 < gateThreshold) {
+      console.error(`\n  GATE FAIL: grounding coverage ${aggPct}% < ${gateThreshold}%`);
+      process.exit(1);
+    }
+    console.log(`\n  GATE PASS: grounding coverage ${aggPct}% ≥ ${gateThreshold}%`);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.5.0',
+  version: '7.6.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/hallucination-benchmark.test.js
+++ b/test/integration/hallucination-benchmark.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Grounding benchmark (the GATE) — scripts/run-hallucination-benchmark.mjs.
+ * Deterministic, offline. Run: node test/integration/hallucination-benchmark.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const GEN = path.join(ROOT, 'gen-context.js');
+const SCRIPT = path.join(ROOT, 'scripts', 'run-hallucination-benchmark.mjs');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gbench-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'),
+      'function alpha(x){ return x; }\nclass Beta { go(){ return 2; } }\nmodule.exports = { alpha, Beta };\n');
+    fs.writeFileSync(path.join(dir, 'src', 'b.js'),
+      'function helper(y){ return y * 2; }\nmodule.exports = { helper };\n');
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+(async () => {
+  const { measureGrounding } = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
+
+  test('baseline: no index → 0% coverage (every symbol dark)', () => {
+    withRepo((dir) => {
+      const m = measureGrounding(dir);
+      assert.ok(m.total > 0, 'should find defined symbols');
+      assert.strictEqual(m.grounded, 0, 'nothing grounded without an index');
+      assert.strictEqual(m.coverage, 0);
+      assert.strictEqual(m.dark, m.total);
+    });
+  });
+
+  test('with SigMap: generated index grounds the symbols (ablation holds)', () => {
+    withRepo((dir) => {
+      execFileSync(process.execPath, [GEN], { cwd: dir, stdio: 'ignore' });
+      const m = measureGrounding(dir);
+      assert.ok(m.total > 0);
+      assert.ok(m.grounded > 0, 'symbols should be grounded after generate');
+      assert.ok(m.coverage > 0.5, `coverage should be high for a small repo, got ${m.coverage}`);
+      assert.ok(m.dark < m.total, 'fewer dark symbols with SigMap');
+    });
+  });
+
+  test('measureGrounding shape is stable', () => {
+    withRepo((dir) => {
+      const m = measureGrounding(dir);
+      for (const k of ['total', 'grounded', 'dark', 'coverage']) {
+        assert.ok(typeof m[k] === 'number', `${k} should be a number`);
+      }
+      assert.strictEqual(m.grounded + m.dark, m.total, 'grounded + dark = total');
+    });
+  });
+
+  console.log(`\nhallucination-benchmark: ${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 81,
+  "tests": 82,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.0",
+  "version": "7.6.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.6.0** to main: grounding benchmark / the GATE (#294/#295) + version/changelog/docs prep (#296).

## Test plan
- [x] node test/integration/all.js — 76/76
- [x] gates green (check-bundle, check-version-meta)

After merge: tag v7.6.0 on the main merge commit → npm + binaries.