### PR TITLE
feat: sigmap create — orchestrate the 4-stage grounded-creation pipeline (Gap 2)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -28,6 +28,96 @@ function __require(key) {
 // ── ./src/plan/verify-plan ──
 // ── ./src/cache/freshen ──
 // ── ./src/review/review-pr ──
+// ── ./src/create/orchestrate ──
+__factories["./src/create/orchestrate"] = function(module, exports) {
+  
+  /**
+   * create orchestrator (IMPL.md §6.2 — the capstone of the grounded-creation loop).
+   *
+   * Sequences the four guard stages — scaffold → verify-plan → verify-ai-output →
+   * review-pr — in one pass with `n/4` numbering and a single pass/fail summary.
+   * The agent does the LLM writing between stages; `create` runs the deterministic
+   * guards it owns. A stage runs only when its input is present (else it is
+   * skipped, which does not fail the run). Zero-dependency, bundle-safe; delegates
+   * to the real stage modules.
+   */
+
+  const { proposeScaffold } = __require('./src/scaffold/propose');
+  const { verifyPlan } = __require('./src/plan/verify-plan');
+  const { verify } = __require('./src/verify/hallucination-guard');
+  const { reviewPr } = __require('./src/review/review-pr');
+
+  const TOTAL = 4;
+
+  /**
+   * Run the create pipeline over whatever inputs are available.
+   * @param {object} ctx
+   * @param {string} [ctx.task] free-text task label (echoed back)
+   * @param {string} [ctx.name] module name → enables the scaffold stage
+   * @param {object} [ctx.conventions] an `extractConventions` result (for scaffold)
+   * @param {object} [ctx.scaffoldOpts] options forwarded to `proposeScaffold`
+   * @param {string} [ctx.plan] plan markdown → enables verify-plan
+   * @param {string} [ctx.answer] AI answer markdown → enables verify-ai-output
+   * @param {Array<{path:string,status:string}>} [ctx.changedFiles] → enables review-pr
+   * @param {string} cwd repo root
+   * @returns {{ task: string|null, steps: object[], summary: object }}
+   */
+  function orchestrate(ctx = {}, cwd) {
+    const steps = [];
+
+    // 1/4 — scaffold (needs a name + conventions)
+    if (ctx.name && ctx.conventions) {
+      const d = proposeScaffold(ctx.name, ctx.conventions, ctx.scaffoldOpts || {});
+      steps.push({ n: 1, total: TOTAL, name: 'scaffold', ran: true, ok: !!d.ok, skipped: false, detail: d });
+    } else {
+      steps.push({ n: 1, total: TOTAL, name: 'scaffold', ran: false, ok: null, skipped: true, reason: 'no --name' });
+    }
+
+    // 2/4 — verify-plan (needs a plan)
+    if (ctx.plan != null && String(ctx.plan).trim() !== '') {
+      const r = verifyPlan(ctx.plan, cwd);
+      steps.push({ n: 2, total: TOTAL, name: 'verify-plan', ran: true, ok: !!r.summary.ok, skipped: false, detail: r });
+    } else {
+      steps.push({ n: 2, total: TOTAL, name: 'verify-plan', ran: false, ok: null, skipped: true, reason: 'no --plan' });
+    }
+
+    // 3/4 — verify-ai-output (needs an answer)
+    if (ctx.answer != null && String(ctx.answer).trim() !== '') {
+      const r = verify(ctx.answer, cwd);
+      steps.push({ n: 3, total: TOTAL, name: 'verify-ai-output', ran: true, ok: r.summary.total === 0, skipped: false, detail: r });
+    } else {
+      steps.push({ n: 3, total: TOTAL, name: 'verify-ai-output', ran: false, ok: null, skipped: true, reason: 'no --answer' });
+    }
+
+    // 4/4 — review-pr (needs changed files)
+    if (Array.isArray(ctx.changedFiles) && ctx.changedFiles.length) {
+      const r = reviewPr(ctx.changedFiles, cwd);
+      steps.push({ n: 4, total: TOTAL, name: 'review-pr', ran: true, ok: !!r.summary.ok, skipped: false, detail: r });
+    } else {
+      steps.push({ n: 4, total: TOTAL, name: 'review-pr', ran: false, ok: null, skipped: true, reason: 'no changes' });
+    }
+
+    const ran = steps.filter((s) => s.ran);
+    const passed = ran.filter((s) => s.ok).length;
+    const failed = ran.length - passed;
+    return {
+      task: ctx.task || null,
+      steps,
+      summary: {
+        total: TOTAL,
+        ran: ran.length,
+        skipped: steps.length - ran.length,
+        passed,
+        failed,
+        ok: failed === 0,
+      },
+    };
+  }
+
+  module.exports = { orchestrate, TOTAL };
+  
+};
+
 __factories["./src/review/review-pr"] = function(module, exports) {
   
   /**
@@ -16551,6 +16641,71 @@ function main() {
     }
     console.log(`\n  ${s.findings} finding(s)`);
     process.exit(1);
+  }
+
+  // Gap 2 (capstone): `sigmap create "<task>"` — orchestrate the 4 guard stages
+  // (scaffold → verify-plan → verify-ai-output → review-pr) with n/4 numbering.
+  if (args[0] === 'create') {
+    const jsonOut = args.includes('--json');
+    const task = args[1] && !args[1].startsWith('--') ? args[1] : null;
+    const flagVal = (flag) => { const i = args.indexOf(flag); return i !== -1 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : null; };
+    const nameArg = flagVal('--name');
+    const planFile = flagVal('--plan');
+    const answerFile = flagVal('--answer');
+    const staged = args.includes('--staged');
+    const baseArg = flagVal('--base');
+
+    const ctx = { task };
+
+    if (nameArg) {
+      ctx.name = nameArg;
+      try {
+        const { extractConventions } = requireSourceOrBundled('./src/conventions/extract');
+        ctx.conventions = extractConventions(cwd, buildFileList(cwd, config));
+      } catch (_) {}
+    }
+    for (const [flag, file, key] of [['--plan', planFile, 'plan'], ['--answer', answerFile, 'answer']]) {
+      if (!file) continue;
+      try { ctx[key] = fs.readFileSync(path.resolve(cwd, file), 'utf8'); }
+      catch (e) { console.error(`[sigmap] cannot read ${flag} file: ${e.message}`); process.exit(1); }
+    }
+
+    // review-pr inputs: changed files from git (same collection as review-pr).
+    let nameStatus = '';
+    if (staged) {
+      nameStatus = __tryGit(['diff', '--cached', '--name-status'], { cwd });
+    } else {
+      let base = baseArg;
+      if (!base) {
+        for (const ref of ['main', 'develop']) {
+          if (__tryGit(['rev-parse', '--verify', '--quiet', ref], { cwd })) { base = ref; break; }
+        }
+      }
+      const mb = base ? (__tryGit(['merge-base', 'HEAD', base], { cwd }) || base) : 'HEAD~1';
+      nameStatus = __tryGit(['diff', '--name-status', `${mb}..HEAD`], { cwd });
+    }
+    ctx.changedFiles = nameStatus.split('\n').filter(Boolean).map((line) => {
+      const parts = line.split('\t');
+      return { path: parts[parts.length - 1], status: parts[0][0] };
+    });
+
+    const { orchestrate } = requireSourceOrBundled('./src/create/orchestrate');
+    const result = orchestrate(ctx, cwd);
+
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(result) + '\n');
+      process.exit(result.summary.ok ? 0 : 1);
+    }
+
+    console.log(`[sigmap] create${result.task ? ` "${result.task}"` : ''} — grounded-creation pipeline`);
+    for (const st of result.steps) {
+      const mark = st.skipped ? '–' : (st.ok ? '✓' : '✗');
+      const status = st.skipped ? `skipped (${st.reason})` : (st.ok ? 'ok' : 'FAILED');
+      console.log(`  ${st.n}/${st.total} ${mark} ${st.name.padEnd(16)} ${status}`);
+    }
+    const su = result.summary;
+    console.log(`\n  ${su.ran}/${su.total} ran · ${su.passed} passed · ${su.failed} failed · ${su.skipped} skipped`);
+    process.exit(su.ok ? 0 : 1);
   }
 
   // Feature 1: `sigmap explain <file>` — why a file is included or excluded

--- a/src/create/orchestrate.js
+++ b/src/create/orchestrate.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * create orchestrator (IMPL.md §6.2 — the capstone of the grounded-creation loop).
+ *
+ * Sequences the four guard stages — scaffold → verify-plan → verify-ai-output →
+ * review-pr — in one pass with `n/4` numbering and a single pass/fail summary.
+ * The agent does the LLM writing between stages; `create` runs the deterministic
+ * guards it owns. A stage runs only when its input is present (else it is
+ * skipped, which does not fail the run). Zero-dependency, bundle-safe; delegates
+ * to the real stage modules.
+ */
+
+const { proposeScaffold } = require('../scaffold/propose');
+const { verifyPlan } = require('../plan/verify-plan');
+const { verify } = require('../verify/hallucination-guard');
+const { reviewPr } = require('../review/review-pr');
+
+const TOTAL = 4;
+
+/**
+ * Run the create pipeline over whatever inputs are available.
+ * @param {object} ctx
+ * @param {string} [ctx.task] free-text task label (echoed back)
+ * @param {string} [ctx.name] module name → enables the scaffold stage
+ * @param {object} [ctx.conventions] an `extractConventions` result (for scaffold)
+ * @param {object} [ctx.scaffoldOpts] options forwarded to `proposeScaffold`
+ * @param {string} [ctx.plan] plan markdown → enables verify-plan
+ * @param {string} [ctx.answer] AI answer markdown → enables verify-ai-output
+ * @param {Array<{path:string,status:string}>} [ctx.changedFiles] → enables review-pr
+ * @param {string} cwd repo root
+ * @returns {{ task: string|null, steps: object[], summary: object }}
+ */
+function orchestrate(ctx = {}, cwd) {
+  const steps = [];
+
+  // 1/4 — scaffold (needs a name + conventions)
+  if (ctx.name && ctx.conventions) {
+    const d = proposeScaffold(ctx.name, ctx.conventions, ctx.scaffoldOpts || {});
+    steps.push({ n: 1, total: TOTAL, name: 'scaffold', ran: true, ok: !!d.ok, skipped: false, detail: d });
+  } else {
+    steps.push({ n: 1, total: TOTAL, name: 'scaffold', ran: false, ok: null, skipped: true, reason: 'no --name' });
+  }
+
+  // 2/4 — verify-plan (needs a plan)
+  if (ctx.plan != null && String(ctx.plan).trim() !== '') {
+    const r = verifyPlan(ctx.plan, cwd);
+    steps.push({ n: 2, total: TOTAL, name: 'verify-plan', ran: true, ok: !!r.summary.ok, skipped: false, detail: r });
+  } else {
+    steps.push({ n: 2, total: TOTAL, name: 'verify-plan', ran: false, ok: null, skipped: true, reason: 'no --plan' });
+  }
+
+  // 3/4 — verify-ai-output (needs an answer)
+  if (ctx.answer != null && String(ctx.answer).trim() !== '') {
+    const r = verify(ctx.answer, cwd);
+    steps.push({ n: 3, total: TOTAL, name: 'verify-ai-output', ran: true, ok: r.summary.total === 0, skipped: false, detail: r });
+  } else {
+    steps.push({ n: 3, total: TOTAL, name: 'verify-ai-output', ran: false, ok: null, skipped: true, reason: 'no --answer' });
+  }
+
+  // 4/4 — review-pr (needs changed files)
+  if (Array.isArray(ctx.changedFiles) && ctx.changedFiles.length) {
+    const r = reviewPr(ctx.changedFiles, cwd);
+    steps.push({ n: 4, total: TOTAL, name: 'review-pr', ran: true, ok: !!r.summary.ok, skipped: false, detail: r });
+  } else {
+    steps.push({ n: 4, total: TOTAL, name: 'review-pr', ran: false, ok: null, skipped: true, reason: 'no changes' });
+  }
+
+  const ran = steps.filter((s) => s.ran);
+  const passed = ran.filter((s) => s.ok).length;
+  const failed = ran.length - passed;
+  return {
+    task: ctx.task || null,
+    steps,
+    summary: {
+      total: TOTAL,
+      ran: ran.length,
+      skipped: steps.length - ran.length,
+      passed,
+      failed,
+      ok: failed === 0,
+    },
+  };
+}
+
+module.exports = { orchestrate, TOTAL };

--- a/test/integration/create.test.js
+++ b/test/integration/create.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap create` (Gap 2 capstone — the orchestrator).
+ *   orchestrate: ordering / numbering / skip / pass-fail aggregation · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync, execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { orchestrate, TOTAL } = require(path.join(ROOT, 'src/create/orchestrate'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+// A consistent conventions result so the scaffold stage can propose.
+const consistentConventions = {
+  fileNaming: { dominant: 'camelCase', dominantPct: 0.95, total: 10, tier: 'consistent',
+    variants: [{ label: 'camelCase', count: 10, pct: 1, examples: ['fooBar.js'] }] },
+  exportStyle: { dominant: 'named', dominantPct: 1, total: 10,
+    variants: [{ label: 'named', count: 10, pct: 1, examples: ['fooBar.js'] }] },
+  testFramework: 'jest',
+};
+
+// ── orchestrate (pure) ──────────────────────────────────────────────────────
+test('all stages skipped with empty ctx → 4 skipped, ok', () => {
+  const r = orchestrate({}, ROOT);
+  assert.strictEqual(r.steps.length, 4);
+  assert.strictEqual(r.summary.ran, 0);
+  assert.strictEqual(r.summary.skipped, 4);
+  assert.strictEqual(r.summary.ok, true); // nothing ran → nothing failed
+});
+test('steps are numbered 1/4..4/4 in pipeline order', () => {
+  const r = orchestrate({}, ROOT);
+  assert.deepStrictEqual(r.steps.map((s) => s.n), [1, 2, 3, 4]);
+  assert.deepStrictEqual(r.steps.map((s) => s.name),
+    ['scaffold', 'verify-plan', 'verify-ai-output', 'review-pr']);
+  assert.ok(r.steps.every((s) => s.total === TOTAL));
+});
+test('scaffold runs when name + conventions present', () => {
+  const r = orchestrate({ name: 'user widget', conventions: consistentConventions }, ROOT);
+  const sc = r.steps[0];
+  assert.strictEqual(sc.ran, true);
+  assert.strictEqual(sc.ok, true);
+  assert.strictEqual(sc.detail.proposal.filename, 'userWidget.js');
+});
+test('verify-plan failure makes summary not ok', () => {
+  const r = orchestrate({ plan: 'Edit `src/does-not-exist.js`.' }, ROOT);
+  const vp = r.steps[1];
+  assert.strictEqual(vp.ran, true);
+  assert.strictEqual(vp.ok, false);
+  assert.strictEqual(r.summary.ok, false);
+  assert.strictEqual(r.summary.failed, 1);
+});
+test('review-pr runs from changedFiles', () => {
+  const r = orchestrate({ changedFiles: [{ path: '.env', status: 'M' }] }, ROOT);
+  const rp = r.steps[3];
+  assert.strictEqual(rp.ran, true);
+  assert.strictEqual(rp.ok, false); // .env is a security finding
+});
+test('skipped stages never fail the run', () => {
+  // scaffold ok, others skipped → ok true
+  const r = orchestrate({ name: 'thing', conventions: consistentConventions }, ROOT);
+  assert.strictEqual(r.summary.ran, 1);
+  assert.strictEqual(r.summary.skipped, 3);
+  assert.strictEqual(r.summary.ok, true);
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+function withGitRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-'));
+  const g = (a) => execFileSync('git', a, { cwd: dir, stdio: 'ignore' });
+  try {
+    g(['init', '-q']); g(['config', 'user.email', 't@t.t']); g(['config', 'user.name', 'T']);
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    execFileSync(process.execPath, [SCRIPT], { cwd: dir, stdio: 'ignore' });
+    g(['add', '-A']); g(['commit', '-q', '-m', 'base']);
+    fn(dir, g);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('CLI: create with --name + --plan runs 2 stages (exit 0)', () => {
+  withGitRepo((dir) => {
+    fs.writeFileSync(path.join(dir, 'plan.md'), 'Reference `src/fooBar.js`.');
+    const res = spawnSync('node', [SCRIPT, 'create', 'demo', '--name', 'new thing', '--plan', 'plan.md'],
+      { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stdout + res.stderr);
+    assert.ok(/1\/4 . scaffold/.test(res.stdout), res.stdout);
+    assert.ok(/2\/4 . verify-plan/.test(res.stdout));
+  });
+});
+test('CLI: create --json emits the pipeline result', () => {
+  withGitRepo((dir) => {
+    const res = spawnSync('node', [SCRIPT, 'create', 'demo', '--name', 'thing', '--json'],
+      { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(data.summary.total, 4);
+    assert.strictEqual(data.steps.length, 4);
+  });
+});
+test('CLI: create exits 1 when a ran stage fails', () => {
+  withGitRepo((dir) => {
+    fs.writeFileSync(path.join(dir, 'plan.md'), 'Call `totallyFakeSymbol(...)` in `src/ghost.js`.');
+    const res = spawnSync('node', [SCRIPT, 'create', 'demo', '--plan', 'plan.md'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1, res.stdout);
+    assert.ok(/FAILED/.test(res.stdout));
+  });
+});
+
+console.log(`\ncreate: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 88,
+  "tests": 89,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- The **capstone** of IMPL.md Gap 2 (§6.2): `sigmap create "<task>"` sequences the four guard stages — scaffold → verify-plan → verify-ai-output → review-pr — in one command with `1/4`…`4/4` numbering and a single pass/fail summary. Completes the grounded-creation loop end-to-end. Closes #316.

## Changes
- `src/create/orchestrate.js` (new, zero-dep, bundle-safe): `orchestrate(ctx, cwd)` → `{ task, steps, summary }`. Each stage runs only when its input is present (else `skipped` — which never fails the run); `summary.ok` is false iff a *ran* stage failed. Delegates to the real stage modules (`proposeScaffold`, `verifyPlan`, `verify`, `reviewPr`) — no logic duplication.
- `gen-context.js`: `create "<task>" [--name <n>] [--plan <plan.md>] [--answer <answer.md>] [--staged|--base <ref>] [--json]` — gathers inputs (name→scaffold, plan→verify-plan, answer→verify-ai-output, git diff→review-pr), prints the numbered pipeline + summary, exits 1 when a ran stage fails. Factory added (clean insert).
- `version.json`: derived `tests` 88 → 89.

Example:
```
[sigmap] create "add a thing" — grounded-creation pipeline
  1/4 ✓ scaffold         ok
  2/4 ✓ verify-plan      ok
  3/4 – verify-ai-output skipped (no --answer)
  4/4 – review-pr        skipped (no changes)
  2/4 ran · 2 passed · 0 failed · 2 skipped
```

## Test plan
- [x] `node test/integration/create.test.js` — 9 passed (ordering / numbering / skip / aggregation / CLI)
- [x] `node test/integration/all.js` — 83 suites, 0 failures (incl. standalone-bundle smoke test)
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)