### PR TITLE
release: v7.8.0 — conventions --conflicts (grounded codegen, Layer 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.8.0] — 2026-06-17
+
+Minor release — `sigmap conventions --conflicts` (grounded codegen, Layer 3).
+
+### Added
+- **`sigmap conventions --conflicts` — per-convention breakdown + rename suggestions (#301):** the next slice of Layer 3. Where `conventions` reports the dominant pattern and a consistency tier, `--conflicts` surfaces *why* a convention is mixed — every variant pattern with its file count, share, a visual bar, and example files, plus rename suggestions that move minority file-naming files toward the dominant style. New zero-dependency, bundle-safe `src/conventions/conflicts.js` (`analyzeConflicts`, `toNamingStyle`, `renameSuggestion`); export-style conflicts list variants but no renames (that's a code change, not a rename). `scoreConvention(labels, refs?)` now attaches up to 3 example files per variant (backward compatible). `--json` emits the structured conflict report; a consistent repo prints "no conflicts". `--report`, `--fix`, `--update`, `--ci`, and CLAUDE.md injection remain follow-ups.
+
+---
+
 ## [7.7.0] — 2026-06-17
 
 Minor release — `sigmap conventions` (grounded codegen, Layer 3).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,9 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
+### Recent Contributors (v7.8.0)
+- **@manojmallick** — feat: `sigmap conventions --conflicts` — per-convention breakdown (counts, bars, example files) + rename suggestions; `analyzeConflicts` / `toNamingStyle`; example-file tracking in `scoreConvention`; Layer 3 grounded codegen (#301, PR #302)
+
 ### Recent Contributors (v7.7.0)
 - **@manojmallick** — feat: `sigmap conventions` — extract & report a repo's coding conventions (file naming, export style, test framework) for TS/JS/Python; reusable `scoreConvention` consistency scorer; Layer 3 grounded codegen (#298, PR #299)
 

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -7,7 +7,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 54 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 55 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 54 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 55 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -54,6 +54,7 @@ If you are new to the product, start with the workflow pages first:
 | `ask "<query>" --squeeze-threshold <n>` | Minimum reduction %% to prompt for minimization (default 30) |
 | `squeeze <file\|->` | Minimize a pasted stacktrace / CI-log / JSON blob (`--json` for stats) |
 | `conventions` | Extract & report a repo's coding conventions — file naming, export style, test framework (TS/JS/Python); writes `.context/conventions.json` (`--json` for machine output) |
+| `conventions --conflicts` | Breakdown of every mixed convention (counts, bars, example files) + rename suggestions toward the dominant style |
 | `plan "<goal>"` | Analyze change impact and plan modifications — returns files grouped by confidence |
 | `judge --response <f> --context <f>` | Rule-based groundedness scoring for LLM responses |
 | `verify-ai-output <answer.md>` | Hallucination Guard — flag fake files, test files, imports, symbols, and npm scripts in an AI answer (deterministic, offline) |
@@ -402,8 +403,9 @@ Prose (no recognizable structure) passes through unchanged. The differentiator o
 Extract and report a repo's coding conventions so generated code matches the house style instead of drifting. Scans the source tree (TS/JS/Python) and reports the dominant **file naming** style, **export style**, and **test framework**, each with a consistency tier. Writes `.context/conventions.json` for tools to consume.
 
 ```bash
-sigmap conventions          # report + write .context/conventions.json
-sigmap conventions --json   # machine-readable output
+sigmap conventions              # report + write .context/conventions.json
+sigmap conventions --json       # machine-readable output
+sigmap conventions --conflicts  # breakdown of every mixed convention + rename suggestions
 ```
 
 ```
@@ -427,8 +429,29 @@ Each convention is scored into a **consistency tier** so you know whether it is 
 | Option | Description |
 |--------|-------------|
 | `--json` | Emit `{ fileNaming, exportStyle, testFramework, scope, scannedFiles }` (each convention as `{ dominant, dominantPct, variants, tier }`) |
+| `--conflicts` | Show *why* a convention is mixed — every variant with file count, share, bar, and example files, plus rename suggestions toward the dominant style (`--json` emits the structured report) |
 
-This is the first slice of grounded code generation; `--conflicts`, `--fix`, `--ci`, and CLAUDE.md injection are planned follow-ups.
+### `--conflicts`
+
+When a convention is `mostly` or `inconsistent`, `--conflicts` surfaces the full breakdown: each variant pattern with its file count, share, a visual bar, and example files — plus rename suggestions that move minority file-naming files toward the dominant style. (Export-style conflicts list variants but no renames — switching named ↔ default is a code change, not a rename.) A consistent repo prints `no conflicts`.
+
+```bash
+sigmap conventions --conflicts
+```
+
+```
+[sigmap] conventions --conflicts  (TS/JS/Python)
+
+  file naming — dominant: camelCase 77% [mostly]
+    camelCase      89   77% ███████████████ (dominant)  e.g. diagnostics.js, freshen.js
+    kebab-case     23   20% ████  e.g. coverage-score.js, sig-cache.js
+    snake_case      4    3% █  e.g. python_ast.py
+    rename to match camelCase:
+      coverage-score.js  →  coverageScore.js
+      sig-cache.js  →  sigCache.js
+```
+
+This is the second slice of grounded code generation; `--report`, `--fix`, `--update`, `--ci`, and CLAUDE.md injection are planned follow-ups.
 
 ---
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.7.0, with recent releases adding the sigmap conventions command (grounded codegen, Layer 3), the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.8.0, with recent releases adding the sigmap conventions command and its --conflicts breakdown (grounded codegen, Layer 3), the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Sixty-eight versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 1,030 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,045 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.8.0 — `conventions --conflicts` (grounded codegen, Layer 3) ✓ (2026-06-17)
+
+**Minor release — next slice of Layer 3.** Where `sigmap conventions` reports the dominant pattern and a consistency tier, `--conflicts` surfaces *why* a convention is mixed: every variant pattern with its file count, share, a visual bar, and example files — plus rename suggestions that move minority file-naming files toward the dominant style. New zero-dependency, bundle-safe `src/conventions/conflicts.js` (`analyzeConflicts`, `toNamingStyle`, `renameSuggestion`); export-style conflicts list variants but no renames (named ↔ default is a code change, not a rename). `scoreConvention(labels, refs?)` now attaches up to 3 example files per variant (backward compatible). `--json` emits the structured report; a consistent repo prints "no conflicts". `--report`, `--fix`, `--update`, `--ci`, and CLAUDE.md injection remain follow-ups.
+
+**Tags:** `conventions` · `--conflicts` · `analyzeConflicts` · `toNamingStyle` · `rename-suggestions` · `grounded-codegen` · `layer-3` · `#301`
+
+**Impact:** mixed conventions are now actionable — the breakdown + renames are the input the scaffold confidence floor (Gap 1) will consume.
+
+---
+
 ### v7.7.0 — `sigmap conventions` (grounded codegen, Layer 3) ✓ (2026-06-17)
 
 **Minor release — first slice of Layer 3.** A new `sigmap conventions` command extracts and reports a repo's dominant coding conventions — **file naming** style, **export style**, and **test framework** — for TS/JS/Python, so generated code matches the house style instead of drifting (Cause 4: naming/convention drift). New zero-dependency, bundle-safe `src/conventions/extract.js` exposes `classifyNaming` (PascalCase / camelCase / kebab-case / snake_case), `scoreConvention` (a reusable consistency scorer returning `{ dominant, dominantPct, variants, tier }` with tiers at 90% / 70% — Gap 1's scaffold-confidence floor will reuse it), and `extractConventions`. The command writes `.context/conventions.json` and prints a readable report; `--json` for machine output. `--conflicts`, `--fix`, `--ci`, and CLAUDE.md injection are deferred to follow-ups.
@@ -932,7 +942,7 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ## Current milestone — v7.8+ (grounded codegen: convention enforcement + scaffold)
 
-v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on); and the **grounded-codegen** track — **v7.4–7.5** live-index write hooks + read-time self-heal (Layer 1), **v7.6.0** the offline grounding benchmark (the GATE), and **v7.7.0** **`sigmap conventions`** (Layer 3: extract a repo's file-naming / export / test-framework conventions). Next: finish Layer 3 — `conventions --conflicts/--fix/--ci` and **CLAUDE.md convention injection** — then **Layer 4 scaffold** (generate convention-matched stubs). Also planned: **PR verification** (`verify-plan` / `review-pr` GitHub Action), the **Interactive Context Explorer**, line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on); and the **grounded-codegen** track — **v7.4–7.5** live-index write hooks + read-time self-heal (Layer 1), **v7.6.0** the offline grounding benchmark (the GATE), **v7.7.0** **`sigmap conventions`** (Layer 3: extract a repo's file-naming / export / test-framework conventions); and **v7.8.0** **`conventions --conflicts`** (per-convention breakdown + rename suggestions). Next: finish Layer 3 — `conventions --report/--fix/--update/--ci` and **CLAUDE.md convention injection** — then **Layer 4 scaffold** (generate convention-matched stubs, gated by the confidence floor). Also planned: **PR verification** (`verify-plan` / `review-pr` GitHub Action), the **Interactive Context Explorer**, line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.7.0</span>
+  <span><strong>Release:</strong> v7.8.0</span>
   <span>·</span>
