### PR TITLE
feat: sigmap scaffold — convention-matched proposal with confidence floor (Layer 4)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -24,6 +24,122 @@ function __require(key) {
 // ── ./src/conventions/extract ──
 // ── ./src/conventions/conflicts ──
 // ── ./src/conventions/inject ──
+// ── ./src/scaffold/propose ──
+__factories["./src/scaffold/propose"] = function(module, exports) {
+  
+  /**
+   * Scaffold proposal with a confidence floor (IMPL.md §5 — Cause 3).
+   *
+   * Proposes a convention-matched structure for a new module — filename in the
+   * repo's dominant naming style, the export style to use, and a matching test
+   * file — but only when the conventions are consistent enough. Below a hard
+   * floor it refuses and surfaces the conflict, because a wrong proposal
+   * systematizes bad code. Pure, zero-dependency, bundle-safe; reuses the
+   * conventions primitives.
+   */
+
+  const { toNamingStyle, analyzeConflicts } = __require('./src/conventions/conflicts');
+
+  // Soft threshold is configurable; the hard floor is not (IMPL.md §5.1).
+  const DEFAULT_THRESHOLD = 0.7;
+  const HARD_FLOOR = 0.5;
+
+  /** Tier for a consistency score (matches the conventions tiers). */
+  function _tier(pct) {
+    if (pct >= 0.9) return 'consistent';
+    if (pct >= 0.7) return 'mostly';
+    return 'inconsistent';
+  }
+
+  /** Strip any extension/compound suffix from a requested name → bare stem. */
+  function _stem(name) {
+    const s = String(name || '').trim();
+    const slash = s.lastIndexOf('/');
+    const base = slash >= 0 ? s.slice(slash + 1) : s;
+    const dot = base.indexOf('.');
+    return dot > 0 ? base.slice(0, dot) : base;
+  }
+
+  /** Test file path for a styled stem given the detected framework + ext. */
+  function _testFile(styledStem, framework, ext) {
+    if (framework === 'pytest' || framework === 'unittest') {
+      return `test_${toNamingStyle(styledStem, 'snake_case')}.py`;
+    }
+    return `${styledStem}.test.${ext}`;
+  }
+
+  /**
+   * Propose a convention-matched scaffold, gated by a confidence floor.
+   * @param {string} name desired module name (any casing; extension ignored)
+   * @param {object} conventions an `extractConventions` result
+   * @param {object} [opts]
+   * @param {number} [opts.threshold=0.7] soft threshold (clamped to ≥ hard floor)
+   * @param {boolean} [opts.force=false] allow proposing below the soft threshold
+   *   (never below the hard floor)
+   * @param {string} [opts.ext='js'] file extension for the proposed files
+   * @returns {{ ok:boolean, refused:boolean, name:string, tier:string,
+   *   confidence:number, threshold:number, hardFloor:number, forced:boolean,
+   *   warning:string|null, reason:string, proposal:object|null, conflicts:object }}
+   */
+  function proposeScaffold(name, conventions, opts = {}) {
+    const threshold = Math.max(HARD_FLOOR, opts.threshold != null ? opts.threshold : DEFAULT_THRESHOLD);
+    const force = !!opts.force;
+    const ext = opts.ext || 'js';
+    const fileNaming = (conventions && conventions.fileNaming) || { dominant: null, dominantPct: 0, total: 0 };
+    const exportStyle = (conventions && conventions.exportStyle) || { dominant: null };
+    const confidence = fileNaming.dominantPct || 0;
+    const tier = fileNaming.total > 0 ? _tier(confidence) : 'unknown';
+    const conflicts = analyzeConflicts(conventions || {});
+
+    const base = {
+      ok: false, refused: true, name: String(name || ''), tier, confidence,
+      threshold, hardFloor: HARD_FLOOR, forced: false, warning: null,
+      reason: '', proposal: null, conflicts,
+    };
+
+    if (!fileNaming.dominant || fileNaming.total === 0) {
+      return { ...base, reason: 'no file-naming convention detected — cannot propose a name' };
+    }
+    if (confidence < HARD_FLOOR) {
+      return {
+        ...base,
+        reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the hard floor ${(HARD_FLOOR * 100).toFixed(0)}% — refusing (not overridable)`,
+      };
+    }
+    if (confidence < threshold && !force) {
+      return {
+        ...base,
+        reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the threshold ${(threshold * 100).toFixed(0)}% — refusing (use --force to override above the ${(HARD_FLOOR * 100).toFixed(0)}% floor)`,
+      };
+    }
+
+    const styledStem = toNamingStyle(_stem(name), fileNaming.dominant);
+    const forced = confidence < threshold && force;
+    const proposal = {
+      filename: `${styledStem}.${ext}`,
+      namingStyle: fileNaming.dominant,
+      exportStyle: exportStyle.dominant || 'named',
+      testFile: _testFile(styledStem, conventions.testFramework, ext),
+      testFramework: conventions.testFramework || null,
+    };
+
+    return {
+      ...base,
+      ok: true,
+      refused: false,
+      forced,
+      warning: forced
+        ? `proposed below the ${(threshold * 100).toFixed(0)}% threshold (--force); conventions are only ${tier}`
+        : null,
+      reason: forced ? 'forced proposal above the hard floor' : `conventions are ${tier} — proposing`,
+      proposal,
+    };
+  }
+
+  module.exports = { proposeScaffold, DEFAULT_THRESHOLD, HARD_FLOOR };
+  
+};
+
 __factories["./src/conventions/inject"] = function(module, exports) {
   
   /**
@@ -15939,6 +16055,56 @@ function main() {
     console.log(`  ${'test framework'.padEnd(14)} ${result.testFramework || 'none detected'}`);
     console.log(`\n  → wrote ${path.relative(cwd, outPath)}`);
     process.exit(0);
+  }
+
+  // Layer 4: `sigmap scaffold <name>` — propose a convention-matched structure
+  // for a new module, gated by a confidence floor (refuses if conventions are
+  // too inconsistent; a wrong proposal systematizes bad code).
+  if (args[0] === 'scaffold') {
+    const jsonOut = args.includes('--json');
+    const name = args[1] && !args[1].startsWith('--') ? args[1] : null;
+    if (!name) {
+      console.error('[sigmap] usage: sigmap scaffold <name> [--ext <e>] [--threshold <n>] [--force] [--json]');
+      process.exit(1);
+    }
+    const thIdx = args.indexOf('--threshold');
+    const threshold = thIdx !== -1 && args[thIdx + 1] ? parseFloat(args[thIdx + 1]) : undefined;
+    const extIdx = args.indexOf('--ext');
+    const ext = extIdx !== -1 && args[extIdx + 1] ? args[extIdx + 1].replace(/^\./, '') : undefined;
+    const force = args.includes('--force');
+
+    const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
+    const { proposeScaffold } = requireSourceOrBundled('./src/scaffold/propose');
+    const conventions = extractConventions(cwd, buildFileList(cwd, config));
+    const decision = proposeScaffold(name, conventions, { threshold, ext, force });
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(decision) + '\n');
+      process.exit(decision.ok ? 0 : 1);
+    }
+
+    const pctS = (n) => `${(n * 100).toFixed(0)}%`;
+    if (decision.ok) {
+      console.log(`[sigmap] scaffold "${decision.name}"  — conventions ${decision.tier} (${pctS(decision.confidence)})`);
+      if (decision.warning) console.log(`  ⚠ ${decision.warning}`);
+      const p = decision.proposal;
+      console.log(`  file:           ${p.filename}  (${p.namingStyle})`);
+      console.log(`  export style:   ${p.exportStyle}`);
+      console.log(`  test file:      ${p.testFile}${p.testFramework ? `  (${p.testFramework})` : ''}`);
+      process.exit(0);
+    }
+
+    console.log(`[sigmap] scaffold "${decision.name}" — REFUSED`);
+    console.log(`  ${decision.reason}`);
+    if (decision.conflicts && decision.conflicts.hasConflicts) {
+      for (const c of decision.conflicts.conventions) {
+        console.log(`\n  ${c.name} — dominant: ${c.dominant} ${pctS(c.dominantPct)} [${c.tier}]`);
+        for (const v of c.variants) {
+          console.log(`    ${v.pattern.padEnd(12)} ${pctS(v.pct).padStart(4)}${v.examples.length ? `  e.g. ${v.examples.join(', ')}` : ''}`);
+        }
+      }
+    }
+    process.exit(1);
   }
 
   // v7.0.0: `sigmap squeeze <file|->` — minimize a pasted stacktrace / CI-log / JSON blob

--- a/src/scaffold/propose.js
+++ b/src/scaffold/propose.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Scaffold proposal with a confidence floor (IMPL.md §5 — Cause 3).
+ *
+ * Proposes a convention-matched structure for a new module — filename in the
+ * repo's dominant naming style, the export style to use, and a matching test
+ * file — but only when the conventions are consistent enough. Below a hard
+ * floor it refuses and surfaces the conflict, because a wrong proposal
+ * systematizes bad code. Pure, zero-dependency, bundle-safe; reuses the
+ * conventions primitives.
+ */
+
+const { toNamingStyle, analyzeConflicts } = require('../conventions/conflicts');
+
+// Soft threshold is configurable; the hard floor is not (IMPL.md §5.1).
+const DEFAULT_THRESHOLD = 0.7;
+const HARD_FLOOR = 0.5;
+
+/** Tier for a consistency score (matches the conventions tiers). */
+function _tier(pct) {
+  if (pct >= 0.9) return 'consistent';
+  if (pct >= 0.7) return 'mostly';
+  return 'inconsistent';
+}
+
+/** Strip any extension/compound suffix from a requested name → bare stem. */
+function _stem(name) {
+  const s = String(name || '').trim();
+  const slash = s.lastIndexOf('/');
+  const base = slash >= 0 ? s.slice(slash + 1) : s;
+  const dot = base.indexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}
+
+/** Test file path for a styled stem given the detected framework + ext. */
+function _testFile(styledStem, framework, ext) {
+  if (framework === 'pytest' || framework === 'unittest') {
+    return `test_${toNamingStyle(styledStem, 'snake_case')}.py`;
+  }
+  return `${styledStem}.test.${ext}`;
+}
+
+/**
+ * Propose a convention-matched scaffold, gated by a confidence floor.
+ * @param {string} name desired module name (any casing; extension ignored)
+ * @param {object} conventions an `extractConventions` result
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=0.7] soft threshold (clamped to ≥ hard floor)
+ * @param {boolean} [opts.force=false] allow proposing below the soft threshold
+ *   (never below the hard floor)
+ * @param {string} [opts.ext='js'] file extension for the proposed files
+ * @returns {{ ok:boolean, refused:boolean, name:string, tier:string,
+ *   confidence:number, threshold:number, hardFloor:number, forced:boolean,
+ *   warning:string|null, reason:string, proposal:object|null, conflicts:object }}
+ */
+function proposeScaffold(name, conventions, opts = {}) {
+  const threshold = Math.max(HARD_FLOOR, opts.threshold != null ? opts.threshold : DEFAULT_THRESHOLD);
+  const force = !!opts.force;
+  const ext = opts.ext || 'js';
+  const fileNaming = (conventions && conventions.fileNaming) || { dominant: null, dominantPct: 0, total: 0 };
+  const exportStyle = (conventions && conventions.exportStyle) || { dominant: null };
+  const confidence = fileNaming.dominantPct || 0;
+  const tier = fileNaming.total > 0 ? _tier(confidence) : 'unknown';
+  const conflicts = analyzeConflicts(conventions || {});
+
+  const base = {
+    ok: false, refused: true, name: String(name || ''), tier, confidence,
+    threshold, hardFloor: HARD_FLOOR, forced: false, warning: null,
+    reason: '', proposal: null, conflicts,
+  };
+
+  if (!fileNaming.dominant || fileNaming.total === 0) {
+    return { ...base, reason: 'no file-naming convention detected — cannot propose a name' };
+  }
+  if (confidence < HARD_FLOOR) {
+    return {
+      ...base,
+      reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the hard floor ${(HARD_FLOOR * 100).toFixed(0)}% — refusing (not overridable)`,
+    };
+  }
+  if (confidence < threshold && !force) {
+    return {
+      ...base,
+      reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the threshold ${(threshold * 100).toFixed(0)}% — refusing (use --force to override above the ${(HARD_FLOOR * 100).toFixed(0)}% floor)`,
+    };
+  }
+
+  const styledStem = toNamingStyle(_stem(name), fileNaming.dominant);
+  const forced = confidence < threshold && force;
+  const proposal = {
+    filename: `${styledStem}.${ext}`,
+    namingStyle: fileNaming.dominant,
+    exportStyle: exportStyle.dominant || 'named',
+    testFile: _testFile(styledStem, conventions.testFramework, ext),
+    testFramework: conventions.testFramework || null,
+  };
+
+  return {
+    ...base,
+    ok: true,
+    refused: false,
+    forced,
+    warning: forced
+      ? `proposed below the ${(threshold * 100).toFixed(0)}% threshold (--force); conventions are only ${tier}`
+      : null,
+    reason: forced ? 'forced proposal above the hard floor' : `conventions are ${tier} — proposing`,
+    proposal,
+  };
+}
+
+module.exports = { proposeScaffold, DEFAULT_THRESHOLD, HARD_FLOOR };

--- a/test/integration/scaffold.test.js
+++ b/test/integration/scaffold.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap scaffold` (Layer 4 — confidence floor).
+ *   proposeScaffold: propose / refuse / hard-floor / force / pytest · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { proposeScaffold, HARD_FLOOR, DEFAULT_THRESHOLD } =
+  require(path.join(ROOT, 'src/scaffold/propose'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scaffold-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// Build a conventions result with a specific file-naming consistency.
+function conv(pct, { framework = 'jest' } = {}) {
+  const major = Math.round(pct * 10);
+  const minor = 10 - major;
+  return {
+    fileNaming: {
+      dominant: 'camelCase', dominantPct: pct, total: 10,
+      tier: pct >= 0.9 ? 'consistent' : pct >= 0.7 ? 'mostly' : 'inconsistent',
+      variants: [
+        { label: 'camelCase', count: major, pct, examples: ['fooBar.js'] },
+        { label: 'kebab-case', count: minor, pct: minor / 10, examples: ['user-service.js'] },
+      ],
+    },
+    exportStyle: { dominant: 'named', dominantPct: 1, total: 10,
+      variants: [{ label: 'named', count: 10, pct: 1, examples: ['fooBar.js'] }] },
+    testFramework: framework,
+  };
+}
+
+// ── proposeScaffold ─────────────────────────────────────────────────────────
+test('consistent → proposes convention-matched filename + export + test', () => {
+  const d = proposeScaffold('user profile loader', conv(0.95));
+  assert.strictEqual(d.ok, true);
+  assert.strictEqual(d.refused, false);
+  assert.strictEqual(d.proposal.filename, 'userProfileLoader.js');
+  assert.strictEqual(d.proposal.namingStyle, 'camelCase');
+  assert.strictEqual(d.proposal.exportStyle, 'named');
+  assert.strictEqual(d.proposal.testFile, 'userProfileLoader.test.js');
+});
+test('below threshold (0.6) without force → refuses + surfaces conflicts', () => {
+  const d = proposeScaffold('newWidget', conv(0.6));
+  assert.strictEqual(d.ok, false);
+  assert.strictEqual(d.refused, true);
+  assert.strictEqual(d.proposal, null);
+  assert.ok(/below the threshold/.test(d.reason));
+  assert.strictEqual(d.conflicts.hasConflicts, true);
+});
+test('hard floor is non-overridable — below 0.5 refuses even with force', () => {
+  const d = proposeScaffold('newWidget', conv(0.33), { force: true });
+  assert.strictEqual(d.ok, false);
+  assert.ok(/hard floor/.test(d.reason));
+  assert.strictEqual(d.proposal, null);
+});
+test('force allows a proposal between hard floor and threshold (with warning)', () => {
+  const d = proposeScaffold('newWidget', conv(0.6), { force: true });
+  assert.strictEqual(d.ok, true);
+  assert.strictEqual(d.forced, true);
+  assert.ok(d.warning && /force/.test(d.warning));
+  assert.strictEqual(d.proposal.filename, 'newWidget.js');
+});
+test('no file-naming convention → refuses', () => {
+  const d = proposeScaffold('x', { fileNaming: { dominant: null, dominantPct: 0, total: 0, variants: [] } });
+  assert.strictEqual(d.ok, false);
+  assert.ok(/no file-naming convention/.test(d.reason));
+});
+test('pytest framework → test_<snake>.py test file', () => {
+  const d = proposeScaffold('UserProfile', conv(0.95, { framework: 'pytest' }), { ext: 'py' });
+  assert.strictEqual(d.proposal.testFile, 'test_user_profile.py');
+});
+test('threshold is clamped to the hard floor', () => {
+  // asking for a 0.3 threshold cannot drop below the 0.5 hard floor
+  const d = proposeScaffold('w', conv(0.4), { threshold: 0.3 });
+  assert.strictEqual(d.threshold, HARD_FLOOR);
+  assert.strictEqual(d.ok, false); // 0.4 < 0.5 floor
+});
+test('custom ext is honored', () => {
+  const d = proposeScaffold('myThing', conv(0.95), { ext: 'ts' });
+  assert.strictEqual(d.proposal.filename, 'myThing.ts');
+  assert.strictEqual(d.proposal.testFile, 'myThing.test.ts');
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+function writeRepo(dir, files) {
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  for (const [f, c] of Object.entries(files)) fs.writeFileSync(path.join(dir, 'src', f), c);
+}
+
+test('CLI: scaffold proposes on a consistent repo (exit 0)', () => {
+  withRepo((dir) => {
+    // 9 camelCase + 1 kebab → 90% consistent
+    const files = {};
+    for (let i = 0; i < 9; i++) files[`fooBar${i}.js`] = 'export const a = 1;\n';
+    files['user-service.js'] = 'export const b = 2;\n';
+    writeRepo(dir, files);
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'new thing'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/newThing\.js/.test(res.stdout), 'proposes styled filename');
+  });
+});
+test('CLI: scaffold refuses on an inconsistent repo (exit 1 + conflict)', () => {
+  withRepo((dir) => {
+    writeRepo(dir, {
+      'fooBar.js': 'export const a=1;\n',
+      'user-service.js': 'export const b=2;\n',
+      'some_thing.js': 'export const c=3;\n',
+    });
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'new widget'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1, 'refusal exits 1');
+    assert.ok(/REFUSED/.test(res.stdout), 'prints REFUSED');
+  });
+});
+test('CLI: scaffold --json emits the decision', () => {
+  withRepo((dir) => {
+    const files = {};
+    for (let i = 0; i < 9; i++) files[`fooBar${i}.js`] = 'export const a = 1;\n';
+    files['user-service.js'] = 'export const b = 2;\n';
+    writeRepo(dir, files);
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'myThing', '--json'], { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(typeof data.ok, 'boolean');
+    assert.strictEqual(data.hardFloor, HARD_FLOOR);
+    assert.ok(data.proposal);
+  });
+});
+test('CLI: scaffold with no name exits 1 with usage', () => {
+  withRepo((dir) => {
+    writeRepo(dir, { 'a.js': 'export const a=1;\n' });
+    const res = spawnSync('node', [SCRIPT, 'scaffold'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    assert.ok(/usage/.test(res.stderr));
+  });
+});
+
+console.log(`\nscaffold: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 85,
+  "tests": 86,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- First slice of IMPL.md **Layer 4 (grounded codegen, Cause 3)** — the centerpiece of the remaining work. `sigmap scaffold <name>` proposes a convention-matched structure for a new module, gated by a **confidence floor**: it refuses when the repo's conventions are too inconsistent, because a wrong proposal systematizes bad code. Closes #307.

## Changes
- `src/scaffold/propose.js` (new, zero-dep, bundle-safe): `proposeScaffold(name, conventions, opts)` → `{ ok, refused, tier, confidence, threshold, proposal | null, reason, conflicts, forced, warning }`.
  - Governing confidence = file-naming consistency. Soft threshold default **0.70** (overridable); **hard floor 0.50 non-overridable**.
  - ≥ threshold → propose `{ filename (dominant naming style), exportStyle, testFile, testFramework }`.
  - floor ≤ confidence < threshold → refuse, unless `--force` (proposes with a warning); below the floor → always refuse + surface conflicts (reuses `analyzeConflicts`).
- `gen-context.js`: `scaffold <name>` CLI (`--ext`, `--threshold`, `--force`, `--json`); refusal exits 1. Registered bundle factory.
- `version.json`: derived `tests` 85 → 86.

Deferred follow-ups: scaffold writes `.sigmap/scaffold/latest.md`, `--naming-pattern` override, config-schema threshold (§5.3 1d/1f), then Gap 2 (`verify-plan` → `create` → `review-pr`).

## Test plan
- [x] `node test/integration/scaffold.test.js` — 12 passed (propose / refuse / hard-floor / force / pytest / CLI)
- [x] `node test/integration/all.js` — 80 suites, 0 failures
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)