### PR TITLE
release: v7.10.0 — sigmap scaffold + confidence floor (Layer 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.10.0] — 2026-06-17
+
+Minor release — `sigmap scaffold` with a confidence floor (grounded codegen, Layer 4).
+
+### Added
+- **`sigmap scaffold <name>` — convention-matched proposal with a confidence floor (#307):** the first slice of Layer 4 (Cause 3 — guessing structure for new code). Proposes a convention-matched structure for a new module — filename in the repo's dominant naming style, the export style to use, and a matching test file — but **only when the conventions are consistent enough**. New zero-dependency, bundle-safe `src/scaffold/propose.js` (`proposeScaffold`): the governing confidence is file-naming consistency, with a soft threshold (default 0.70, overridable via `--threshold`) and a **non-overridable hard floor of 0.50**. Below the threshold it refuses and surfaces the conflict (reusing `analyzeConflicts`); `--force` allows a proposal between the floor and the threshold (flagged with a warning), but never below the floor — a wrong proposal systematizes bad code. CLI supports `--ext`, `--threshold`, `--force`, and `--json` (refusal exits 1). Scaffold persistence (`.sigmap/scaffold/latest.md`), `--naming-pattern` override, and the `verify-plan` → `create` → `review-pr` pipeline remain follow-ups.
+
+---
+
 ## [7.9.0] — 2026-06-17
 
 Minor release — `sigmap conventions --inject` (grounded codegen, Layer 3).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,9 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
+### Recent Contributors (v7.10.0)
+- **@manojmallick** — feat: `sigmap scaffold` — convention-matched proposal with a confidence floor (soft threshold 0.70, non-overridable hard floor 0.50); `proposeScaffold`; Layer 4 grounded codegen (#307, PR #308)
+
 ### Recent Contributors (v7.9.0)
 - **@manojmallick** — feat: `sigmap conventions --inject` — write the auto-detected conventions block into CLAUDE.md (idempotent, marker-scoped); `renderConventionsBlock` / `injectConventions`; Layer 3 grounded codegen (#304, PR #305)
 

--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -7,7 +7,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - property: og:description
-      content: "All 56 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 57 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, scaffold, plan, bench, judge, verify-ai-output, note, status, validate, roots, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/cli"
@@ -19,7 +19,7 @@ head:
       content: "SigMap CLI Reference — every command and flag with examples"
   - - meta
     - name: twitter:description
-      content: "All 56 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
+      content: "All 57 SigMap commands and flags documented with examples. ask, gain, squeeze, conventions, scaffold, plan, bench, judge, verify-ai-output, note, status, validate, history, --ci, --cost, --coverage, --watch, --diff, --mcp, --report, --health, weights --export/--import and more."
   - - meta
     - name: twitter:image:alt
       content: "SigMap CLI Reference"
@@ -56,6 +56,7 @@ If you are new to the product, start with the workflow pages first:
 | `conventions` | Extract & report a repo's coding conventions — file naming, export style, test framework (TS/JS/Python); writes `.context/conventions.json` (`--json` for machine output) |
 | `conventions --conflicts` | Breakdown of every mixed convention (counts, bars, example files) + rename suggestions toward the dominant style |
 | `conventions --inject` | Write/update the auto-detected conventions block in `CLAUDE.md` (idempotent, marker-scoped) so agents see the house style |
+| `scaffold <name>` | Propose a convention-matched structure (filename, export style, test file) for a new module — refuses below the confidence floor |
 | `plan "<goal>"` | Analyze change impact and plan modifications — returns files grouped by confidence |
 | `judge --response <f> --context <f>` | Rule-based groundedness scoring for LLM responses |
 | `verify-ai-output <answer.md>` | Hallucination Guard — flag fake files, test files, imports, symbols, and npm scripts in an AI answer (deterministic, offline) |
@@ -472,7 +473,46 @@ Match these when writing or editing code (TS/JS/Python):
 <!-- sigmap-conventions:end -->
 ```
 
-These are the conventions slices of grounded code generation; `--report`, `--fix`, `--update`, `--ci`, and the Layer 4 scaffold are planned follow-ups.
+These are the conventions slices of grounded code generation; `--report`, `--fix`, `--update`, and `--ci` are planned follow-ups.
+
+---
+
+## scaffold
+
+Propose a **convention-matched structure** for a new module — but only when the repo's conventions are consistent enough. `scaffold <name>` reports a filename in the dominant naming style, the export style to use, and a matching test file. Below a confidence floor it **refuses** and surfaces the conflict, because a wrong proposal systematizes bad code.
+
+```bash
+sigmap scaffold "user profile loader"      # propose
+sigmap scaffold "userProfile" --json       # machine-readable decision
+sigmap scaffold "widget" --force           # propose below the soft threshold (not below the hard floor)
+sigmap scaffold "widget" --ext ts          # set the file extension
+```
+
+```
+[sigmap] scaffold "user profile loader"  — conventions mostly (77%)
+  file:           userProfileLoader.js  (camelCase)
+  export style:   named
+  test file:      userProfileLoader.test.js
+```
+
+The proposal is gated by the **file-naming consistency** (the confidence):
+
+| Confidence | Behavior |
+|------------|----------|
+| ≥ threshold (default 0.70) | propose |
+| hard floor (0.50) ≤ c < threshold | refuse — unless `--force` (proposes with a warning) |
+| < 0.50 (hard floor) | **always refuse** — not overridable, even with `--force` |
+
+When it refuses, it prints the conflicting patterns (counts + example files) so you can fix the convention first. A refusal exits non-zero (useful in CI/scripts).
+
+| Option | Description |
+|--------|-------------|
+| `--ext <e>` | File extension for the proposed files (default `js`) |
+| `--threshold <n>` | Soft consistency threshold 0–1 (default 0.70; clamped to the 0.50 hard floor) |
+| `--force` | Propose between the hard floor and the soft threshold (flagged with a warning); never below the floor |
+| `--json` | Emit the full decision `{ ok, refused, tier, confidence, threshold, proposal, conflicts }` |
+
+This is the first slice of Layer 4 (grounded code generation); scaffold persistence, a `--naming-pattern` override, and the `verify-plan` → `create` → `review-pr` pipeline are planned follow-ups.
 
 ---
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: SigMap version history and roadmap. From v0.0 to v7.9.0, with recent releases adding the sigmap conventions command with its --conflicts breakdown and --inject CLAUDE.md injection (grounded codegen, Layer 3), the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
+description: SigMap version history and roadmap. From v0.0 to v7.10.0, with recent releases adding the sigmap scaffold command with its confidence floor and the conventions command with --conflicts breakdown and --inject CLAUDE.md injection (grounded codegen, Layers 3–4), the grounding benchmark, read-time self-heal, live-index MCP write hooks, the get_callee_signatures MCP tool (exact callee signatures), realistic per-query savings, release-pipeline robustness (bundle integrity + version.json gates, standalone-bundle smoke test), the sigmap gain token-savings dashboard, supply-chain hardening (zero system-shell access), Squeeze input minimization with symbol enrichment, source-of-truth llms.txt, the verify-ai-output Hallucination Guard, and Memory tools (note, status, read_memory MCP tool).
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Sixty-eight versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 1,055 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,068 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -828,6 +828,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 
 ---
 
+### v7.10.0 — `sigmap scaffold` + confidence floor (Layer 4) ✓ (2026-06-17)
+
+**Minor release — first slice of Layer 4 (Cause 3: guessing structure for new code).** `sigmap scaffold <name>` proposes a convention-matched structure for a new module — filename in the dominant naming style, the export style to use, and a matching test file — but **only when the conventions are consistent enough**. New zero-dependency, bundle-safe `src/scaffold/propose.js` (`proposeScaffold`): the governing confidence is file-naming consistency, with a configurable soft threshold (default 0.70) and a **non-overridable hard floor of 0.50**. Below the threshold it refuses and surfaces the conflict (reusing `analyzeConflicts`); `--force` allows a proposal between the floor and the threshold (flagged), but never below the floor — a wrong proposal *systematizes* bad code, so the floor is the safety. CLI supports `--ext`, `--threshold`, `--force`, `--json`; a refusal exits non-zero. This closes the last open root cause (Cause 3).
+
+**Tags:** `scaffold` · `confidence-floor` · `proposeScaffold` · `hard-floor` · `grounded-codegen` · `layer-4` · `cause-3` · `#307`
+
+**Impact:** grounded codegen now *produces* structure, not just describes it — and refuses rather than systematize an inconsistent convention.
+
+---
+
 ### v7.9.0 — `conventions --inject` (CLAUDE.md injection, Layer 3) ✓ (2026-06-17)
 
 **Minor release — completes the "agent sees the conventions" link.** `sigmap conventions --inject` renders the detected conventions (file naming, export style, test framework — each with dominant pattern + consistency tier) into a marker-delimited block and writes it into `CLAUDE.md`, creating the file if absent. New zero-dependency, bundle-safe `src/conventions/inject.js` (`renderConventionsBlock`, `injectConventions`): idempotent and marker-scoped (`<!-- sigmap-conventions:start -->` … `:end -->`), preserving all human content and coexisting with the `## Auto-generated signatures` block. This is §8 step 5 of the grounded-creation loop — the LLM now plans grounded in the repo's house style. `--report`, `--fix`, `--update`, `--ci`, and the Layer 4 scaffold remain follow-ups.
@@ -950,9 +960,9 @@ Alongside it: the **token budget now keeps full signatures** (#240) — when con
 
 ---
 
-## Current milestone — v7.8+ (grounded codegen: convention enforcement + scaffold)
+## Current milestone — v7.11+ (grounded codegen: the `sigmap create` pipeline)
 
-v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on); and the **grounded-codegen** track — **v7.4–7.5** live-index write hooks + read-time self-heal (Layer 1), **v7.6.0** the offline grounding benchmark (the GATE), **v7.7.0** **`sigmap conventions`** (Layer 3: extract a repo's file-naming / export / test-framework conventions); **v7.8.0** **`conventions --conflicts`** (per-convention breakdown + rename suggestions); and **v7.9.0** **`conventions --inject`** (CLAUDE.md convention injection — the agent now sees the house style). Next: round out Layer 3 — `conventions --report/--fix/--update/--ci` — then **Layer 4 scaffold** (generate convention-matched stubs, gated by the confidence floor). Also planned: **PR verification** (`verify-plan` / `review-pr` GitHub Action), the **Interactive Context Explorer**, line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
+v6.0–v7.0.0 shipped graph-boosted retrieval, incremental signature cache, weights sharing, native tool instructions across all 7 adapters, MCP auto-wire, intelligent source root detection, intent-aware retrieval, cross-session context memory with impact planning, R language support, Python AST extraction, line anchors (Surgical Context), demand-driven retrieval with the `get_lines` MCP tool, the **`verify-ai-output` Hallucination Guard** (five-detector reliable MVP with closest-match suggestions + HTML report), **Memory tools** (`note`, `status`, `read_memory` — 11 MCP tools total), **v7.0.0**: **Squeeze** input minimization with symbol enrichment, full-signatures-under-budget, one canonical usage block, source-of-truth `llms.txt`, and pinned reproducible benchmarks; **v7.1.0**: the **`sigmap gain`** token-savings dashboard (cumulative tokens saved, %, est. $, daily/weekly/monthly trends; privacy-safe, local-only, default-on); and the **grounded-codegen** track — **v7.4–7.5** live-index write hooks + read-time self-heal (Layer 1), **v7.6.0** the offline grounding benchmark (the GATE), **v7.7.0** **`sigmap conventions`** (Layer 3: extract a repo's file-naming / export / test-framework conventions); **v7.8.0** **`conventions --conflicts`** (per-convention breakdown + rename suggestions); **v7.9.0** **`conventions --inject`** (CLAUDE.md convention injection — the agent now sees the house style); and **v7.10.0** **`sigmap scaffold`** (Layer 4: convention-matched proposal gated by a confidence floor — closing the last root cause). Next: the **`sigmap create` pipeline** (Gap 2) — `verify-plan` (plan vs live index) → `create` orchestration → `review-pr` (`verify-ai-output` is already shipped) — plus scaffold persistence and the remaining `conventions --report/--fix/--update/--ci` flags. Also planned: **PR verification** (`verify-plan` / `review-pr` GitHub Action), the **Interactive Context Explorer**, line anchors for the remaining extractors (Java, Go, Rust, C#, …), and performance optimizations for very large monorepos (>50K files).
 
 ---
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.9.0</span>
+  <span><strong>Release:</strong> v7.10.0</span>
   <span>·</span>
-  <span><code>sigmap conventions --inject</code> — write the auto-detected conventions block into CLAUDE.md so agents plan in your house style (grounded codegen, Layer 3)</span>
+  <span><code>sigmap scaffold</code> — propose a convention-matched structure for new code, gated by a confidence floor (grounded codegen, Layer 4)</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.9.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.10.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.9.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.10.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -24,6 +24,122 @@ function __require(key) {
 // ── ./src/conventions/extract ──
 // ── ./src/conventions/conflicts ──
 // ── ./src/conventions/inject ──
+// ── ./src/scaffold/propose ──
+__factories["./src/scaffold/propose"] = function(module, exports) {
+  
+  /**
+   * Scaffold proposal with a confidence floor (IMPL.md §5 — Cause 3).
+   *
+   * Proposes a convention-matched structure for a new module — filename in the
+   * repo's dominant naming style, the export style to use, and a matching test
+   * file — but only when the conventions are consistent enough. Below a hard
+   * floor it refuses and surfaces the conflict, because a wrong proposal
+   * systematizes bad code. Pure, zero-dependency, bundle-safe; reuses the
+   * conventions primitives.
+   */
+
+  const { toNamingStyle, analyzeConflicts } = __require('./src/conventions/conflicts');
+
+  // Soft threshold is configurable; the hard floor is not (IMPL.md §5.1).
+  const DEFAULT_THRESHOLD = 0.7;
+  const HARD_FLOOR = 0.5;
+
+  /** Tier for a consistency score (matches the conventions tiers). */
+  function _tier(pct) {
+    if (pct >= 0.9) return 'consistent';
+    if (pct >= 0.7) return 'mostly';
+    return 'inconsistent';
+  }
+
+  /** Strip any extension/compound suffix from a requested name → bare stem. */
+  function _stem(name) {
+    const s = String(name || '').trim();
+    const slash = s.lastIndexOf('/');
+    const base = slash >= 0 ? s.slice(slash + 1) : s;
+    const dot = base.indexOf('.');
+    return dot > 0 ? base.slice(0, dot) : base;
+  }
+
+  /** Test file path for a styled stem given the detected framework + ext. */
+  function _testFile(styledStem, framework, ext) {
+    if (framework === 'pytest' || framework === 'unittest') {
+      return `test_${toNamingStyle(styledStem, 'snake_case')}.py`;
+    }
+    return `${styledStem}.test.${ext}`;
+  }
+
+  /**
+   * Propose a convention-matched scaffold, gated by a confidence floor.
+   * @param {string} name desired module name (any casing; extension ignored)
+   * @param {object} conventions an `extractConventions` result
+   * @param {object} [opts]
+   * @param {number} [opts.threshold=0.7] soft threshold (clamped to ≥ hard floor)
+   * @param {boolean} [opts.force=false] allow proposing below the soft threshold
+   *   (never below the hard floor)
+   * @param {string} [opts.ext='js'] file extension for the proposed files
+   * @returns {{ ok:boolean, refused:boolean, name:string, tier:string,
+   *   confidence:number, threshold:number, hardFloor:number, forced:boolean,
+   *   warning:string|null, reason:string, proposal:object|null, conflicts:object }}
+   */
+  function proposeScaffold(name, conventions, opts = {}) {
+    const threshold = Math.max(HARD_FLOOR, opts.threshold != null ? opts.threshold : DEFAULT_THRESHOLD);
+    const force = !!opts.force;
+    const ext = opts.ext || 'js';
+    const fileNaming = (conventions && conventions.fileNaming) || { dominant: null, dominantPct: 0, total: 0 };
+    const exportStyle = (conventions && conventions.exportStyle) || { dominant: null };
+    const confidence = fileNaming.dominantPct || 0;
+    const tier = fileNaming.total > 0 ? _tier(confidence) : 'unknown';
+    const conflicts = analyzeConflicts(conventions || {});
+
+    const base = {
+      ok: false, refused: true, name: String(name || ''), tier, confidence,
+      threshold, hardFloor: HARD_FLOOR, forced: false, warning: null,
+      reason: '', proposal: null, conflicts,
+    };
+
+    if (!fileNaming.dominant || fileNaming.total === 0) {
+      return { ...base, reason: 'no file-naming convention detected — cannot propose a name' };
+    }
+    if (confidence < HARD_FLOOR) {
+      return {
+        ...base,
+        reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the hard floor ${(HARD_FLOOR * 100).toFixed(0)}% — refusing (not overridable)`,
+      };
+    }
+    if (confidence < threshold && !force) {
+      return {
+        ...base,
+        reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the threshold ${(threshold * 100).toFixed(0)}% — refusing (use --force to override above the ${(HARD_FLOOR * 100).toFixed(0)}% floor)`,
+      };
+    }
+
+    const styledStem = toNamingStyle(_stem(name), fileNaming.dominant);
+    const forced = confidence < threshold && force;
+    const proposal = {
+      filename: `${styledStem}.${ext}`,
+      namingStyle: fileNaming.dominant,
+      exportStyle: exportStyle.dominant || 'named',
+      testFile: _testFile(styledStem, conventions.testFramework, ext),
+      testFramework: conventions.testFramework || null,
+    };
+
+    return {
+      ...base,
+      ok: true,
+      refused: false,
+      forced,
+      warning: forced
+        ? `proposed below the ${(threshold * 100).toFixed(0)}% threshold (--force); conventions are only ${tier}`
+        : null,
+      reason: forced ? 'forced proposal above the hard floor' : `conventions are ${tier} — proposing`,
+      proposal,
+    };
+  }
+
+  module.exports = { proposeScaffold, DEFAULT_THRESHOLD, HARD_FLOOR };
+  
+};
+
 __factories["./src/conventions/inject"] = function(module, exports) {
   
   /**
@@ -15939,6 +16055,56 @@ function main() {
     console.log(`  ${'test framework'.padEnd(14)} ${result.testFramework || 'none detected'}`);
     console.log(`\n  → wrote ${path.relative(cwd, outPath)}`);
     process.exit(0);
+  }
+
+  // Layer 4: `sigmap scaffold <name>` — propose a convention-matched structure
+  // for a new module, gated by a confidence floor (refuses if conventions are
+  // too inconsistent; a wrong proposal systematizes bad code).
+  if (args[0] === 'scaffold') {
+    const jsonOut = args.includes('--json');
+    const name = args[1] && !args[1].startsWith('--') ? args[1] : null;
+    if (!name) {
+      console.error('[sigmap] usage: sigmap scaffold <name> [--ext <e>] [--threshold <n>] [--force] [--json]');
+      process.exit(1);
+    }
+    const thIdx = args.indexOf('--threshold');
+    const threshold = thIdx !== -1 && args[thIdx + 1] ? parseFloat(args[thIdx + 1]) : undefined;
+    const extIdx = args.indexOf('--ext');
+    const ext = extIdx !== -1 && args[extIdx + 1] ? args[extIdx + 1].replace(/^\./, '') : undefined;
+    const force = args.includes('--force');
+
+    const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
+    const { proposeScaffold } = requireSourceOrBundled('./src/scaffold/propose');
+    const conventions = extractConventions(cwd, buildFileList(cwd, config));
+    const decision = proposeScaffold(name, conventions, { threshold, ext, force });
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(decision) + '\n');
+      process.exit(decision.ok ? 0 : 1);
+    }
+
+    const pctS = (n) => `${(n * 100).toFixed(0)}%`;
+    if (decision.ok) {
+      console.log(`[sigmap] scaffold "${decision.name}"  — conventions ${decision.tier} (${pctS(decision.confidence)})`);
+      if (decision.warning) console.log(`  ⚠ ${decision.warning}`);
+      const p = decision.proposal;
+      console.log(`  file:           ${p.filename}  (${p.namingStyle})`);
+      console.log(`  export style:   ${p.exportStyle}`);
+      console.log(`  test file:      ${p.testFile}${p.testFramework ? `  (${p.testFramework})` : ''}`);
+      process.exit(0);
+    }
+
+    console.log(`[sigmap] scaffold "${decision.name}" — REFUSED`);
+    console.log(`  ${decision.reason}`);
+    if (decision.conflicts && decision.conflicts.hasConflicts) {
+      for (const c of decision.conflicts.conventions) {
+        console.log(`\n  ${c.name} — dominant: ${c.dominant} ${pctS(c.dominantPct)} [${c.tier}]`);
+        for (const v of c.variants) {
+          console.log(`    ${v.pattern.padEnd(12)} ${pctS(v.pct).padStart(4)}${v.examples.length ? `  e.g. ${v.examples.join(', ')}` : ''}`);
+        }
+      }
+    }
+    process.exit(1);
   }
 
   // v7.0.0: `sigmap squeeze <file|->` — minimize a pasted stacktrace / CI-log / JSON blob

--- a/gen-context.js
+++ b/gen-context.js
@@ -7119,7 +7119,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.9.0',
+    version: '7.10.0',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -12797,7 +12797,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.9.0';
+const VERSION = '7.10.0';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.9.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.10.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.9.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
+# Version: 7.10.0 | Benchmark: sigmap-v7.0-main (2026-06-14)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.9.0',
+  version: '7.10.0',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/src/scaffold/propose.js
+++ b/src/scaffold/propose.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Scaffold proposal with a confidence floor (IMPL.md §5 — Cause 3).
+ *
+ * Proposes a convention-matched structure for a new module — filename in the
+ * repo's dominant naming style, the export style to use, and a matching test
+ * file — but only when the conventions are consistent enough. Below a hard
+ * floor it refuses and surfaces the conflict, because a wrong proposal
+ * systematizes bad code. Pure, zero-dependency, bundle-safe; reuses the
+ * conventions primitives.
+ */
+
+const { toNamingStyle, analyzeConflicts } = require('../conventions/conflicts');
+
+// Soft threshold is configurable; the hard floor is not (IMPL.md §5.1).
+const DEFAULT_THRESHOLD = 0.7;
+const HARD_FLOOR = 0.5;
+
+/** Tier for a consistency score (matches the conventions tiers). */
+function _tier(pct) {
+  if (pct >= 0.9) return 'consistent';
+  if (pct >= 0.7) return 'mostly';
+  return 'inconsistent';
+}
+
+/** Strip any extension/compound suffix from a requested name → bare stem. */
+function _stem(name) {
+  const s = String(name || '').trim();
+  const slash = s.lastIndexOf('/');
+  const base = slash >= 0 ? s.slice(slash + 1) : s;
+  const dot = base.indexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}
+
+/** Test file path for a styled stem given the detected framework + ext. */
+function _testFile(styledStem, framework, ext) {
+  if (framework === 'pytest' || framework === 'unittest') {
+    return `test_${toNamingStyle(styledStem, 'snake_case')}.py`;
+  }
+  return `${styledStem}.test.${ext}`;
+}
+
+/**
+ * Propose a convention-matched scaffold, gated by a confidence floor.
+ * @param {string} name desired module name (any casing; extension ignored)
+ * @param {object} conventions an `extractConventions` result
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=0.7] soft threshold (clamped to ≥ hard floor)
+ * @param {boolean} [opts.force=false] allow proposing below the soft threshold
+ *   (never below the hard floor)
+ * @param {string} [opts.ext='js'] file extension for the proposed files
+ * @returns {{ ok:boolean, refused:boolean, name:string, tier:string,
+ *   confidence:number, threshold:number, hardFloor:number, forced:boolean,
+ *   warning:string|null, reason:string, proposal:object|null, conflicts:object }}
+ */
+function proposeScaffold(name, conventions, opts = {}) {
+  const threshold = Math.max(HARD_FLOOR, opts.threshold != null ? opts.threshold : DEFAULT_THRESHOLD);
+  const force = !!opts.force;
+  const ext = opts.ext || 'js';
+  const fileNaming = (conventions && conventions.fileNaming) || { dominant: null, dominantPct: 0, total: 0 };
+  const exportStyle = (conventions && conventions.exportStyle) || { dominant: null };
+  const confidence = fileNaming.dominantPct || 0;
+  const tier = fileNaming.total > 0 ? _tier(confidence) : 'unknown';
+  const conflicts = analyzeConflicts(conventions || {});
+
+  const base = {
+    ok: false, refused: true, name: String(name || ''), tier, confidence,
+    threshold, hardFloor: HARD_FLOOR, forced: false, warning: null,
+    reason: '', proposal: null, conflicts,
+  };
+
+  if (!fileNaming.dominant || fileNaming.total === 0) {
+    return { ...base, reason: 'no file-naming convention detected — cannot propose a name' };
+  }
+  if (confidence < HARD_FLOOR) {
+    return {
+      ...base,
+      reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the hard floor ${(HARD_FLOOR * 100).toFixed(0)}% — refusing (not overridable)`,
+    };
+  }
+  if (confidence < threshold && !force) {
+    return {
+      ...base,
+      reason: `file-naming consistency ${(confidence * 100).toFixed(0)}% is below the threshold ${(threshold * 100).toFixed(0)}% — refusing (use --force to override above the ${(HARD_FLOOR * 100).toFixed(0)}% floor)`,
+    };
+  }
+
+  const styledStem = toNamingStyle(_stem(name), fileNaming.dominant);
+  const forced = confidence < threshold && force;
+  const proposal = {
+    filename: `${styledStem}.${ext}`,
+    namingStyle: fileNaming.dominant,
+    exportStyle: exportStyle.dominant || 'named',
+    testFile: _testFile(styledStem, conventions.testFramework, ext),
+    testFramework: conventions.testFramework || null,
+  };
+
+  return {
+    ...base,
+    ok: true,
+    refused: false,
+    forced,
+    warning: forced
+      ? `proposed below the ${(threshold * 100).toFixed(0)}% threshold (--force); conventions are only ${tier}`
+      : null,
+    reason: forced ? 'forced proposal above the hard floor' : `conventions are ${tier} — proposing`,
+    proposal,
+  };
+}
+
+module.exports = { proposeScaffold, DEFAULT_THRESHOLD, HARD_FLOOR };

--- a/test/integration/scaffold.test.js
+++ b/test/integration/scaffold.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap scaffold` (Layer 4 — confidence floor).
+ *   proposeScaffold: propose / refuse / hard-floor / force / pytest · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { proposeScaffold, HARD_FLOOR, DEFAULT_THRESHOLD } =
+  require(path.join(ROOT, 'src/scaffold/propose'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scaffold-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// Build a conventions result with a specific file-naming consistency.
+function conv(pct, { framework = 'jest' } = {}) {
+  const major = Math.round(pct * 10);
+  const minor = 10 - major;
+  return {
+    fileNaming: {
+      dominant: 'camelCase', dominantPct: pct, total: 10,
+      tier: pct >= 0.9 ? 'consistent' : pct >= 0.7 ? 'mostly' : 'inconsistent',
+      variants: [
+        { label: 'camelCase', count: major, pct, examples: ['fooBar.js'] },
+        { label: 'kebab-case', count: minor, pct: minor / 10, examples: ['user-service.js'] },
+      ],
+    },
+    exportStyle: { dominant: 'named', dominantPct: 1, total: 10,
+      variants: [{ label: 'named', count: 10, pct: 1, examples: ['fooBar.js'] }] },
+    testFramework: framework,
+  };
+}
+
+// ── proposeScaffold ─────────────────────────────────────────────────────────
+test('consistent → proposes convention-matched filename + export + test', () => {
+  const d = proposeScaffold('user profile loader', conv(0.95));
+  assert.strictEqual(d.ok, true);
+  assert.strictEqual(d.refused, false);
+  assert.strictEqual(d.proposal.filename, 'userProfileLoader.js');
+  assert.strictEqual(d.proposal.namingStyle, 'camelCase');
+  assert.strictEqual(d.proposal.exportStyle, 'named');
+  assert.strictEqual(d.proposal.testFile, 'userProfileLoader.test.js');
+});
+test('below threshold (0.6) without force → refuses + surfaces conflicts', () => {
+  const d = proposeScaffold('newWidget', conv(0.6));
+  assert.strictEqual(d.ok, false);
+  assert.strictEqual(d.refused, true);
+  assert.strictEqual(d.proposal, null);
+  assert.ok(/below the threshold/.test(d.reason));
+  assert.strictEqual(d.conflicts.hasConflicts, true);
+});
+test('hard floor is non-overridable — below 0.5 refuses even with force', () => {
+  const d = proposeScaffold('newWidget', conv(0.33), { force: true });
+  assert.strictEqual(d.ok, false);
+  assert.ok(/hard floor/.test(d.reason));
+  assert.strictEqual(d.proposal, null);
+});
+test('force allows a proposal between hard floor and threshold (with warning)', () => {
+  const d = proposeScaffold('newWidget', conv(0.6), { force: true });
+  assert.strictEqual(d.ok, true);
+  assert.strictEqual(d.forced, true);
+  assert.ok(d.warning && /force/.test(d.warning));
+  assert.strictEqual(d.proposal.filename, 'newWidget.js');
+});
+test('no file-naming convention → refuses', () => {
+  const d = proposeScaffold('x', { fileNaming: { dominant: null, dominantPct: 0, total: 0, variants: [] } });
+  assert.strictEqual(d.ok, false);
+  assert.ok(/no file-naming convention/.test(d.reason));
+});
+test('pytest framework → test_<snake>.py test file', () => {
+  const d = proposeScaffold('UserProfile', conv(0.95, { framework: 'pytest' }), { ext: 'py' });
+  assert.strictEqual(d.proposal.testFile, 'test_user_profile.py');
+});
+test('threshold is clamped to the hard floor', () => {
+  // asking for a 0.3 threshold cannot drop below the 0.5 hard floor
+  const d = proposeScaffold('w', conv(0.4), { threshold: 0.3 });
+  assert.strictEqual(d.threshold, HARD_FLOOR);
+  assert.strictEqual(d.ok, false); // 0.4 < 0.5 floor
+});
+test('custom ext is honored', () => {
+  const d = proposeScaffold('myThing', conv(0.95), { ext: 'ts' });
+  assert.strictEqual(d.proposal.filename, 'myThing.ts');
+  assert.strictEqual(d.proposal.testFile, 'myThing.test.ts');
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+function writeRepo(dir, files) {
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  for (const [f, c] of Object.entries(files)) fs.writeFileSync(path.join(dir, 'src', f), c);
+}
+
+test('CLI: scaffold proposes on a consistent repo (exit 0)', () => {
+  withRepo((dir) => {
+    // 9 camelCase + 1 kebab → 90% consistent
+    const files = {};
+    for (let i = 0; i < 9; i++) files[`fooBar${i}.js`] = 'export const a = 1;\n';
+    files['user-service.js'] = 'export const b = 2;\n';
+    writeRepo(dir, files);
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'new thing'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/newThing\.js/.test(res.stdout), 'proposes styled filename');
+  });
+});
+test('CLI: scaffold refuses on an inconsistent repo (exit 1 + conflict)', () => {
+  withRepo((dir) => {
+    writeRepo(dir, {
+      'fooBar.js': 'export const a=1;\n',
+      'user-service.js': 'export const b=2;\n',
+      'some_thing.js': 'export const c=3;\n',
+    });
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'new widget'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1, 'refusal exits 1');
+    assert.ok(/REFUSED/.test(res.stdout), 'prints REFUSED');
+  });
+});
+test('CLI: scaffold --json emits the decision', () => {
+  withRepo((dir) => {
+    const files = {};
+    for (let i = 0; i < 9; i++) files[`fooBar${i}.js`] = 'export const a = 1;\n';
+    files['user-service.js'] = 'export const b = 2;\n';
+    writeRepo(dir, files);
+    const res = spawnSync('node', [SCRIPT, 'scaffold', 'myThing', '--json'], { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(typeof data.ok, 'boolean');
+    assert.strictEqual(data.hardFloor, HARD_FLOOR);
+    assert.ok(data.proposal);
+  });
+});
+test('CLI: scaffold with no name exits 1 with usage', () => {
+  withRepo((dir) => {
+    writeRepo(dir, { 'a.js': 'export const a=1;\n' });
+    const res = spawnSync('node', [SCRIPT, 'scaffold'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    assert.ok(/usage/.test(res.stderr));
+  });
+});
+
+console.log(`\nscaffold: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 85,
+  "tests": 86,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.9.0",
+  "version": "7.10.0",
   "benchmark_date": "2026-06-14",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,


### PR DESCRIPTION
## Summary
- Ships **v7.10.0** to main: `sigmap scaffold` (convention-matched proposal gated by a confidence floor) + docs/benchmark refresh prepared by /update-docs. Closes the last open root cause (Cause 3).

## Changes
- `src/scaffold/propose.js` (proposeScaffold — soft threshold 0.70, non-overridable hard floor 0.50) + `scaffold <name>` CLI
- Version sync 7.9.0 → 7.10.0; CHANGELOG + CONTRIBUTORS; docs-vp (cli, roadmap, index); llms.txt regenerated
- Benchmarks confirmed stable: 75.6% hit@5 · 97.0% token reduction (no retrieval/token code changed)

## Test plan
- [x] `node test/integration/all.js` — 80 suites, 0 failures
- [x] bundle / version-meta / llms gates pass
- [x] supply-chain local audit PASS