### PR TITLE
feat: sigmap conventions --report — consistency audit + trend vs last run

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -29,6 +29,85 @@ function __require(key) {
 // ── ./src/cache/freshen ──
 // ── ./src/review/review-pr ──
 // ── ./src/create/orchestrate ──
+// ── ./src/conventions/report ──
+__factories["./src/conventions/report"] = function(module, exports) {
+  
+  /**
+   * Convention audit + trend (IMPL.md §4 — `conventions --report`).
+   *
+   * Turns an `extractConventions` result into an audit: a consistency score per
+   * convention plus a single file-count-weighted overall score, each with a delta
+   * vs the previous run (the trend). Pure, zero-dependency, bundle-safe.
+   */
+
+  const NAMES = { fileNaming: 'file naming', exportStyle: 'export style' };
+
+  /** File-count-weighted mean of the scored conventions' dominant shares (0–1). */
+  function overallScore(result) {
+    let num = 0;
+    let den = 0;
+    for (const key of ['fileNaming', 'exportStyle']) {
+      const c = result && result[key];
+      if (c && c.total > 0) { num += c.dominantPct * c.total; den += c.total; }
+    }
+    return den > 0 ? num / den : 0;
+  }
+
+  /**
+   * Build a consistency report with trend vs a prior snapshot.
+   * @param {object} result an `extractConventions` result
+   * @param {object|null} [prior] a previous snapshot (this module's `snapshot` shape)
+   * @returns {{ conventions: object[], testFramework: string|null,
+   *   score: number, prevScore: number|null, scoreDelta: number|null }}
+   */
+  function scoreReport(result, prior) {
+    const conventions = [];
+    for (const key of ['fileNaming', 'exportStyle']) {
+      const c = (result && result[key]) || { dominant: null, dominantPct: 0, total: 0, tier: 'unknown' };
+      const priorPct = prior && prior[key] && typeof prior[key].dominantPct === 'number' ? prior[key].dominantPct : null;
+      conventions.push({
+        key,
+        name: NAMES[key] || key,
+        dominant: c.dominant,
+        dominantPct: c.dominantPct,
+        tier: c.tier,
+        total: c.total,
+        delta: priorPct == null ? null : c.dominantPct - priorPct,
+      });
+    }
+    const score = overallScore(result);
+    const prevScore = prior && typeof prior.score === 'number' ? prior.score : null;
+    return {
+      conventions,
+      testFramework: (result && result.testFramework) || null,
+      score,
+      prevScore,
+      scoreDelta: prevScore == null ? null : score - prevScore,
+    };
+  }
+
+  /**
+   * A compact, persistable snapshot of a run (one line in the history log).
+   * @param {object} result an `extractConventions` result
+   * @param {string} [ts] ISO timestamp (caller supplies — keeps this pure)
+   */
+  function snapshot(result, ts) {
+    const pick = (c) => (c && c.total > 0
+      ? { dominant: c.dominant, dominantPct: c.dominantPct, tier: c.tier, total: c.total }
+      : { dominant: null, dominantPct: 0, tier: 'unknown', total: 0 });
+    return {
+      ts: ts || null,
+      fileNaming: pick(result && result.fileNaming),
+      exportStyle: pick(result && result.exportStyle),
+      testFramework: (result && result.testFramework) || null,
+      score: overallScore(result),
+    };
+  }
+
+  module.exports = { scoreReport, snapshot, overallScore };
+  
+};
+
 __factories["./src/create/orchestrate"] = function(module, exports) {
   
   /**
@@ -16329,6 +16408,38 @@ function main() {
         process.exit(1);
       }
       console.log(`[sigmap] conventions → injected block into ${path.relative(cwd, claudePath) || 'CLAUDE.md'}`);
+      process.exit(0);
+    }
+
+    // `--report`: consistency audit + score + trend vs the last run.
+    if (args.includes('--report')) {
+      const { scoreReport, snapshot } = requireSourceOrBundled('./src/conventions/report');
+      const histPath = path.join(cwd, '.context', 'conventions-history.ndjson');
+      let prior = null;
+      try {
+        const lines = fs.readFileSync(histPath, 'utf8').split('\n').filter(Boolean);
+        if (lines.length) prior = JSON.parse(lines[lines.length - 1]);
+      } catch (_) {}
+      const report = scoreReport(result, prior);
+      // Append the new snapshot to the history log.
+      try {
+        fs.mkdirSync(path.join(cwd, '.context'), { recursive: true });
+        fs.appendFileSync(histPath, JSON.stringify(snapshot(result, new Date().toISOString())) + '\n');
+      } catch (_) {}
+
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify(report) + '\n');
+        process.exit(0);
+      }
+      const pctR = (n) => `${(n * 100).toFixed(0)}%`;
+      const arrow = (d) => (d == null ? '' : d > 0.0005 ? ` ▲${(d * 100).toFixed(0)}pp` : d < -0.0005 ? ` ▼${(Math.abs(d) * 100).toFixed(0)}pp` : ' =');
+      console.log('[sigmap] conventions --report  (TS/JS/Python)');
+      console.log(`  overall consistency: ${pctR(report.score)}${arrow(report.scoreDelta)}${report.prevScore == null ? '  (first run)' : ''}`);
+      for (const c of report.conventions) {
+        if (c.total === 0) { console.log(`  ${c.name.padEnd(14)} n/a (no samples)`); continue; }
+        console.log(`  ${c.name.padEnd(14)} ${c.dominant} ${pctR(c.dominantPct)} [${c.tier}]${arrow(c.delta)}`);
+      }
+      console.log(`  ${'test framework'.padEnd(14)} ${report.testFramework || 'none detected'}`);
       process.exit(0);
     }
 

--- a/src/conventions/report.js
+++ b/src/conventions/report.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Convention audit + trend (IMPL.md §4 — `conventions --report`).
+ *
+ * Turns an `extractConventions` result into an audit: a consistency score per
+ * convention plus a single file-count-weighted overall score, each with a delta
+ * vs the previous run (the trend). Pure, zero-dependency, bundle-safe.
+ */
+
+const NAMES = { fileNaming: 'file naming', exportStyle: 'export style' };
+
+/** File-count-weighted mean of the scored conventions' dominant shares (0–1). */
+function overallScore(result) {
+  let num = 0;
+  let den = 0;
+  for (const key of ['fileNaming', 'exportStyle']) {
+    const c = result && result[key];
+    if (c && c.total > 0) { num += c.dominantPct * c.total; den += c.total; }
+  }
+  return den > 0 ? num / den : 0;
+}
+
+/**
+ * Build a consistency report with trend vs a prior snapshot.
+ * @param {object} result an `extractConventions` result
+ * @param {object|null} [prior] a previous snapshot (this module's `snapshot` shape)
+ * @returns {{ conventions: object[], testFramework: string|null,
+ *   score: number, prevScore: number|null, scoreDelta: number|null }}
+ */
+function scoreReport(result, prior) {
+  const conventions = [];
+  for (const key of ['fileNaming', 'exportStyle']) {
+    const c = (result && result[key]) || { dominant: null, dominantPct: 0, total: 0, tier: 'unknown' };
+    const priorPct = prior && prior[key] && typeof prior[key].dominantPct === 'number' ? prior[key].dominantPct : null;
+    conventions.push({
+      key,
+      name: NAMES[key] || key,
+      dominant: c.dominant,
+      dominantPct: c.dominantPct,
+      tier: c.tier,
+      total: c.total,
+      delta: priorPct == null ? null : c.dominantPct - priorPct,
+    });
+  }
+  const score = overallScore(result);
+  const prevScore = prior && typeof prior.score === 'number' ? prior.score : null;
+  return {
+    conventions,
+    testFramework: (result && result.testFramework) || null,
+    score,
+    prevScore,
+    scoreDelta: prevScore == null ? null : score - prevScore,
+  };
+}
+
+/**
+ * A compact, persistable snapshot of a run (one line in the history log).
+ * @param {object} result an `extractConventions` result
+ * @param {string} [ts] ISO timestamp (caller supplies — keeps this pure)
+ */
+function snapshot(result, ts) {
+  const pick = (c) => (c && c.total > 0
+    ? { dominant: c.dominant, dominantPct: c.dominantPct, tier: c.tier, total: c.total }
+    : { dominant: null, dominantPct: 0, tier: 'unknown', total: 0 });
+  return {
+    ts: ts || null,
+    fileNaming: pick(result && result.fileNaming),
+    exportStyle: pick(result && result.exportStyle),
+    testFramework: (result && result.testFramework) || null,
+    score: overallScore(result),
+  };
+}
+
+module.exports = { scoreReport, snapshot, overallScore };

--- a/test/integration/conventions-report.test.js
+++ b/test/integration/conventions-report.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions --report` (Layer 3 — audit + trend).
+ *   overallScore · scoreReport (delta vs prior) · snapshot · CLI (trend + history)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { scoreReport, snapshot, overallScore } = require(path.join(ROOT, 'src/conventions/report'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-rep-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+const result = (fnPct, fnTotal) => ({
+  fileNaming: { dominant: 'camelCase', dominantPct: fnPct, total: fnTotal, tier: fnPct >= 0.9 ? 'consistent' : fnPct >= 0.7 ? 'mostly' : 'inconsistent', variants: [] },
+  exportStyle: { dominant: 'named', dominantPct: 1, total: 10, tier: 'consistent', variants: [] },
+  testFramework: 'jest',
+});
+
+// ── overallScore ────────────────────────────────────────────────────────────
+test('overallScore: file-count-weighted mean', () => {
+  // fileNaming 0.8 over 10, exportStyle 1.0 over 10 → (8 + 10)/20 = 0.9
+  const s = overallScore(result(0.8, 10));
+  assert.ok(Math.abs(s - 0.9) < 1e-9, `got ${s}`);
+});
+test('overallScore: 0 when no samples', () => {
+  assert.strictEqual(overallScore({ fileNaming: { total: 0 }, exportStyle: { total: 0 } }), 0);
+});
+
+// ── scoreReport ─────────────────────────────────────────────────────────────
+test('scoreReport: no prior → deltas null', () => {
+  const r = scoreReport(result(0.8, 10), null);
+  assert.strictEqual(r.scoreDelta, null);
+  assert.strictEqual(r.prevScore, null);
+  assert.ok(r.conventions.every((c) => c.delta === null));
+});
+test('scoreReport: delta vs prior snapshot', () => {
+  const prior = snapshot(result(0.6, 10), '2026-01-01T00:00:00Z'); // score 0.8
+  const r = scoreReport(result(0.8, 10), prior); // score 0.9
+  assert.ok(Math.abs(r.scoreDelta - 0.1) < 1e-9, `scoreDelta ${r.scoreDelta}`);
+  const fn = r.conventions.find((c) => c.key === 'fileNaming');
+  assert.ok(Math.abs(fn.delta - 0.2) < 1e-9, `fileNaming delta ${fn.delta}`);
+});
+test('scoreReport: per-convention audit shape', () => {
+  const r = scoreReport(result(0.95, 10), null);
+  const fn = r.conventions.find((c) => c.key === 'fileNaming');
+  assert.strictEqual(fn.dominant, 'camelCase');
+  assert.strictEqual(fn.tier, 'consistent');
+  assert.strictEqual(r.testFramework, 'jest');
+});
+
+// ── snapshot ────────────────────────────────────────────────────────────────
+test('snapshot: compact persistable shape with score + ts', () => {
+  const s = snapshot(result(0.8, 10), '2026-06-17T00:00:00Z');
+  assert.strictEqual(s.ts, '2026-06-17T00:00:00Z');
+  assert.strictEqual(s.fileNaming.dominant, 'camelCase');
+  assert.ok(typeof s.score === 'number');
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: --report prints score + audit on first run', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--report'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/overall consistency/.test(res.stdout));
+    assert.ok(/first run/.test(res.stdout));
+    assert.ok(fs.existsSync(path.join(dir, '.context', 'conventions-history.ndjson')), 'writes history');
+  });
+});
+test('CLI: --report shows a trend on the second run', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'fooBar.js'), 'export const a = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src', 'bazQux.js'), 'export const b = 2;\n');
+    const run = () => spawnSync('node', [SCRIPT, 'conventions', '--report'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(run().status, 0);
+    // introduce drift
+    fs.writeFileSync(path.join(dir, 'src', 'new-thing.js'), 'export const c = 3;\n');
+    const res = run();
+    assert.strictEqual(res.status, 0);
+    assert.ok(/▼/.test(res.stdout), `expected a downward trend arrow:\n${res.stdout}`);
+    const hist = fs.readFileSync(path.join(dir, '.context', 'conventions-history.ndjson'), 'utf8').split('\n').filter(Boolean);
+    assert.strictEqual(hist.length, 2, 'two history entries');
+  });
+});
+test('CLI: --report --json emits the structured report', () => {
+  withRepo((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'aaa.js'), 'export const a = 1;\n');
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--report', '--json'], { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.ok(typeof data.score === 'number');
+    assert.ok(Array.isArray(data.conventions));
+  });
+});
+
+console.log(`\nconventions-report: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 89,
+  "tests": 90,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Adds `sigmap conventions --report` — the next listed `conventions` flag (IMPL.md §4): a consistency audit with a per-convention score and an overall file-count-weighted score, plus a **trend vs the last run**. Gives teams one trackable "how consistent is our style, and is it improving?" number. Closes #319.

## Changes
- `src/conventions/report.js` (new, zero-dep, bundle-safe): `scoreReport(result, prior)` → per-convention audit `{ dominant, dominantPct, tier, delta }` + overall weighted `score` (+ `scoreDelta` vs prior); `snapshot()` for the persistable history shape; `overallScore()`.
- `gen-context.js`: `conventions --report` reads the last snapshot from `.context/conventions-history.ndjson`, prints the audit + score + trend arrows (▲/▼ pp), appends a new snapshot; `--json`. Factory added.
- `version.json`: derived `tests` 89 → 90.

Example (second run, after drift):
```
[sigmap] conventions --report  (TS/JS/Python)
  overall consistency: 83% ▼17pp
  file naming    camelCase 67% [inconsistent] ▼33pp
  export style   named 100% [consistent] =
```

Remaining `conventions` flags (`--fix`, `--update`, `--ci`) and the §9 LLM A/B benchmark are follow-ups.

## Test plan
- [x] `node test/integration/conventions-report.test.js` — 9 passed (score / delta / snapshot / CLI trend + history)
- [x] `node test/integration/all.js` — 84 suites, 0 failures (incl. standalone-bundle smoke test)
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)