### PR TITLE
feat: sigmap conventions --conflicts — breakdown + rename suggestions (Layer 3)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -22,6 +22,121 @@ function __require(key) {
 
 // ── ./src/cache/freshen ──
 // ── ./src/conventions/extract ──
+// ── ./src/conventions/conflicts ──
+__factories["./src/conventions/conflicts"] = function(module, exports) {
+  
+  /**
+   * Convention conflict analysis (IMPL.md §4 / §5.3 — grounded codegen, Layer 3).
+   *
+   * Given an `extractConventions` result, surface *why* a convention is mixed:
+   * every variant pattern with its file count, share, and example files, plus
+   * rename suggestions that move minority file-naming files toward the dominant
+   * style. Pure, zero-dependency, bundle-safe.
+   */
+
+  /** Split a file name into its stem (before the first dot) and the rest. */
+  function _splitName(filename) {
+    const s = String(filename || '');
+    const dot = s.indexOf('.');
+    if (dot <= 0) return { stem: s, ext: '' };
+    return { stem: s.slice(0, dot), ext: s.slice(dot) };
+  }
+
+  /** Break a stem into lowercase word parts regardless of its current style. */
+  function _words(stem) {
+    return String(stem || '')
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // camel/Pascal boundaries
+      .replace(/[-_]+/g, ' ')                 // kebab / snake separators
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((w) => w.toLowerCase());
+  }
+
+  const _cap = (w) => w.charAt(0).toUpperCase() + w.slice(1);
+
+  /**
+   * Convert a file stem to a target naming style.
+   * @param {string} stem name without extension
+   * @param {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'} style
+   * @returns {string}
+   */
+  function toNamingStyle(stem, style) {
+    const w = _words(stem);
+    if (w.length === 0) return String(stem || '');
+    switch (style) {
+      case 'PascalCase': return w.map(_cap).join('');
+      case 'camelCase': return w[0] + w.slice(1).map(_cap).join('');
+      case 'kebab-case': return w.join('-');
+      case 'snake_case': return w.join('_');
+      default: return String(stem || '');
+    }
+  }
+
+  /** Rename suggestion to bring a file to the dominant naming style. */
+  function renameSuggestion(filename, dominantStyle) {
+    const { stem, ext } = _splitName(filename);
+    const to = toNamingStyle(stem, dominantStyle) + ext;
+    return { from: filename, to };
+  }
+
+  const LABELS = {
+    fileNaming: 'file naming',
+    exportStyle: 'export style',
+  };
+
+  /**
+   * Analyze an `extractConventions` result for conflicts.
+   * @param {object} result the object returned by `extractConventions`
+   * @returns {{ hasConflicts: boolean, conventions: Array<{
+   *   key:string, name:string, dominant:string|null, dominantPct:number,
+   *   tier:string, total:number,
+   *   variants:Array<{pattern:string,count:number,pct:number,examples:string[]}>,
+   *   renames:Array<{from:string,to:string}> }> }}
+   */
+  function analyzeConflicts(result) {
+    const out = [];
+    for (const key of ['fileNaming', 'exportStyle']) {
+      const conv = result && result[key];
+      // A conflict is any convention with more than one observed pattern.
+      if (!conv || conv.total === 0 || conv.variants.length < 2) continue;
+
+      const variants = conv.variants.map((v) => ({
+        pattern: v.label,
+        count: v.count,
+        pct: v.pct,
+        examples: v.examples || [],
+      }));
+
+      // Rename suggestions only for file naming (export style is a code change, not a rename).
+      const renames = [];
+      if (key === 'fileNaming' && conv.dominant) {
+        for (const v of conv.variants) {
+          if (v.label === conv.dominant) continue;
+          for (const ex of (v.examples || [])) {
+            renames.push(renameSuggestion(ex, conv.dominant));
+          }
+        }
+      }
+
+      out.push({
+        key,
+        name: LABELS[key] || key,
+        dominant: conv.dominant,
+        dominantPct: conv.dominantPct,
+        tier: conv.tier,
+        total: conv.total,
+        variants,
+        renames,
+      });
+    }
+    return { hasConflicts: out.length > 0, conventions: out };
+  }
+
+  module.exports = { analyzeConflicts, toNamingStyle, renameSuggestion };
+  
+};
+
 __factories["./src/conventions/extract"] = function(module, exports) {
   
   /**
@@ -15641,6 +15756,38 @@ function main() {
     const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
     const files = buildFileList(cwd, config);
     const result = extractConventions(cwd, files);
+
+    // `--conflicts`: surface why a convention is mixed (breakdown + rename suggestions).
+    if (args.includes('--conflicts')) {
+      const { analyzeConflicts } = requireSourceOrBundled('./src/conventions/conflicts');
+      const report = analyzeConflicts(result);
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify(report) + '\n');
+        process.exit(0);
+      }
+      const pctC = (n) => `${(n * 100).toFixed(0)}%`;
+      if (!report.hasConflicts) {
+        console.log('[sigmap] conventions --conflicts  (TS/JS/Python)');
+        console.log('  no conflicts — conventions are consistent ✓');
+        process.exit(0);
+      }
+      console.log('[sigmap] conventions --conflicts  (TS/JS/Python)');
+      for (const c of report.conventions) {
+        console.log(`\n  ${c.name} — dominant: ${c.dominant} ${pctC(c.dominantPct)} [${c.tier}]`);
+        for (const v of c.variants) {
+          const barLen = Math.max(1, Math.round(v.pct * 20));
+          const bar = '█'.repeat(barLen);
+          const tag = v.pattern === c.dominant ? ' (dominant)' : '';
+          const ex = v.examples.length ? `  e.g. ${v.examples.join(', ')}` : '';
+          console.log(`    ${v.pattern.padEnd(12)} ${String(v.count).padStart(4)}  ${pctC(v.pct).padStart(4)} ${bar}${tag}${ex}`);
+        }
+        if (c.renames.length) {
+          console.log(`    rename to match ${c.dominant}:`);
+          for (const r of c.renames) console.log(`      ${r.from}  →  ${r.to}`);
+        }
+      }
+      process.exit(0);
+    }
 
     const outDir = path.join(cwd, '.context');
     const outPath = path.join(outDir, 'conventions.json');

--- a/src/conventions/conflicts.js
+++ b/src/conventions/conflicts.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Convention conflict analysis (IMPL.md §4 / §5.3 — grounded codegen, Layer 3).
+ *
+ * Given an `extractConventions` result, surface *why* a convention is mixed:
+ * every variant pattern with its file count, share, and example files, plus
+ * rename suggestions that move minority file-naming files toward the dominant
+ * style. Pure, zero-dependency, bundle-safe.
+ */
+
+/** Split a file name into its stem (before the first dot) and the rest. */
+function _splitName(filename) {
+  const s = String(filename || '');
+  const dot = s.indexOf('.');
+  if (dot <= 0) return { stem: s, ext: '' };
+  return { stem: s.slice(0, dot), ext: s.slice(dot) };
+}
+
+/** Break a stem into lowercase word parts regardless of its current style. */
+function _words(stem) {
+  return String(stem || '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // camel/Pascal boundaries
+    .replace(/[-_]+/g, ' ')                 // kebab / snake separators
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.toLowerCase());
+}
+
+const _cap = (w) => w.charAt(0).toUpperCase() + w.slice(1);
+
+/**
+ * Convert a file stem to a target naming style.
+ * @param {string} stem name without extension
+ * @param {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'} style
+ * @returns {string}
+ */
+function toNamingStyle(stem, style) {
+  const w = _words(stem);
+  if (w.length === 0) return String(stem || '');
+  switch (style) {
+    case 'PascalCase': return w.map(_cap).join('');
+    case 'camelCase': return w[0] + w.slice(1).map(_cap).join('');
+    case 'kebab-case': return w.join('-');
+    case 'snake_case': return w.join('_');
+    default: return String(stem || '');
+  }
+}
+
+/** Rename suggestion to bring a file to the dominant naming style. */
+function renameSuggestion(filename, dominantStyle) {
+  const { stem, ext } = _splitName(filename);
+  const to = toNamingStyle(stem, dominantStyle) + ext;
+  return { from: filename, to };
+}
+
+const LABELS = {
+  fileNaming: 'file naming',
+  exportStyle: 'export style',
+};
+
+/**
+ * Analyze an `extractConventions` result for conflicts.
+ * @param {object} result the object returned by `extractConventions`
+ * @returns {{ hasConflicts: boolean, conventions: Array<{
+ *   key:string, name:string, dominant:string|null, dominantPct:number,
+ *   tier:string, total:number,
+ *   variants:Array<{pattern:string,count:number,pct:number,examples:string[]}>,
+ *   renames:Array<{from:string,to:string}> }> }}
+ */
+function analyzeConflicts(result) {
+  const out = [];
+  for (const key of ['fileNaming', 'exportStyle']) {
+    const conv = result && result[key];
+    // A conflict is any convention with more than one observed pattern.
+    if (!conv || conv.total === 0 || conv.variants.length < 2) continue;
+
+    const variants = conv.variants.map((v) => ({
+      pattern: v.label,
+      count: v.count,
+      pct: v.pct,
+      examples: v.examples || [],
+    }));
+
+    // Rename suggestions only for file naming (export style is a code change, not a rename).
+    const renames = [];
+    if (key === 'fileNaming' && conv.dominant) {
+      for (const v of conv.variants) {
+        if (v.label === conv.dominant) continue;
+        for (const ex of (v.examples || [])) {
+          renames.push(renameSuggestion(ex, conv.dominant));
+        }
+      }
+    }
+
+    out.push({
+      key,
+      name: LABELS[key] || key,
+      dominant: conv.dominant,
+      dominantPct: conv.dominantPct,
+      tier: conv.tier,
+      total: conv.total,
+      variants,
+      renames,
+    });
+  }
+  return { hasConflicts: out.length > 0, conventions: out };
+}
+
+module.exports = { analyzeConflicts, toNamingStyle, renameSuggestion };

--- a/src/conventions/extract.js
+++ b/src/conventions/extract.js
@@ -42,24 +42,42 @@ function classifyNaming(basename) {
   return 'other';
 }
 
+const MAX_EXAMPLES = 3;
+
 /**
  * Score a set of categorical observations into a dominant convention plus its
  * consistency tier. The reusable primitive (IMPL.md §5.2).
  * @param {string[]} labels observed category for each sample (e.g. naming styles)
+ * @param {string[]} [refs] optional identifier (e.g. file name) parallel to
+ *   `labels`; when given, each variant carries up to 3 `examples`.
  * @returns {{ dominant: string|null, dominantPct: number, total: number,
- *             variants: Array<{label:string, count:number, pct:number}>,
+ *             variants: Array<{label:string, count:number, pct:number, examples?:string[]}>,
  *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
  */
-function scoreConvention(labels) {
-  const list = (labels || []).filter((l) => l != null && l !== 'other');
-  const total = list.length;
+function scoreConvention(labels, refs) {
+  const all = labels || [];
+  const counts = new Map();
+  const examples = new Map();
+  let total = 0;
+  for (let i = 0; i < all.length; i++) {
+    const l = all[i];
+    if (l == null || l === 'other') continue;
+    total++;
+    counts.set(l, (counts.get(l) || 0) + 1);
+    if (refs && refs[i] != null) {
+      const ex = examples.get(l) || [];
+      if (ex.length < MAX_EXAMPLES) { ex.push(refs[i]); examples.set(l, ex); }
+    }
+  }
   if (total === 0) {
     return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
   }
-  const counts = new Map();
-  for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
   const variants = [...counts.entries()]
-    .map(([label, count]) => ({ label, count, pct: count / total }))
+    .map(([label, count]) => {
+      const v = { label, count, pct: count / total };
+      if (refs) v.examples = examples.get(label) || [];
+      return v;
+    })
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
   const top = variants[0];
   let tier = 'inconsistent';
@@ -131,22 +149,26 @@ function _detectTestFramework(cwd, files) {
 function extractConventions(cwd, files) {
   const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
   const namingLabels = [];
+  const namingRefs = [];
   const exportLabels = [];
+  const exportRefs = [];
   for (const f of scoped) {
     const base = path.basename(f);
     // Skip test files for the naming convention (they have their own naming).
     if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
       namingLabels.push(classifyNaming(base));
+      namingRefs.push(base);
     }
     if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
       let src = '';
       try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
       exportLabels.push(_jsExportStyle(src));
+      exportRefs.push(base);
     }
   }
   return {
-    fileNaming: scoreConvention(namingLabels),
-    exportStyle: scoreConvention(exportLabels),
+    fileNaming: scoreConvention(namingLabels, namingRefs),
+    exportStyle: scoreConvention(exportLabels, exportRefs),
     testFramework: _detectTestFramework(cwd, scoped),
     scope: ['typescript', 'javascript', 'python'],
     scannedFiles: scoped.length,

--- a/test/integration/conventions-conflicts.test.js
+++ b/test/integration/conventions-conflicts.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions --conflicts` (Layer 3).
+ *   scoreConvention examples · toNamingStyle · renameSuggestion · analyzeConflicts · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { scoreConvention, extractConventions } = require(path.join(ROOT, 'src/conventions/extract'));
+const { analyzeConflicts, toNamingStyle, renameSuggestion } =
+  require(path.join(ROOT, 'src/conventions/conflicts'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-conf-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// ── scoreConvention examples (backward compatible) ──────────────────────────
+test('scoreConvention: no refs → no examples key', () => {
+  const r = scoreConvention(['a', 'a', 'b']);
+  assert.strictEqual(r.variants[0].examples, undefined);
+});
+test('scoreConvention: refs → up to 3 examples per variant', () => {
+  const labels = ['a', 'a', 'a', 'a', 'b'];
+  const refs = ['a1', 'a2', 'a3', 'a4', 'b1'];
+  const r = scoreConvention(labels, refs);
+  const a = r.variants.find((v) => v.label === 'a');
+  assert.deepStrictEqual(a.examples, ['a1', 'a2', 'a3']); // capped at 3
+  const b = r.variants.find((v) => v.label === 'b');
+  assert.deepStrictEqual(b.examples, ['b1']);
+});
+
+// ── toNamingStyle ───────────────────────────────────────────────────────────
+test('toNamingStyle: kebab → camelCase', () => {
+  assert.strictEqual(toNamingStyle('user-service', 'camelCase'), 'userService');
+});
+test('toNamingStyle: snake → PascalCase', () => {
+  assert.strictEqual(toNamingStyle('user_service', 'PascalCase'), 'UserService');
+});
+test('toNamingStyle: camel → kebab-case', () => {
+  assert.strictEqual(toNamingStyle('userService', 'kebab-case'), 'user-service');
+});
+test('toNamingStyle: camel → snake_case', () => {
+  assert.strictEqual(toNamingStyle('fooBarBaz', 'snake_case'), 'foo_bar_baz');
+});
+
+// ── renameSuggestion ────────────────────────────────────────────────────────
+test('renameSuggestion: preserves extension', () => {
+  assert.deepStrictEqual(renameSuggestion('user-service.ts', 'camelCase'),
+    { from: 'user-service.ts', to: 'userService.ts' });
+});
+test('renameSuggestion: preserves compound suffix', () => {
+  assert.deepStrictEqual(renameSuggestion('user-service.test.ts', 'camelCase'),
+    { from: 'user-service.test.ts', to: 'userService.test.ts' });
+});
+
+// ── analyzeConflicts ────────────────────────────────────────────────────────
+test('analyzeConflicts: consistent repo → no conflicts', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const r = analyzeConflicts(extractConventions(dir, [
+      path.join(dir, 'src', 'fooBar.js'), path.join(dir, 'src', 'bazQux.js'),
+    ]));
+    assert.strictEqual(r.hasConflicts, false);
+    assert.strictEqual(r.conventions.length, 0);
+  });
+});
+test('analyzeConflicts: mixed naming → conflict with breakdown + renames', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    // 2 camelCase (dominant) + 1 kebab-case minority
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const files = ['fooBar.js', 'bazQux.js', 'user-service.js'].map((f) => path.join(dir, 'src', f));
+    const r = analyzeConflicts(extractConventions(dir, files));
+    assert.strictEqual(r.hasConflicts, true);
+    const naming = r.conventions.find((c) => c.key === 'fileNaming');
+    assert.ok(naming, 'fileNaming conflict present');
+    assert.strictEqual(naming.dominant, 'camelCase');
+    assert.ok(naming.variants.length >= 2, 'multiple variants');
+    const kebab = naming.variants.find((v) => v.pattern === 'kebab-case');
+    assert.ok(kebab.examples.includes('user-service.js'), 'carries example file');
+    // rename suggestion moves the minority file to the dominant style
+    assert.deepStrictEqual(naming.renames.find((x) => x.from === 'user-service.js'),
+      { from: 'user-service.js', to: 'userService.js' });
+  });
+});
+test('analyzeConflicts: export-style conflict has no rename suggestions', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    // consistent kebab naming, but mixed export style
+    fs.writeFileSync(path.join(dir, 'src', 'aa.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bb.js'), 'export default function () {}\n');
+    const files = ['aa.js', 'bb.js'].map((f) => path.join(dir, 'src', f));
+    const r = analyzeConflicts(extractConventions(dir, files));
+    const exp = r.conventions.find((c) => c.key === 'exportStyle');
+    assert.ok(exp, 'exportStyle conflict present');
+    assert.strictEqual(exp.renames.length, 0, 'no renames for export style');
+  });
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: --conflicts prints breakdown for a mixed repo', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/file naming/.test(res.stdout), 'shows convention');
+    assert.ok(/rename to match camelCase/.test(res.stdout), 'shows rename block');
+    assert.ok(/user-service\.js\s+→\s+userService\.js/.test(res.stdout), 'shows rename arrow');
+  });
+});
+test('CLI: --conflicts --json emits structured object', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(typeof data.hasConflicts, 'boolean');
+    assert.ok(Array.isArray(data.conventions));
+  });
+});
+test('CLI: --conflicts on consistent repo says no conflicts', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/no conflicts/.test(res.stdout), 'reports no conflicts');
+  });
+});
+
+console.log(`\nconventions-conflicts: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 83,
+  "tests": 84,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Next slice of IMPL.md **Layer 3 (grounded codegen)** after the v7.7.0 conventions core: `sigmap conventions --conflicts` surfaces *why* a convention is mixed — per-pattern breakdown (count, %, bar, example files) + rename suggestions toward the dominant style. Closes #301.

## Changes
- `src/conventions/conflicts.js` (new, zero-dep, bundle-safe): `analyzeConflicts(result)`, `toNamingStyle(stem, style)`, `renameSuggestion(file, style)`. Lists only non-consistent conventions; rename suggestions convert minority file-naming files to the dominant style (export-style conflicts get no renames — that's a code change, not a rename).
- `src/conventions/extract.js`: `scoreConvention(labels, refs?)` now attaches up to 3 `examples` per variant when a parallel `refs` array is given (backward compatible — labels-only callers unchanged). `extractConventions` passes basenames so variants carry example files.
- `gen-context.js`: `conventions --conflicts` prints the breakdown with bars + renames; `--json` emits the structured report; "no conflicts" when consistent. Registered bundle factory.
- `version.json`: derived `tests` 83 → 84 (no version/metric change — `/update-docs` owns the bump).

Deferred (still Layer 3 / Gap 1): `--report`, `--fix`, `--update`, `--ci`, CLAUDE.md injection, scaffold confidence floor.

## Test plan
- [x] `node test/integration/conventions-conflicts.test.js` — 14 passed
- [x] `node test/integration/conventions.test.js` — 14 passed (no regression)
- [x] `node test/integration/all.js` — 78 suites, 0 failures
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)