-  <span><code>sigmap conventions</code> — extract a repo's file-naming, export, and test-framework conventions so generated code matches the house style (grounded codegen, Layer 3)</span>
+  <span><code>sigmap conventions --conflicts</code> — breakdown of every mixed convention (counts, bars, example files) + rename suggestions toward the dominant style (grounded codegen, Layer 3)</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.8.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.8.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -22,6 +22,121 @@ function __require(key) {
 
 // ── ./src/cache/freshen ──
 // ── ./src/conventions/extract ──
+// ── ./src/conventions/conflicts ──
+__factories["./src/conventions/conflicts"] = function(module, exports) {
+  
+  /**
+   * Convention conflict analysis (IMPL.md §4 / §5.3 — grounded codegen, Layer 3).
+   *
+   * Given an `extractConventions` result, surface *why* a convention is mixed:
+   * every variant pattern with its file count, share, and example files, plus
+   * rename suggestions that move minority file-naming files toward the dominant
+   * style. Pure, zero-dependency, bundle-safe.
+   */
+
+  /** Split a file name into its stem (before the first dot) and the rest. */
+  function _splitName(filename) {
+    const s = String(filename || '');
+    const dot = s.indexOf('.');
+    if (dot <= 0) return { stem: s, ext: '' };
+    return { stem: s.slice(0, dot), ext: s.slice(dot) };
+  }
+
+  /** Break a stem into lowercase word parts regardless of its current style. */
+  function _words(stem) {
+    return String(stem || '')
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // camel/Pascal boundaries
+      .replace(/[-_]+/g, ' ')                 // kebab / snake separators
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((w) => w.toLowerCase());
+  }
+
+  const _cap = (w) => w.charAt(0).toUpperCase() + w.slice(1);
+
+  /**
+   * Convert a file stem to a target naming style.
+   * @param {string} stem name without extension
+   * @param {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'} style
+   * @returns {string}
+   */
+  function toNamingStyle(stem, style) {
+    const w = _words(stem);
+    if (w.length === 0) return String(stem || '');
+    switch (style) {
+      case 'PascalCase': return w.map(_cap).join('');
+      case 'camelCase': return w[0] + w.slice(1).map(_cap).join('');
+      case 'kebab-case': return w.join('-');
+      case 'snake_case': return w.join('_');
+      default: return String(stem || '');
+    }
+  }
+
+  /** Rename suggestion to bring a file to the dominant naming style. */
+  function renameSuggestion(filename, dominantStyle) {
+    const { stem, ext } = _splitName(filename);
+    const to = toNamingStyle(stem, dominantStyle) + ext;
+    return { from: filename, to };
+  }
+
+  const LABELS = {
+    fileNaming: 'file naming',
+    exportStyle: 'export style',
+  };
+
+  /**
+   * Analyze an `extractConventions` result for conflicts.
+   * @param {object} result the object returned by `extractConventions`
+   * @returns {{ hasConflicts: boolean, conventions: Array<{
+   *   key:string, name:string, dominant:string|null, dominantPct:number,
+   *   tier:string, total:number,
+   *   variants:Array<{pattern:string,count:number,pct:number,examples:string[]}>,
+   *   renames:Array<{from:string,to:string}> }> }}
+   */
+  function analyzeConflicts(result) {
+    const out = [];
+    for (const key of ['fileNaming', 'exportStyle']) {
+      const conv = result && result[key];
+      // A conflict is any convention with more than one observed pattern.
+      if (!conv || conv.total === 0 || conv.variants.length < 2) continue;
+
+      const variants = conv.variants.map((v) => ({
+        pattern: v.label,
+        count: v.count,
+        pct: v.pct,
+        examples: v.examples || [],
+      }));
+
+      // Rename suggestions only for file naming (export style is a code change, not a rename).
+      const renames = [];
+      if (key === 'fileNaming' && conv.dominant) {
+        for (const v of conv.variants) {
+          if (v.label === conv.dominant) continue;
+          for (const ex of (v.examples || [])) {
+            renames.push(renameSuggestion(ex, conv.dominant));
+          }
+        }
+      }
+
+      out.push({
+        key,
+        name: LABELS[key] || key,
+        dominant: conv.dominant,
+        dominantPct: conv.dominantPct,
+        tier: conv.tier,
+        total: conv.total,
+        variants,
+        renames,
+      });
+    }
+    return { hasConflicts: out.length > 0, conventions: out };
+  }
+
+  module.exports = { analyzeConflicts, toNamingStyle, renameSuggestion };
+  
+};
+
 __factories["./src/conventions/extract"] = function(module, exports) {
   
   /**
@@ -15641,6 +15756,38 @@ function main() {
     const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
     const files = buildFileList(cwd, config);
     const result = extractConventions(cwd, files);
+
+    // `--conflicts`: surface why a convention is mixed (breakdown + rename suggestions).
+    if (args.includes('--conflicts')) {
+      const { analyzeConflicts } = requireSourceOrBundled('./src/conventions/conflicts');
+      const report = analyzeConflicts(result);
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify(report) + '\n');
+        process.exit(0);
+      }
+      const pctC = (n) => `${(n * 100).toFixed(0)}%`;
+      if (!report.hasConflicts) {
+        console.log('[sigmap] conventions --conflicts  (TS/JS/Python)');
+        console.log('  no conflicts — conventions are consistent ✓');
+        process.exit(0);
+      }
+      console.log('[sigmap] conventions --conflicts  (TS/JS/Python)');
+      for (const c of report.conventions) {
+        console.log(`\n  ${c.name} — dominant: ${c.dominant} ${pctC(c.dominantPct)} [${c.tier}]`);
+        for (const v of c.variants) {
+          const barLen = Math.max(1, Math.round(v.pct * 20));
+          const bar = '█'.repeat(barLen);
+          const tag = v.pattern === c.dominant ? ' (dominant)' : '';
+          const ex = v.examples.length ? `  e.g. ${v.examples.join(', ')}` : '';
+          console.log(`    ${v.pattern.padEnd(12)} ${String(v.count).padStart(4)}  ${pctC(v.pct).padStart(4)} ${bar}${tag}${ex}`);
+        }
+        if (c.renames.length) {
+          console.log(`    rename to match ${c.dominant}:`);
+          for (const r of c.renames) console.log(`      ${r.from}  →  ${r.to}`);
+        }
+      }
+      process.exit(0);
+    }
 
     const outDir = path.join(cwd, '.context');
     const outPath = path.join(outDir, 'conventions.json');

--- a/gen-context.js
+++ b/gen-context.js
@@ -6901,7 +6901,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.7.0',
+    version: '7.8.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -12579,7 +12579,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.7.0';
+const VERSION = '7.8.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.8.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.7.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.8.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/conventions/conflicts.js
+++ b/src/conventions/conflicts.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Convention conflict analysis (IMPL.md §4 / §5.3 — grounded codegen, Layer 3).
+ *
+ * Given an `extractConventions` result, surface *why* a convention is mixed:
+ * every variant pattern with its file count, share, and example files, plus
+ * rename suggestions that move minority file-naming files toward the dominant
+ * style. Pure, zero-dependency, bundle-safe.
+ */
+
+/** Split a file name into its stem (before the first dot) and the rest. */
+function _splitName(filename) {
+  const s = String(filename || '');
+  const dot = s.indexOf('.');
+  if (dot <= 0) return { stem: s, ext: '' };
+  return { stem: s.slice(0, dot), ext: s.slice(dot) };
+}
+
+/** Break a stem into lowercase word parts regardless of its current style. */
+function _words(stem) {
+  return String(stem || '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // camel/Pascal boundaries
+    .replace(/[-_]+/g, ' ')                 // kebab / snake separators
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.toLowerCase());
+}
+
+const _cap = (w) => w.charAt(0).toUpperCase() + w.slice(1);
+
+/**
+ * Convert a file stem to a target naming style.
+ * @param {string} stem name without extension
+ * @param {'PascalCase'|'camelCase'|'kebab-case'|'snake_case'} style
+ * @returns {string}
+ */
+function toNamingStyle(stem, style) {
+  const w = _words(stem);
+  if (w.length === 0) return String(stem || '');
+  switch (style) {
+    case 'PascalCase': return w.map(_cap).join('');
+    case 'camelCase': return w[0] + w.slice(1).map(_cap).join('');
+    case 'kebab-case': return w.join('-');
+    case 'snake_case': return w.join('_');
+    default: return String(stem || '');
+  }
+}
+
+/** Rename suggestion to bring a file to the dominant naming style. */
+function renameSuggestion(filename, dominantStyle) {
+  const { stem, ext } = _splitName(filename);
+  const to = toNamingStyle(stem, dominantStyle) + ext;
+  return { from: filename, to };
+}
+
+const LABELS = {
+  fileNaming: 'file naming',
+  exportStyle: 'export style',
+};
+
+/**
+ * Analyze an `extractConventions` result for conflicts.
+ * @param {object} result the object returned by `extractConventions`
+ * @returns {{ hasConflicts: boolean, conventions: Array<{
+ *   key:string, name:string, dominant:string|null, dominantPct:number,
+ *   tier:string, total:number,
+ *   variants:Array<{pattern:string,count:number,pct:number,examples:string[]}>,
+ *   renames:Array<{from:string,to:string}> }> }}
+ */
+function analyzeConflicts(result) {
+  const out = [];
+  for (const key of ['fileNaming', 'exportStyle']) {
+    const conv = result && result[key];
+    // A conflict is any convention with more than one observed pattern.
+    if (!conv || conv.total === 0 || conv.variants.length < 2) continue;
+
+    const variants = conv.variants.map((v) => ({
+      pattern: v.label,
+      count: v.count,
+      pct: v.pct,
+      examples: v.examples || [],
+    }));
+
+    // Rename suggestions only for file naming (export style is a code change, not a rename).
+    const renames = [];
+    if (key === 'fileNaming' && conv.dominant) {
+      for (const v of conv.variants) {
+        if (v.label === conv.dominant) continue;
+        for (const ex of (v.examples || [])) {
+          renames.push(renameSuggestion(ex, conv.dominant));
+        }
+      }
+    }
+
+    out.push({
+      key,
+      name: LABELS[key] || key,
+      dominant: conv.dominant,
+      dominantPct: conv.dominantPct,
+      tier: conv.tier,
+      total: conv.total,
+      variants,
+      renames,
+    });
+  }
+  return { hasConflicts: out.length > 0, conventions: out };
+}
+
+module.exports = { analyzeConflicts, toNamingStyle, renameSuggestion };

--- a/src/conventions/extract.js
+++ b/src/conventions/extract.js
@@ -42,24 +42,42 @@ function classifyNaming(basename) {
   return 'other';
 }
 
+const MAX_EXAMPLES = 3;
+
 /**
  * Score a set of categorical observations into a dominant convention plus its
  * consistency tier. The reusable primitive (IMPL.md §5.2).
  * @param {string[]} labels observed category for each sample (e.g. naming styles)
+ * @param {string[]} [refs] optional identifier (e.g. file name) parallel to
+ *   `labels`; when given, each variant carries up to 3 `examples`.
  * @returns {{ dominant: string|null, dominantPct: number, total: number,
- *             variants: Array<{label:string, count:number, pct:number}>,
+ *             variants: Array<{label:string, count:number, pct:number, examples?:string[]}>,
  *             tier: 'consistent'|'mostly'|'inconsistent'|'unknown' }}
  */
-function scoreConvention(labels) {
-  const list = (labels || []).filter((l) => l != null && l !== 'other');
-  const total = list.length;
+function scoreConvention(labels, refs) {
+  const all = labels || [];
+  const counts = new Map();
+  const examples = new Map();
+  let total = 0;
+  for (let i = 0; i < all.length; i++) {
+    const l = all[i];
+    if (l == null || l === 'other') continue;
+    total++;
+    counts.set(l, (counts.get(l) || 0) + 1);
+    if (refs && refs[i] != null) {
+      const ex = examples.get(l) || [];
+      if (ex.length < MAX_EXAMPLES) { ex.push(refs[i]); examples.set(l, ex); }
+    }
+  }
   if (total === 0) {
     return { dominant: null, dominantPct: 0, total: 0, variants: [], tier: 'unknown' };
   }
-  const counts = new Map();
-  for (const l of list) counts.set(l, (counts.get(l) || 0) + 1);
   const variants = [...counts.entries()]
-    .map(([label, count]) => ({ label, count, pct: count / total }))
+    .map(([label, count]) => {
+      const v = { label, count, pct: count / total };
+      if (refs) v.examples = examples.get(label) || [];
+      return v;
+    })
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
   const top = variants[0];
   let tier = 'inconsistent';
@@ -131,22 +149,26 @@ function _detectTestFramework(cwd, files) {
 function extractConventions(cwd, files) {
   const scoped = (files || []).filter((f) => SCOPED_EXTS.has(path.extname(f).toLowerCase()));
   const namingLabels = [];
+  const namingRefs = [];
   const exportLabels = [];
+  const exportRefs = [];
   for (const f of scoped) {
     const base = path.basename(f);
     // Skip test files for the naming convention (they have their own naming).
     if (!/\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/.test(f)) {
       namingLabels.push(classifyNaming(base));
+      namingRefs.push(base);
     }
     if (JS_TS_EXTS.has(path.extname(f).toLowerCase())) {
       let src = '';
       try { src = fs.readFileSync(f, 'utf8'); } catch (_) {}
       exportLabels.push(_jsExportStyle(src));
+      exportRefs.push(base);
     }
   }
   return {
-    fileNaming: scoreConvention(namingLabels),
-    exportStyle: scoreConvention(exportLabels),
+    fileNaming: scoreConvention(namingLabels, namingRefs),
+    exportStyle: scoreConvention(exportLabels, exportRefs),
     testFramework: _detectTestFramework(cwd, scoped),
     scope: ['typescript', 'javascript', 'python'],
     scannedFiles: scoped.length,

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.7.0',
+  version: '7.8.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/conventions-conflicts.test.js
+++ b/test/integration/conventions-conflicts.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions --conflicts` (Layer 3).
+ *   scoreConvention examples · toNamingStyle · renameSuggestion · analyzeConflicts · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { scoreConvention, extractConventions } = require(path.join(ROOT, 'src/conventions/extract'));
+const { analyzeConflicts, toNamingStyle, renameSuggestion } =
+  require(path.join(ROOT, 'src/conventions/conflicts'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-conf-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// ── scoreConvention examples (backward compatible) ──────────────────────────
+test('scoreConvention: no refs → no examples key', () => {
+  const r = scoreConvention(['a', 'a', 'b']);
+  assert.strictEqual(r.variants[0].examples, undefined);
+});
+test('scoreConvention: refs → up to 3 examples per variant', () => {
+  const labels = ['a', 'a', 'a', 'a', 'b'];
+  const refs = ['a1', 'a2', 'a3', 'a4', 'b1'];
+  const r = scoreConvention(labels, refs);
+  const a = r.variants.find((v) => v.label === 'a');
+  assert.deepStrictEqual(a.examples, ['a1', 'a2', 'a3']); // capped at 3
+  const b = r.variants.find((v) => v.label === 'b');
+  assert.deepStrictEqual(b.examples, ['b1']);
+});
+
+// ── toNamingStyle ───────────────────────────────────────────────────────────
+test('toNamingStyle: kebab → camelCase', () => {
+  assert.strictEqual(toNamingStyle('user-service', 'camelCase'), 'userService');
+});
+test('toNamingStyle: snake → PascalCase', () => {
+  assert.strictEqual(toNamingStyle('user_service', 'PascalCase'), 'UserService');
+});
+test('toNamingStyle: camel → kebab-case', () => {
+  assert.strictEqual(toNamingStyle('userService', 'kebab-case'), 'user-service');
+});
+test('toNamingStyle: camel → snake_case', () => {
+  assert.strictEqual(toNamingStyle('fooBarBaz', 'snake_case'), 'foo_bar_baz');
+});
+
+// ── renameSuggestion ────────────────────────────────────────────────────────
+test('renameSuggestion: preserves extension', () => {
+  assert.deepStrictEqual(renameSuggestion('user-service.ts', 'camelCase'),
+    { from: 'user-service.ts', to: 'userService.ts' });
+});
+test('renameSuggestion: preserves compound suffix', () => {
+  assert.deepStrictEqual(renameSuggestion('user-service.test.ts', 'camelCase'),
+    { from: 'user-service.test.ts', to: 'userService.test.ts' });
+});
+
+// ── analyzeConflicts ────────────────────────────────────────────────────────
+test('analyzeConflicts: consistent repo → no conflicts', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const r = analyzeConflicts(extractConventions(dir, [
+      path.join(dir, 'src', 'fooBar.js'), path.join(dir, 'src', 'bazQux.js'),
+    ]));
+    assert.strictEqual(r.hasConflicts, false);
+    assert.strictEqual(r.conventions.length, 0);
+  });
+});
+test('analyzeConflicts: mixed naming → conflict with breakdown + renames', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    // 2 camelCase (dominant) + 1 kebab-case minority
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const files = ['fooBar.js', 'bazQux.js', 'user-service.js'].map((f) => path.join(dir, 'src', f));
+    const r = analyzeConflicts(extractConventions(dir, files));
+    assert.strictEqual(r.hasConflicts, true);
+    const naming = r.conventions.find((c) => c.key === 'fileNaming');
+    assert.ok(naming, 'fileNaming conflict present');
+    assert.strictEqual(naming.dominant, 'camelCase');
+    assert.ok(naming.variants.length >= 2, 'multiple variants');
+    const kebab = naming.variants.find((v) => v.pattern === 'kebab-case');
+    assert.ok(kebab.examples.includes('user-service.js'), 'carries example file');
+    // rename suggestion moves the minority file to the dominant style
+    assert.deepStrictEqual(naming.renames.find((x) => x.from === 'user-service.js'),
+      { from: 'user-service.js', to: 'userService.js' });
+  });
+});
+test('analyzeConflicts: export-style conflict has no rename suggestions', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    // consistent kebab naming, but mixed export style
+    fs.writeFileSync(path.join(dir, 'src', 'aa.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bb.js'), 'export default function () {}\n');
+    const files = ['aa.js', 'bb.js'].map((f) => path.join(dir, 'src', f));
+    const r = analyzeConflicts(extractConventions(dir, files));
+    const exp = r.conventions.find((c) => c.key === 'exportStyle');
+    assert.ok(exp, 'exportStyle conflict present');
+    assert.strictEqual(exp.renames.length, 0, 'no renames for export style');
+  });
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: --conflicts prints breakdown for a mixed repo', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/file naming/.test(res.stdout), 'shows convention');
+    assert.ok(/rename to match camelCase/.test(res.stdout), 'shows rename block');
+    assert.ok(/user-service\.js\s+→\s+userService\.js/.test(res.stdout), 'shows rename arrow');
+  });
+});
+test('CLI: --conflicts --json emits structured object', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'user-service.js'), 'export const c = 3;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(typeof data.hasConflicts, 'boolean');
+    assert.ok(Array.isArray(data.conventions));
+  });
+});
+test('CLI: --conflicts on consistent repo says no conflicts', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--conflicts'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/no conflicts/.test(res.stdout), 'reports no conflicts');
+  });
+});
+
+console.log(`\nconventions-conflicts: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 83,
+  "tests": 84,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.7.0",
+  "version": "7.8.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
@@ -12,7 +12,7 @@
     "task_success_proxy_pct": 52.2,
     "prompts_per_task": 1.72,
     "baseline_prompts_per_task": 2.84,
-    "overall_token_reduction_pct": 97.0,
+    "overall_token_reduction_pct": 97,
     "retrieval_lift": 5.6,
     "graph_boosted_hit_at_5": 0.756
   }


### PR DESCRIPTION
## Summary
- Ships **v7.8.0** to main: `sigmap conventions --conflicts` (per-convention breakdown + rename suggestions) + docs/benchmark refresh prepared by /update-docs.

## Changes
- `src/conventions/conflicts.js` (analyzeConflicts / toNamingStyle / renameSuggestion) + `conventions --conflicts` CLI; example-file tracking in `scoreConvention`
- Version sync 7.7.0 → 7.8.0; CHANGELOG + CONTRIBUTORS; docs-vp (cli, roadmap, index); llms.txt regenerated
- Benchmarks confirmed stable: 75.6% hit@5 · 97.0% token reduction (no retrieval/token code changed)

## Test plan
- [x] `node test/integration/all.js` — 78 suites, 0 failures
- [x] bundle / version-meta / llms gates pass
- [x] supply-chain local audit PASS