### PR TITLE
release: v7.7.0 — sigmap conventions (grounded codegen, Layer 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.7.0] — 2026-06-17
+
+Minor release — `sigmap conventions` (grounded codegen, Layer 3).
+
+### Added
+- **`sigmap conventions` — extract & report a repo's coding conventions (#298):** the first slice of Layer 3 (grounded code generation). Detects the dominant **file naming** style, **export style**, and **test framework** for TS/JS/Python so generated code matches the house style instead of drifting (Cause 4: naming/convention drift). New zero-dependency, bundle-safe `src/conventions/extract.js` exposes `classifyNaming` (PascalCase / camelCase / kebab-case / snake_case), `scoreConvention` (a reusable consistency scorer returning `{ dominant, dominantPct, variants, tier }` with tiers at 90% / 70% — Gap 1's scaffold-confidence floor will reuse it), and `extractConventions`. The command writes `.context/conventions.json` and prints a readable report; `--json` emits machine output. `--conflicts`, `--fix`, `--ci`, and CLAUDE.md injection are deferred to follow-ups.
+
+---
+
 ## [7.6.0] — 2026-06-17
 
 Minor release — the grounding benchmark (the offline GATE for grounded codegen).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,9 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
+### Recent Contributors (v7.7.0)
+- **@manojmallick** — feat: `sigmap conventions` — extract & report a repo's coding conventions (file naming, export style, test framework) for TS/JS/Python; reusable `scoreConvention` consistency scorer; Layer 3 grounded codegen (#298, PR #299)
+
 ### Recent Contributors (v7.0.1)
 - **@manojmallick** — fix: shell-free subprocess calls (zero `execSync` in the published surface), `main` → core API, removed unused device fingerprint, star nudge counts plain `sigmap` runs (#250, PRs #251 #252)
 

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -1,13 +1,13 @@
 ---
 title: CLI reference
-description: Complete SigMap CLI reference. All commands and flags with examples — ask, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --package, --global, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more.
+description: Complete SigMap CLI reference. All commands and flags with examples — ask, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --package, --global, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more.
 head:
   - - meta
     - property: og:title
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 54 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 53 SigMap commands and flags documented with examples. ask, gain, squeeze, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 54 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -53,6 +53,7 @@ If you are new to the product, start with the workflow pages first:
 | `ask "<query>" --no-squeeze` | Disable input minimization entirely |
 | `ask "<query>" --squeeze-threshold <n>` | Minimum reduction %% to prompt for minimization (default 30) |
 | `squeeze <file\|->` | Minimize a pasted stacktrace / CI-log / JSON blob (`--json` for stats) |
+| `conventions` | Extract & report a repo's coding conventions — file naming, export style, test framework (TS/JS/Python); writes `.context/conventions.json` (`--json` for machine output) |
 | `plan "<goal>"` | Analyze change impact and plan modifications — returns files grouped by confidence |
 | `judge --response <f> --context <f>` | Rule-based groundedness scoring for LLM responses |
 | `verify-ai-output <answer.md>` | Hallucination Guard — flag fake files, test files, imports, symbols, and npm scripts in an AI answer (deterministic, offline) |
@@ -393,6 +394,41 @@ Three deterministic detectors, each with its own minimizer:
 | `--json` | Emit `{ category, confidence, rawTokens, squeezedTokens, reduction, enriched, squeezed }` |
 
 Prose (no recognizable structure) passes through unchanged. The differentiator over generic log summarizers is **symbol enrichment** — SigMap attaches a real function signature to the top stack frame because it has the repo's symbol index.
+
+---
+
+## conventions
+
+Extract and report a repo's coding conventions so generated code matches the house style instead of drifting. Scans the source tree (TS/JS/Python) and reports the dominant **file naming** style, **export style**, and **test framework**, each with a consistency tier. Writes `.context/conventions.json` for tools to consume.
+
+```bash
+sigmap conventions          # report + write .context/conventions.json
+sigmap conventions --json   # machine-readable output
+```
+
+```
+[sigmap] conventions  (TS/JS/Python)
+  scanned        115 files
+  file naming    camelCase 77% [mostly]  ·  also: kebab-case 20%, snake_case 3%
+  export style   named 99% [consistent]  ·  also: default 1%
+  test framework none detected
+
+  → wrote .context/conventions.json
+```
+
+Each convention is scored into a **consistency tier** so you know whether it is safe to enforce:
+
+| Tier | Dominant share | Meaning |
+|------|----------------|---------|
+| `consistent` | ≥ 90% | One clear convention — safe to enforce |
+| `mostly` | 70–89% | A dominant convention with some drift |
+| `inconsistent` | < 70% | No clear convention |
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Emit `{ fileNaming, exportStyle, testFramework, scope, scannedFiles }` (each convention as `{ dominant, dominantPct, variants, tier }`) |
+
+This is the first slice of grounded code generation; `--conflicts`, `--fix`, `--ci`, and CLAUDE.md injection are planned follow-ups.
 
 ---
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.6.0, with recent releases adding the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.7.0, with recent releases adding the sigmap conventions command (grounded codegen, Layer 3), the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Sixty-eight versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 1,006 tests passing · 11 MCP tools · 29 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,030 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.7.0 — `sigmap conventions` (grounded codegen, Layer 3) ✓ (2026-06-17)
+
+**Minor release — first slice of Layer 3.** A new `sigmap conventions` command extracts and reports a repo's dominant coding conventions — **file naming** style, **export style**, and **test framework** — for TS/JS/Python, so generated code matches the house style instead of drifting (Cause 4: naming/convention drift). New zero-dependency, bundle-safe `src/conventions/extract.js` exposes `classifyNaming` (PascalCase / camelCase / kebab-case / snake_case), `scoreConvention` (a reusable consistency scorer returning `{ dominant, dominantPct, variants, tier }` with tiers at 90% / 70% — Gap 1's scaffold-confidence floor will reuse it), and `extractConventions`. The command writes `.context/conventions.json` and prints a readable report; `--json` for machine output. `--conflicts`, `--fix`, `--ci`, and CLAUDE.md injection are deferred to follow-ups.
+
+**Tags:** `conventions` · `grounded-codegen` · `layer-3` · `classifyNaming` · `scoreConvention` · `consistency-tiers` · `#298`
+
+**Impact:** SigMap now surfaces *how a repo writes code*, not just *what it contains* — the foundation for convention-matched code generation.
+
+---
+
 ### v7.6.0 — Grounding benchmark (the GATE) ✓ (2026-06-17)
 
 **Minor release.** A deterministic, offline **callee-grounding ablation** (`npm run benchmark:grounding`) that measures how much ground truth SigMap actually gives an agent: per corpus repo, `coverage = grounded / universe` — universe being every symbol defined in the source, grounded the subset SigMap surfaces in its index (resolvable by `get_callee_signatures`); baseline is 0 (no SigMap → guess every reference). `scripts/run-hallucination-benchmark.mjs` prints per-repo + aggregate coverage, `--save`s `hallucination.json`, and `--gate <pct>` exits non-zero below a threshold. Honestly framed as a ground-truth-availability proxy — not an LLM hallucination rate (the LLM A/B ablation is a follow-up needing an API key). This is the **decision gate** before the grounded-codegen Layers 3–4 (conventions/scaffold): measure first, then decide.
