### PR TITLE
feat: sigmap conventions — extract repo coding conventions (Layer 3)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -21,6 +21,166 @@ function __require(key) {
 
 
 // ── ./src/cache/freshen ──
+// ── ./src/conventions/extract ──
+__factories["./src/conventions/extract"] = function(module, exports) {
+  
+  /**
+   * Convention extraction (IMPL.md Layer 3 — grounded code generation).
+   *
+   * Detects a repo's dominant coding conventions so generated code matches the
+   * house style instead of drifting (Cause 4: naming/convention drift). This
+   * first slice covers TS/JS/Python and three conventions: file naming, export
+   * style, and test framework. `scoreConvention` is the reusable consistency
+   * primitive that Gap 1 (scaffold confidence) will also build on.
+   *
+   * Zero dependencies, bundle-safe (fs + path only).
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+  const PY_EXTS = new Set(['.py']);
+  const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+  // Consistency tiers (IMPL.md §5.1): a convention is only safe to enforce when
+  // it is actually consistent.
+  const TIER_CONSISTENT = 0.9;
+  const TIER_MOSTLY = 0.7;
+
+  /**
+   * Classify a file's base name (without extension) into a naming style.
+   * @param {string} basename a file basename, e.g. "user-service.ts"
+   * @returns {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'|'other'}
+   */
+  function classifyNaming(basename) {
+    let stem = String(basename || '');
+    const dot = stem.indexOf('.');
+    if (dot > 0) stem = stem.slice(0, dot); // strip ext + compound suffix (.test, .d)
+    if (!stem) return 'other';
+    if (/[-]/.test(stem) && /^[a-z0-9]+(?:-[a-z0-9]+)+$/.test(stem)) return 'kebab-case';
+    if (/[_]/.test(stem) && /^[a-z0-9]+(?:_[a-z0-9]+)+$/.test(stem)) return 'snake_case';
+    if (/^[A-Z][A-Za-z0-9]*$/.test(stem) && /[a-z]/.test(stem)) return 'PascalCase';
+    if (/^[a-z][A-Za-z0-9]*$/.test(stem) && /[A-Z]/.test(stem)) return 'camelCase';
+    if (/^[a-z][a-z0-9]*$/.test(stem)) return 'camelCase'; // single lowercase word
+    return 'other';
+  }
+
+  /**
+   * Score a set of categorical observations into a dominant convention plus its
+   * consistency tier. The reusable primitive (IMPL.md §5.2).
+   * @param {string[]} labels observed category for each sample (e.g. naming styles)
+   * @returns {{ dominant: string|null, dominantPct: number, total: number,
+   *             variants: Array<{label:string, count:number, pct:number}>,
+   *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
+   */
+  function scoreConvention(labels) {
+    const list = (labels || []).filter((l) => l != null && l !== 'other');
+    const total = list.length;
+    if (total === 0) {
+      return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
+    }
+    const counts = new Map();
+    for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
+    const variants = [...counts.entries()]
+      .map(([label, count]) => ({ label, count, pct: count / total }))
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    const top = variants[0];
+    let tier = 'inconsistent';
+    if (top.pct >= TIER_CONSISTENT) tier = 'consistent';
+    else if (top.pct >= TIER_MOSTLY) tier = 'mostly';
+    return {
+      dominant: top.label,
+      dominantPct: top.pct,
+      total,
+      variants,
+      tier,
+    };
+  }
+
+  /** Detect JS/TS export style for a single file's source. */
+  function _jsExportStyle(src) {
+    const s = String(src || '');
+    if (/\bexport\s+default\b/.test(s) || /\bmodule\.exports\s*=\s*(?:function|class|\{?\s*[A-Za-z_$])/.test(s)) {
+      // module.exports = { a, b } reads as named; only treat bare assignment as default.
+      if (/\bexport\s+default\b/.test(s)) return 'default';
+      if (/\bmodule\.exports\s*=\s*\{/.test(s)) return 'named';
+      return 'default';
+    }
+    if (/\bexport\s+(?:const|let|var|function|class|async\s+function|\{|type|interface|enum)\b/.test(s)
+      || /\bmodule\.exports\s*=\s*\{/.test(s) || /\bexports\.[A-Za-z_$]/.test(s)) {
+      return 'named';
+    }
+    return 'other';
+  }
+
+  /** Detect the test framework in use from manifests + source heuristics. */
+  function _detectTestFramework(cwd, files) {
+    const deps = {};
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      Object.assign(deps, pkg.dependencies, pkg.devDependencies);
+    } catch (_) {}
+    for (const fw of ['vitest', 'jest', 'mocha', 'ava', 'jasmine']) {
+      if (deps[fw]) return fw;
+    }
+    // Python: pytest in requirements / pyproject.
+    for (const manifest of ['requirements.txt', 'requirements-dev.txt', 'pyproject.toml', 'setup.cfg']) {
+      try {
+        const raw = fs.readFileSync(path.join(cwd, manifest), 'utf8');
+        if (/\bpytest\b/.test(raw)) return 'pytest';
+        if (/\bunittest\b/.test(raw)) return 'unittest';
+      } catch (_) {}
+    }
+    // Fallback: infer from test file contents.
+    for (const f of files) {
+      if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) continue;
+      let src = '';
+      try { src = fs.readFileSync(f, 'utf8'); } catch (_) { continue; }
+      if (/\bvi\.(fn|mock|spyOn)\b|from ['"]vitest['"]/.test(src)) return 'vitest';
+      if (/\bjest\.(fn|mock|spyOn)\b/.test(src)) return 'jest';
+      if (/\bimport pytest\b|@pytest\./.test(src)) return 'pytest';
+      if (/\bdescribe\(|\bit\(/.test(src)) return 'mocha/jest-style';
+    }
+    return null;
+  }
+
+  /**
+   * Extract repo coding conventions for the scoped languages (TS/JS/Python).
+   * @param {string} cwd repo root
+   * @param {string[]} files absolute paths to source files (e.g. from buildFileList)
+   * @returns {{ fileNaming: object, exportStyle: object, testFramework: string|null,
+   *             scope: string[], scannedFiles: number }}
+   */
+  function extractConventions(cwd, files) {
+    const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
+    const namingLabels = [];
+    const exportLabels = [];
+    for (const f of scoped) {
+      const base = path.basename(f);
+      // Skip test files for the naming convention (they have their own naming).
+      if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
+        namingLabels.push(classifyNaming(base));
+      }
+      if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
+        let src = '';
+        try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
+        exportLabels.push(_jsExportStyle(src));
+      }
+    }
+    return {
+      fileNaming: scoreConvention(namingLabels),
+      exportStyle: scoreConvention(exportLabels),
+      testFramework: _detectTestFramework(cwd, scoped),
+      scope: ['typescript', 'javascript', 'python'],
+      scannedFiles: scoped.length,
+    };
+  }
+
+  module.exports = { classifyNaming, scoreConvention, extractConventions };
+  
+};
+
 __factories["./src/cache/freshen"] = function(module, exports) {
   
   /**
@@ -15470,6 +15630,48 @@ function main() {
     } else {
       console.log('  Notes:         none — add with: sigmap note "<text>"');
     }
+    process.exit(0);
+  }
+
+  // Layer 3: `sigmap conventions` — extract & report repo coding conventions
+  // (file naming, export style, test framework) for TS/JS/Python so generated
+  // code matches the house style. Writes .context/conventions.json.
+  if (args[0] === 'conventions') {
+    const jsonOut = args.includes('--json');
+    const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
+    const files = buildFileList(cwd, config);
+    const result = extractConventions(cwd, files);
+
+    const outDir = path.join(cwd, '.context');
+    const outPath = path.join(outDir, 'conventions.json');
+    try {
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n');
+    } catch (e) {
+      console.error(`[sigmap] cannot write ${outPath}: ${e.message}`);
+      process.exit(1);
+    }
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(result) + '\n');
+      process.exit(0);
+    }
+
+    const pct = (n) => `${(n * 100).toFixed(0)}%`;
+    const tierLabel = { consistent: 'consistent', mostly: 'mostly', inconsistent: 'mixed', unknown: 'n/a' };
+    const line = (name, conv) => {
+      if (!conv || conv.total === 0) return `  ${name.padEnd(14)} n/a (no samples)`;
+      const variants = conv.variants.slice(1, 3).map((v) => `${v.label} ${pct(v.pct)}`).join(', ');
+      const tail = variants ? `  ·  also: ${variants}` : '';
+      return `  ${name.padEnd(14)} ${conv.dominant} ${pct(conv.dominantPct)} [${tierLabel[conv.tier]}]${tail}`;
+    };
+
+    console.log('[sigmap] conventions  (TS/JS/Python)');
+    console.log(`  scanned        ${result.scannedFiles} file${result.scannedFiles === 1 ? '' : 's'}`);
+    console.log(line('file naming', result.fileNaming));
+    console.log(line('export style', result.exportStyle));
+    console.log(`  ${'test framework'.padEnd(14)} ${result.testFramework || 'none detected'}`);
+    console.log(`\n  → wrote ${path.relative(cwd, outPath)}`);
     process.exit(0);
   }
 

--- a/src/conventions/extract.js
+++ b/src/conventions/extract.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Convention extraction (IMPL.md Layer 3 — grounded code generation).
+ *
+ * Detects a repo's dominant coding conventions so generated code matches the
+ * house style instead of drifting (Cause 4: naming/convention drift). This
+ * first slice covers TS/JS/Python and three conventions: file naming, export
+ * style, and test framework. `scoreConvention` is the reusable consistency
+ * primitive that Gap 1 (scaffold confidence) will also build on.
+ *
+ * Zero dependencies, bundle-safe (fs + path only).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const PY_EXTS = new Set(['.py']);
+const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+// Consistency tiers (IMPL.md §5.1): a convention is only safe to enforce when
+// it is actually consistent.
+const TIER_CONSISTENT = 0.9;
+const TIER_MOSTLY = 0.7;
+
+/**
+ * Classify a file's base name (without extension) into a naming style.
+ * @param {string} basename a file basename, e.g. "user-service.ts"
+ * @returns {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'|'other'}
+ */
+function classifyNaming(basename) {
+  let stem = String(basename || '');
+  const dot = stem.indexOf('.');
+  if (dot > 0) stem = stem.slice(0, dot); // strip ext + compound suffix (.test, .d)
+  if (!stem) return 'other';
+  if (/[-]/.test(stem) && /^[a-z0-9]+(?:-[a-z0-9]+)+$/.test(stem)) return 'kebab-case';
+  if (/[_]/.test(stem) && /^[a-z0-9]+(?:_[a-z0-9]+)+$/.test(stem)) return 'snake_case';
+  if (/^[A-Z][A-Za-z0-9]*$/.test(stem) && /[a-z]/.test(stem)) return 'PascalCase';
+  if (/^[a-z][A-Za-z0-9]*$/.test(stem) && /[A-Z]/.test(stem)) return 'camelCase';
+  if (/^[a-z][a-z0-9]*$/.test(stem)) return 'camelCase'; // single lowercase word
+  return 'other';
+}
+
+/**
+ * Score a set of categorical observations into a dominant convention plus its
+ * consistency tier. The reusable primitive (IMPL.md §5.2).
+ * @param {string[]} labels observed category for each sample (e.g. naming styles)
+ * @returns {{ dominant: string|null, dominantPct: number, total: number,
+ *             variants: Array<{label:string, count:number, pct:number}>,
+ *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
+ */
+function scoreConvention(labels) {
+  const list = (labels || []).filter((l) => l != null && l !== 'other');
+  const total = list.length;
+  if (total === 0) {
+    return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
+  }
+  const counts = new Map();
+  for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
+  const variants = [...counts.entries()]
+    .map(([label, count]) => ({ label, count, pct: count / total }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  const top = variants[0];
+  let tier = 'inconsistent';
+  if (top.pct >= TIER_CONSISTENT) tier = 'consistent';
+  else if (top.pct >= TIER_MOSTLY) tier = 'mostly';
+  return {
+    dominant: top.label,
+    dominantPct: top.pct,
+    total,
+    variants,
+    tier,
+  };
+}
+
+/** Detect JS/TS export style for a single file's source. */
+function _jsExportStyle(src) {
+  const s = String(src || '');
+  if (/\bexport\s+default\b/.test(s) || /\bmodule\.exports\s*=\s*(?:function|class|\{?\s*[A-Za-z_$])/.test(s)) {
+    // module.exports = { a, b } reads as named; only treat bare assignment as default.
+    if (/\bexport\s+default\b/.test(s)) return 'default';
+    if (/\bmodule\.exports\s*=\s*\{/.test(s)) return 'named';
+    return 'default';
+  }
+  if (/\bexport\s+(?:const|let|var|function|class|async\s+function|\{|type|interface|enum)\b/.test(s)
+    || /\bmodule\.exports\s*=\s*\{/.test(s) || /\bexports\.[A-Za-z_$]/.test(s)) {
+    return 'named';
+  }
+  return 'other';
+}
+
+/** Detect the test framework in use from manifests + source heuristics. */
+function _detectTestFramework(cwd, files) {
+  const deps = {};
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    Object.assign(deps, pkg.dependencies, pkg.devDependencies);
+  } catch (_) {}
+  for (const fw of ['vitest', 'jest', 'mocha', 'ava', 'jasmine']) {
+    if (deps[fw]) return fw;
+  }
+  // Python: pytest in requirements / pyproject.
+  for (const manifest of ['requirements.txt', 'requirements-dev.txt', 'pyproject.toml', 'setup.cfg']) {
+    try {
+      const raw = fs.readFileSync(path.join(cwd, manifest), 'utf8');
+      if (/\bpytest\b/.test(raw)) return 'pytest';
+      if (/\bunittest\b/.test(raw)) return 'unittest';
+    } catch (_) {}
+  }
+  // Fallback: infer from test file contents.
+  for (const f of files) {
+    if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) continue;
+    let src = '';
+    try { src = fs.readFileSync(f, 'utf8'); } catch (_) { continue; }
+    if (/\bvi\.(fn|mock|spyOn)\b|from ['"]vitest['"]/.test(src)) return 'vitest';
+    if (/\bjest\.(fn|mock|spyOn)\b/.test(src)) return 'jest';
+    if (/\bimport pytest\b|@pytest\./.test(src)) return 'pytest';
+    if (/\bdescribe\(|\bit\(/.test(src)) return 'mocha/jest-style';
+  }
+  return null;
+}
+
+/**
+ * Extract repo coding conventions for the scoped languages (TS/JS/Python).
+ * @param {string} cwd repo root
+ * @param {string[]} files absolute paths to source files (e.g. from buildFileList)
+ * @returns {{ fileNaming: object, exportStyle: object, testFramework: string|null,
+ *             scope: string[], scannedFiles: number }}
+ */
+function extractConventions(cwd, files) {
+  const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
+  const namingLabels = [];
+  const exportLabels = [];
+  for (const f of scoped) {
+    const base = path.basename(f);
+    // Skip test files for the naming convention (they have their own naming).
+    if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
+      namingLabels.push(classifyNaming(base));
+    }
+    if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
+      let src = '';
+      try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
+      exportLabels.push(_jsExportStyle(src));
+    }
+  }
+  return {
+    fileNaming: scoreConvention(namingLabels),
+    exportStyle: scoreConvention(exportLabels),
+    testFramework: _detectTestFramework(cwd, scoped),
+    scope: ['typescript', 'javascript', 'python'],
+    scannedFiles: scoped.length,
+  };
+}
+
+module.exports = { classifyNaming, scoreConvention, extractConventions };

--- a/test/integration/conventions.test.js
+++ b/test/integration/conventions.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions` (Layer 3 — grounded codegen).
+ *   classifyNaming · scoreConvention (tiers) · extractConventions · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { classifyNaming, scoreConvention, extractConventions } =
+  require(path.join(ROOT, 'src/conventions/extract'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// ── classifyNaming ──────────────────────────────────────────────────────────
+test('classifyNaming: PascalCase', () => {
+  assert.strictEqual(classifyNaming('UserService.ts'), 'PascalCase');
+});
+test('classifyNaming: camelCase', () => {
+  assert.strictEqual(classifyNaming('userService.ts'), 'camelCase');
+  assert.strictEqual(classifyNaming('loader.js'), 'camelCase'); // single lowercase word
+});
+test('classifyNaming: kebab-case', () => {
+  assert.strictEqual(classifyNaming('user-service.ts'), 'kebab-case');
+});
+test('classifyNaming: snake_case', () => {
+  assert.strictEqual(classifyNaming('user_service.py'), 'snake_case');
+});
+test('classifyNaming: strips compound suffix', () => {
+  assert.strictEqual(classifyNaming('user-service.test.ts'), 'kebab-case');
+});
+
+// ── scoreConvention ─────────────────────────────────────────────────────────
+test('scoreConvention: empty → unknown', () => {
+  const r = scoreConvention([]);
+  assert.strictEqual(r.tier, 'unknown');
+  assert.strictEqual(r.dominant, null);
+  assert.strictEqual(r.total, 0);
+});
+test('scoreConvention: consistent tier at >=90%', () => {
+  const labels = Array(95).fill('camelCase').concat(Array(5).fill('kebab-case'));
+  const r = scoreConvention(labels);
+  assert.strictEqual(r.dominant, 'camelCase');
+  assert.strictEqual(r.tier, 'consistent');
+  assert.ok(Math.abs(r.dominantPct - 0.95) < 1e-9);
+});
+test('scoreConvention: mostly tier in [70,90)', () => {
+  const r = scoreConvention(Array(8).fill('a').concat(Array(2).fill('b')));
+  assert.strictEqual(r.tier, 'mostly');
+});
+test('scoreConvention: inconsistent tier below 70%', () => {
+  const r = scoreConvention(Array(6).fill('a').concat(Array(4).fill('b')));
+  assert.strictEqual(r.tier, 'inconsistent');
+});
+test('scoreConvention: ignores "other" samples', () => {
+  const r = scoreConvention(['a', 'a', 'other', 'other']);
+  assert.strictEqual(r.total, 2);
+  assert.strictEqual(r.tier, 'consistent');
+});
+
+// ── extractConventions ──────────────────────────────────────────────────────
+test('extractConventions: detects naming + export + framework', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'),
+      'function a(){} module.exports = { a };\n');
+    fs.writeFileSync(path.join(dir, 'src', 'auth-guard.js'),
+      'export const b = 1;\n');
+    fs.writeFileSync(path.join(dir, 'package.json'),
+      JSON.stringify({ name: 't', devDependencies: { jest: '^29' } }));
+    const files = [
+      path.join(dir, 'src', 'user-service.js'),
+      path.join(dir, 'src', 'auth-guard.js'),
+    ];
+    const r = extractConventions(dir, files);
+    assert.strictEqual(r.fileNaming.dominant, 'kebab-case');
+    assert.strictEqual(r.fileNaming.tier, 'consistent');
+    assert.strictEqual(r.exportStyle.dominant, 'named');
+    assert.strictEqual(r.testFramework, 'jest');
+    assert.strictEqual(r.scannedFiles, 2);
+  });
+});
+test('extractConventions: ignores non-scoped files', () => {
+  withRepo((dir) => {
+    const files = [path.join(dir, 'a.go'), path.join(dir, 'b.rs')];
+    const r = extractConventions(dir, files);
+    assert.strictEqual(r.scannedFiles, 0);
+    assert.strictEqual(r.fileNaming.tier, 'unknown');
+  });
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: conventions writes .context/conventions.json and reports', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const x = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const y = 2;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/file naming/.test(res.stdout), 'prints report');
+    const outPath = path.join(dir, '.context', 'conventions.json');
+    assert.ok(fs.existsSync(outPath), 'writes conventions.json');
+    const data = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.strictEqual(data.fileNaming.dominant, 'camelCase');
+  });
+});
+test('CLI: conventions --json emits machine output', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'aaa.js'), 'export const x = 1;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.ok(data.fileNaming, 'has fileNaming');
+    assert.deepStrictEqual(data.scope, ['typescript', 'javascript', 'python']);
+  });
+});
+
+console.log(`\nconventions: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 82,
+  "tests": 83,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Adds `sigmap conventions` — the first slice of IMPL.md **Layer 3 (grounded code generation)**. Detects a repo's dominant coding conventions (file naming, export style, test framework) for TS/JS/Python so generated code matches the house style instead of drifting (Cause 4). Closes #298.

> Gate note: the v7.6.0 grounding GATE measured *coverage* (23.4%) — a ground-truth-availability proxy, not the LLM-ablation hallucination delta. Conventions is independently valuable for Cause 4, so we proceed here; the formal LLM A/B remains a follow-up.

## Changes
- `src/conventions/extract.js` (new, zero-dep, bundle-safe):
  - `classifyNaming(basename)` → naming style
  - `scoreConvention(labels[])` → `{ dominant, dominantPct, variants, tier }` — reusable consistency scorer (tiers at 90% / 70%); Gap 1 scaffold-confidence will reuse it
  - `extractConventions(cwd, files)` → file naming + JS/TS export style + test framework
- `gen-context.js`: `sigmap conventions` command → writes `.context/conventions.json`, prints a report, `--json` for machine output. Registered bundle factory.
- `version.json`: derived `tests` count 82 → 83 (no version/metric change — `/update-docs` owns the version bump).

Deferred to follow-ups: `--conflicts`, `--fix`, `--ci`, CLAUDE.md injection.

## Test plan
- [x] `node test/integration/conventions.test.js` — 14 passed
- [x] `node test/integration/all.js` — full suite green
- [x] `node scripts/check-bundle.mjs` / `check-version-meta.mjs` — gates pass
- [x] Supply-chain local audit: no shell spawns · no install scripts · main exports API · no fingerprinting