@@ -920,9 +930,9 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.7+ (PR verification + Interactive Context Explorer)
+## Current milestone — v7.8+ (grounded codegen: convention enforcement + scaffold)
 
-v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; and **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on). Next: **PR verification** — `verify-plan` and `review-pr` with a GitHub Action that posts a scope-drift + blast-radius comment on real PRs — plus the **Interactive Context Explorer** (a static, offline "what exactly gets sent for this query" demo), line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on); and the **grounded-codegen** track — **v7.4–7.5** live-index write hooks + read-time self-heal (Layer 1), **v7.6.0** the offline grounding benchmark (the GATE), and **v7.7.0** **`sigmap conventions`** (Layer 3: extract a repo's file-naming / export / test-framework conventions). Next: finish Layer 3 — `conventions --conflicts/--fix/--ci` and **CLAUDE.md convention injection** — then **Layer 4 scaffold** (generate convention-matched stubs). Also planned: **PR verification** (`verify-plan` / `review-pr` GitHub Action), the **Interactive Context Explorer**, line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.6.0</span>
+  <span><strong>Release:</strong> v7.7.0</span>
   <span>·</span>
-  <span>Grounding benchmark (<code>npm run benchmark:grounding</code>) — a deterministic, offline measure of how much ground truth SigMap gives an agent vs guessing</span>
+  <span><code>sigmap conventions</code> — extract a repo's file-naming, export, and test-framework conventions so generated code matches the house style (grounded codegen, Layer 3)</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -6786,7 +6786,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.6.0',
+    version: '7.7.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -12464,7 +12464,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.6.0';
+const VERSION = '7.7.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -21,6 +21,166 @@ function __require(key) {
 
 
 // ── ./src/cache/freshen ──
+// ── ./src/conventions/extract ──
+__factories["./src/conventions/extract"] = function(module, exports) {
+  
+  /**
+   * Convention extraction (IMPL.md Layer 3 — grounded code generation).
+   *
+   * Detects a repo's dominant coding conventions so generated code matches the
+   * house style instead of drifting (Cause 4: naming/convention drift). This
+   * first slice covers TS/JS/Python and three conventions: file naming, export
+   * style, and test framework. `scoreConvention` is the reusable consistency
+   * primitive that Gap 1 (scaffold confidence) will also build on.
+   *
+   * Zero dependencies, bundle-safe (fs + path only).
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+  const PY_EXTS = new Set(['.py']);
+  const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+  // Consistency tiers (IMPL.md §5.1): a convention is only safe to enforce when
+  // it is actually consistent.
+  const TIER_CONSISTENT = 0.9;
+  const TIER_MOSTLY = 0.7;
+
+  /**
+   * Classify a file's base name (without extension) into a naming style.
+   * @param {string} basename a file basename, e.g. "user-service.ts"
+   * @returns {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'|'other'}
+   */
+  function classifyNaming(basename) {
+    let stem = String(basename || '');
+    const dot = stem.indexOf('.');
+    if (dot > 0) stem = stem.slice(0, dot); // strip ext + compound suffix (.test, .d)
+    if (!stem) return 'other';
+    if (/[-]/.test(stem) && /^[a-z0-9]+(?:-[a-z0-9]+)+$/.test(stem)) return 'kebab-case';
+    if (/[_]/.test(stem) && /^[a-z0-9]+(?:_[a-z0-9]+)+$/.test(stem)) return 'snake_case';
+    if (/^[A-Z][A-Za-z0-9]*$/.test(stem) && /[a-z]/.test(stem)) return 'PascalCase';
+    if (/^[a-z][A-Za-z0-9]*$/.test(stem) && /[A-Z]/.test(stem)) return 'camelCase';
+    if (/^[a-z][a-z0-9]*$/.test(stem)) return 'camelCase'; // single lowercase word
+    return 'other';
+  }
+
+  /**
+   * Score a set of categorical observations into a dominant convention plus its
+   * consistency tier. The reusable primitive (IMPL.md §5.2).
+   * @param {string[]} labels observed category for each sample (e.g. naming styles)
+   * @returns {{ dominant: string|null, dominantPct: number, total: number,
+   *             variants: Array<{label:string, count:number, pct:number}>,
+   *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
+   */
+  function scoreConvention(labels) {
+    const list = (labels || []).filter((l) => l != null && l !== 'other');
+    const total = list.length;
+    if (total === 0) {
+      return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
+    }
+    const counts = new Map();
+    for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
+    const variants = [...counts.entries()]
+      .map(([label, count]) => ({ label, count, pct: count / total }))
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    const top = variants[0];
+    let tier = 'inconsistent';
+    if (top.pct >= TIER_CONSISTENT) tier = 'consistent';
+    else if (top.pct >= TIER_MOSTLY) tier = 'mostly';
+    return {
+      dominant: top.label,
+      dominantPct: top.pct,
+      total,
+      variants,
+      tier,
+    };
+  }
+
+  /** Detect JS/TS export style for a single file's source. */
+  function _jsExportStyle(src) {
+    const s = String(src || '');
+    if (/\bexport\s+default\b/.test(s) || /\bmodule\.exports\s*=\s*(?:function|class|\{?\s*[A-Za-z_$])/.test(s)) {
+      // module.exports = { a, b } reads as named; only treat bare assignment as default.
+      if (/\bexport\s+default\b/.test(s)) return 'default';
+      if (/\bmodule\.exports\s*=\s*\{/.test(s)) return 'named';
+      return 'default';
+    }
+    if (/\bexport\s+(?:const|let|var|function|class|async\s+function|\{|type|interface|enum)\b/.test(s)
+      || /\bmodule\.exports\s*=\s*\{/.test(s) || /\bexports\.[A-Za-z_$]/.test(s)) {
+      return 'named';
+    }
+    return 'other';
+  }
+
+  /** Detect the test framework in use from manifests + source heuristics. */
+  function _detectTestFramework(cwd, files) {
+    const deps = {};
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      Object.assign(deps, pkg.dependencies, pkg.devDependencies);
+    } catch (_) {}
+    for (const fw of ['vitest', 'jest', 'mocha', 'ava', 'jasmine']) {
+      if (deps[fw]) return fw;
+    }
+    // Python: pytest in requirements / pyproject.
+    for (const manifest of ['requirements.txt', 'requirements-dev.txt', 'pyproject.toml', 'setup.cfg']) {
+      try {
+        const raw = fs.readFileSync(path.join(cwd, manifest), 'utf8');
+        if (/\bpytest\b/.test(raw)) return 'pytest';
+        if (/\bunittest\b/.test(raw)) return 'unittest';
+      } catch (_) {}
+    }
+    // Fallback: infer from test file contents.
+    for (const f of files) {
+      if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) continue;
+      let src = '';
+      try { src = fs.readFileSync(f, 'utf8'); } catch (_) { continue; }
+      if (/\bvi\.(fn|mock|spyOn)\b|from ['"]vitest['"]/.test(src)) return 'vitest';
+      if (/\bjest\.(fn|mock|spyOn)\b/.test(src)) return 'jest';
+      if (/\bimport pytest\b|@pytest\./.test(src)) return 'pytest';
+      if (/\bdescribe\(|\bit\(/.test(src)) return 'mocha/jest-style';
+    }
+    return null;
+  }
+
+  /**
+   * Extract repo coding conventions for the scoped languages (TS/JS/Python).
+   * @param {string} cwd repo root
+   * @param {string[]} files absolute paths to source files (e.g. from buildFileList)
+   * @returns {{ fileNaming: object, exportStyle: object, testFramework: string|null,
+   *             scope: string[], scannedFiles: number }}
+   */
+  function extractConventions(cwd, files) {
+    const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
+    const namingLabels = [];
+    const exportLabels = [];
+    for (const f of scoped) {
+      const base = path.basename(f);
+      // Skip test files for the naming convention (they have their own naming).
+      if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
+        namingLabels.push(classifyNaming(base));
+      }
+      if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
+        let src = '';
+        try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
+        exportLabels.push(_jsExportStyle(src));
+      }
+    }
+    return {
+      fileNaming: scoreConvention(namingLabels),
+      exportStyle: scoreConvention(exportLabels),
+      testFramework: _detectTestFramework(cwd, scoped),
+      scope: ['typescript', 'javascript', 'python'],
+      scannedFiles: scoped.length,
+    };
+  }
+
+  module.exports = { classifyNaming, scoreConvention, extractConventions };
+  
+};
+
 __factories["./src/cache/freshen"] = function(module, exports) {
   
   /**
@@ -15470,6 +15630,48 @@ function main() {
     } else {
       console.log('  Notes:         none — add with: sigmap note "<text>"');
     }
+    process.exit(0);
+  }
+
+  // Layer 3: `sigmap conventions` — extract & report repo coding conventions
+  // (file naming, export style, test framework) for TS/JS/Python so generated
+  // code matches the house style. Writes .context/conventions.json.
+  if (args[0] === 'conventions') {
+    const jsonOut = args.includes('--json');
+    const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
+    const files = buildFileList(cwd, config);
+    const result = extractConventions(cwd, files);
+
+    const outDir = path.join(cwd, '.context');
+    const outPath = path.join(outDir, 'conventions.json');
+    try {
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n');
+    } catch (e) {
+      console.error(`[sigmap] cannot write ${outPath}: ${e.message}`);
+      process.exit(1);
+    }
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(result) + '\n');
+      process.exit(0);
+    }
+
+    const pct = (n) => `${(n * 100).toFixed(0)}%`;
+    const tierLabel = { consistent: 'consistent', mostly: 'mostly', inconsistent: 'mixed', unknown: 'n/a' };
+    const line = (name, conv) => {
+      if (!conv || conv.total === 0) return `  ${name.padEnd(14)} n/a (no samples)`;
+      const variants = conv.variants.slice(1, 3).map((v) => `${v.label} ${pct(v.pct)}`).join(', ');
+      const tail = variants ? `  ·  also: ${variants}` : '';
+      return `  ${name.padEnd(14)} ${conv.dominant} ${pct(conv.dominantPct)} [${tierLabel[conv.tier]}]${tail}`;
+    };
+
+    console.log('[sigmap] conventions  (TS/JS/Python)');
+    console.log(`  scanned        ${result.scannedFiles} file${result.scannedFiles === 1 ? '' : 's'}`);
+    console.log(line('file naming', result.fileNaming));
+    console.log(line('export style', result.exportStyle));
+    console.log(`  ${'test framework'.padEnd(14)} ${result.testFramework || 'none detected'}`);
+    console.log(`\n  → wrote ${path.relative(cwd, outPath)}`);
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.6.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/conventions/extract.js
+++ b/src/conventions/extract.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Convention extraction (IMPL.md Layer 3 — grounded code generation).
+ *
+ * Detects a repo's dominant coding conventions so generated code matches the
+ * house style instead of drifting (Cause 4: naming/convention drift). This
+ * first slice covers TS/JS/Python and three conventions: file naming, export
+ * style, and test framework. `scoreConvention` is the reusable consistency
+ * primitive that Gap 1 (scaffold confidence) will also build on.
+ *
+ * Zero dependencies, bundle-safe (fs + path only).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const PY_EXTS = new Set(['.py']);
+const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+// Consistency tiers (IMPL.md §5.1): a convention is only safe to enforce when
+// it is actually consistent.
+const TIER_CONSISTENT = 0.9;
+const TIER_MOSTLY = 0.7;
+
+/**
+ * Classify a file's base name (without extension) into a naming style.
+ * @param {string} basename a file basename, e.g. "user-service.ts"
+ * @returns {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'|'other'}
+ */
+function classifyNaming(basename) {
+  let stem = String(basename || '');
+  const dot = stem.indexOf('.');
+  if (dot > 0) stem = stem.slice(0, dot); // strip ext + compound suffix (.test, .d)
+  if (!stem) return 'other';
+  if (/[-]/.test(stem) && /^[a-z0-9]+(?:-[a-z0-9]+)+$/.test(stem)) return 'kebab-case';
+  if (/[_]/.test(stem) && /^[a-z0-9]+(?:_[a-z0-9]+)+$/.test(stem)) return 'snake_case';
+  if (/^[A-Z][A-Za-z0-9]*$/.test(stem) && /[a-z]/.test(stem)) return 'PascalCase';
+  if (/^[a-z][A-Za-z0-9]*$/.test(stem) && /[A-Z]/.test(stem)) return 'camelCase';
+  if (/^[a-z][a-z0-9]*$/.test(stem)) return 'camelCase'; // single lowercase word
+  return 'other';
+}
+
+/**
+ * Score a set of categorical observations into a dominant convention plus its
+ * consistency tier. The reusable primitive (IMPL.md §5.2).
+ * @param {string[]} labels observed category for each sample (e.g. naming styles)
+ * @returns {{ dominant: string|null, dominantPct: number, total: number,
+ *             variants: Array<{label:string, count:number, pct:number}>,
+ *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
+ */
+function scoreConvention(labels) {
+  const list = (labels || []).filter((l) => l != null && l !== 'other');
+  const total = list.length;
+  if (total === 0) {
+    return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
+  }
+  const counts = new Map();
+  for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
+  const variants = [...counts.entries()]
+    .map(([label, count]) => ({ label, count, pct: count / total }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  const top = variants[0];
+  let tier = 'inconsistent';
+  if (top.pct >= TIER_CONSISTENT) tier = 'consistent';
+  else if (top.pct >= TIER_MOSTLY) tier = 'mostly';
+  return {
+    dominant: top.label,
+    dominantPct: top.pct,
+    total,
+    variants,
+    tier,
+  };
+}
+
+/** Detect JS/TS export style for a single file's source. */
+function _jsExportStyle(src) {
+  const s = String(src || '');
+  if (/\bexport\s+default\b/.test(s) || /\bmodule\.exports\s*=\s*(?:function|class|\{?\s*[A-Za-z_$])/.test(s)) {
+    // module.exports = { a, b } reads as named; only treat bare assignment as default.
+    if (/\bexport\s+default\b/.test(s)) return 'default';
+    if (/\bmodule\.exports\s*=\s*\{/.test(s)) return 'named';
+    return 'default';
+  }
+  if (/\bexport\s+(?:const|let|var|function|class|async\s+function|\{|type|interface|enum)\b/.test(s)
+    || /\bmodule\.exports\s*=\s*\{/.test(s) || /\bexports\.[A-Za-z_$]/.test(s)) {
+    return 'named';
+  }
+  return 'other';
+}
+
+/** Detect the test framework in use from manifests + source heuristics. */
+function _detectTestFramework(cwd, files) {
+  const deps = {};
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    Object.assign(deps, pkg.dependencies, pkg.devDependencies);
+  } catch (_) {}
+  for (const fw of ['vitest', 'jest', 'mocha', 'ava', 'jasmine']) {
+    if (deps[fw]) return fw;
+  }
+  // Python: pytest in requirements / pyproject.
+  for (const manifest of ['requirements.txt', 'requirements-dev.txt', 'pyproject.toml', 'setup.cfg']) {
+    try {
+      const raw = fs.readFileSync(path.join(cwd, manifest), 'utf8');
+      if (/\bpytest\b/.test(raw)) return 'pytest';
+      if (/\bunittest\b/.test(raw)) return 'unittest';
+    } catch (_) {}
+  }
+  // Fallback: infer from test file contents.
+  for (const f of files) {
+    if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) continue;
+    let src = '';
+    try { src = fs.readFileSync(f, 'utf8'); } catch (_) { continue; }
+    if (/\bvi\.(fn|mock|spyOn)\b|from ['"]vitest['"]/.test(src)) return 'vitest';
+    if (/\bjest\.(fn|mock|spyOn)\b/.test(src)) return 'jest';
+    if (/\bimport pytest\b|@pytest\./.test(src)) return 'pytest';
+    if (/\bdescribe\(|\bit\(/.test(src)) return 'mocha/jest-style';
+  }
+  return null;
+}
+
+/**
+ * Extract repo coding conventions for the scoped languages (TS/JS/Python).
+ * @param {string} cwd repo root
+ * @param {string[]} files absolute paths to source files (e.g. from buildFileList)
+ * @returns {{ fileNaming: object, exportStyle: object, testFramework: string|null,
+ *             scope: string[], scannedFiles: number }}
+ */
+function extractConventions(cwd, files) {
+  const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
+  const namingLabels = [];
+  const exportLabels = [];
+  for (const f of scoped) {
+    const base = path.basename(f);
+    // Skip test files for the naming convention (they have their own naming).
+    if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
+      namingLabels.push(classifyNaming(base));
+    }
+    if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
+      let src = '';
+      try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
+      exportLabels.push(_jsExportStyle(src));
+    }
+  }
+  return {
+    fileNaming: scoreConvention(namingLabels),
+    exportStyle: scoreConvention(exportLabels),
+    testFramework: _detectTestFramework(cwd, scoped),
+    scope: ['typescript', 'javascript', 'python'],
+    scannedFiles: scoped.length,
+  };
+}
+
+module.exports = { classifyNaming, scoreConvention, extractConventions };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.6.0',
+  version: '7.7.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/conventions.test.js
+++ b/test/integration/conventions.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions` (Layer 3 — grounded codegen).
+ *   classifyNaming · scoreConvention (tiers) · extractConventions · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { classifyNaming, scoreConvention, extractConventions } =
+  require(path.join(ROOT, 'src/conventions/extract'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// ── classifyNaming ──────────────────────────────────────────────────────────
+test('classifyNaming: PascalCase', () => {
+  assert.strictEqual(classifyNaming('UserService.ts'), 'PascalCase');
+});
+test('classifyNaming: camelCase', () => {
+  assert.strictEqual(classifyNaming('userService.ts'), 'camelCase');
+  assert.strictEqual(classifyNaming('loader.js'), 'camelCase'); // single lowercase word
+});
+test('classifyNaming: kebab-case', () => {
+  assert.strictEqual(classifyNaming('user-service.ts'), 'kebab-case');
+});
+test('classifyNaming: snake_case', () => {
+  assert.strictEqual(classifyNaming('user_service.py'), 'snake_case');
+});
+test('classifyNaming: strips compound suffix', () => {
+  assert.strictEqual(classifyNaming('user-service.test.ts'), 'kebab-case');
+});
+
+// ── scoreConvention ─────────────────────────────────────────────────────────
+test('scoreConvention: empty → unknown', () => {
+  const r = scoreConvention([]);
+  assert.strictEqual(r.tier, 'unknown');
+  assert.strictEqual(r.dominant, null);
+  assert.strictEqual(r.total, 0);
+});
+test('scoreConvention: consistent tier at >=90%', () => {
+  const labels = Array(95).fill('camelCase').concat(Array(5).fill('kebab-case'));
+  const r = scoreConvention(labels);
+  assert.strictEqual(r.dominant, 'camelCase');
+  assert.strictEqual(r.tier, 'consistent');
+  assert.ok(Math.abs(r.dominantPct - 0.95) < 1e-9);
+});
+test('scoreConvention: mostly tier in [70,90)', () => {
+  const r = scoreConvention(Array(8).fill('a').concat(Array(2).fill('b')));
+  assert.strictEqual(r.tier, 'mostly');
+});
+test('scoreConvention: inconsistent tier below 70%', () => {
+  const r = scoreConvention(Array(6).fill('a').concat(Array(4).fill('b')));
+  assert.strictEqual(r.tier, 'inconsistent');
+});
+test('scoreConvention: ignores "other" samples', () => {
+  const r = scoreConvention(['a', 'a', 'other', 'other']);
+  assert.strictEqual(r.total, 2);
+  assert.strictEqual(r.tier, 'consistent');
+});
+
+// ── extractConventions ──────────────────────────────────────────────────────
+test('extractConventions: detects naming + export + framework', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'),
+      'function a(){} module.exports = { a };\n');
+    fs.writeFileSync(path.join(dir, 'src', 'auth-guard.js'),
+      'export const b = 1;\n');
+    fs.writeFileSync(path.join(dir, 'package.json'),
+      JSON.stringify({ name: 't', devDependencies: { jest: '^29' } }));
+    const files = [
+      path.join(dir, 'src', 'user-service.js'),
+      path.join(dir, 'src', 'auth-guard.js'),
+    ];
+    const r = extractConventions(dir, files);
+    assert.strictEqual(r.fileNaming.dominant, 'kebab-case');
+    assert.strictEqual(r.fileNaming.tier, 'consistent');
+    assert.strictEqual(r.exportStyle.dominant, 'named');
+    assert.strictEqual(r.testFramework, 'jest');
+    assert.strictEqual(r.scannedFiles, 2);
+  });
+});
+test('extractConventions: ignores non-scoped files', () => {
+  withRepo((dir) => {
+    const files = [path.join(dir, 'a.go'), path.join(dir, 'b.rs')];
+    const r = extractConventions(dir, files);
+    assert.strictEqual(r.scannedFiles, 0);
+    assert.strictEqual(r.fileNaming.tier, 'unknown');
+  });
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: conventions writes .context/conventions.json and reports', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const x = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const y = 2;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/file naming/.test(res.stdout), 'prints report');
+    const outPath = path.join(dir, '.context', 'conventions.json');
+    assert.ok(fs.existsSync(outPath), 'writes conventions.json');
+    const data = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.strictEqual(data.fileNaming.dominant, 'camelCase');
+  });
+});
+test('CLI: conventions --json emits machine output', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'aaa.js'), 'export const x = 1;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.ok(data.fileNaming, 'has fileNaming');
+    assert.deepStrictEqual(data.scope, ['typescript', 'javascript', 'python']);
+  });
+});
+
+console.log(`\nconventions: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.6.0",
+  "version": "7.7.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 82,
+  "tests": 83,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Ships **v7.7.0** to main: the `sigmap conventions` command (grounded codegen, Layer 3) + docs/benchmark refresh prepared by /update-docs.

## Changes
- `src/conventions/extract.js` + `sigmap conventions` CLI (file naming / export style / test framework for TS/JS/Python; writes `.context/conventions.json`)
- Version sync 7.6.0 → 7.7.0; CHANGELOG + CONTRIBUTORS; docs-vp (cli, roadmap, index); llms.txt regenerated
- Benchmarks re-run — metrics stable: 97.0% token reduction · 75.6% hit@5 · 39.4% prompt reduction · 16/21 → 0/21 overflow

## Test plan
- [x] `node test/integration/all.js` — 77 suites, 0 failures
- [x] bundle / version-meta / llms gates pass
- [x] supply-chain local audit PASS