### PR TITLE
feat: sigmap conventions --ci — gate CI on convention consistency

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -30,6 +30,58 @@ function __require(key) {
 // ── ./src/review/review-pr ──
 // ── ./src/create/orchestrate ──
 // ── ./src/conventions/report ──
+// ── ./src/conventions/ci ──
+__factories["./src/conventions/ci"] = function(module, exports) {
+  
+  /**
+   * Convention CI gate (IMPL.md §4 — `conventions --ci`).
+   *
+   * Fails CI when a repo's overall convention consistency is below a threshold,
+   * and optionally when it regresses vs the last recorded run. Builds on the
+   * `--report` score. Pure, zero-dependency, bundle-safe.
+   */
+
+  const { overallScore } = __require('./src/conventions/report');
+
+  const DEFAULT_MIN = 0.7;
+  const EPS = 1e-9;
+
+  /**
+   * Evaluate the consistency gate.
+   * @param {object} result an `extractConventions` result
+   * @param {object} [opts]
+   * @param {number} [opts.min=0.7] minimum overall consistency (0–1)
+   * @param {boolean} [opts.noRegress=false] also fail if the score dropped vs prior
+   * @param {object|null} [prior] the previous snapshot (from `report.snapshot`)
+   * @returns {{ score:number, min:number, ok:boolean, regressed:boolean, reasons:string[] }}
+   */
+  function ciGate(result, opts = {}, prior = null) {
+    const min = opts.min != null ? opts.min : DEFAULT_MIN;
+    const score = overallScore(result);
+    const reasons = [];
+    let ok = true;
+
+    if (score < min) {
+      ok = false;
+      reasons.push(`consistency ${(score * 100).toFixed(0)}% below min ${(min * 100).toFixed(0)}%`);
+    }
+
+    let regressed = false;
+    if (opts.noRegress && prior && typeof prior.score === 'number') {
+      if (score < prior.score - EPS) {
+        regressed = true;
+        ok = false;
+        reasons.push(`consistency dropped ${(prior.score * 100).toFixed(0)}% → ${(score * 100).toFixed(0)}%`);
+      }
+    }
+
+    return { score, min, ok, regressed, reasons };
+  }
+
+  module.exports = { ciGate, DEFAULT_MIN };
+  
+};
+
 __factories["./src/conventions/report"] = function(module, exports) {
   
   /**
@@ -16409,6 +16461,34 @@ function main() {
       }
       console.log(`[sigmap] conventions → injected block into ${path.relative(cwd, claudePath) || 'CLAUDE.md'}`);
       process.exit(0);
+    }
+
+    // `--ci`: gate — fail when overall consistency is below a threshold (or regresses).
+    if (args.includes('--ci')) {
+      const { ciGate } = requireSourceOrBundled('./src/conventions/ci');
+      const minIdx = args.indexOf('--min');
+      const min = minIdx !== -1 && args[minIdx + 1] ? parseFloat(args[minIdx + 1]) : undefined;
+      const noRegress = args.includes('--no-regress');
+      let prior = null;
+      if (noRegress) {
+        try {
+          const lines = fs.readFileSync(path.join(cwd, '.context', 'conventions-history.ndjson'), 'utf8').split('\n').filter(Boolean);
+          if (lines.length) prior = JSON.parse(lines[lines.length - 1]);
+        } catch (_) {}
+      }
+      const gate = ciGate(result, { min, noRegress }, prior);
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify(gate) + '\n');
+        process.exit(gate.ok ? 0 : 1);
+      }
+      const pctC = (n) => `${(n * 100).toFixed(0)}%`;
+      if (gate.ok) {
+        console.log(`[sigmap] conventions --ci  ✓ PASS — consistency ${pctC(gate.score)} (min ${pctC(gate.min)})`);
+        process.exit(0);
+      }
+      console.log(`[sigmap] conventions --ci  ✗ FAIL — consistency ${pctC(gate.score)} (min ${pctC(gate.min)})`);
+      for (const r of gate.reasons) console.log(`  • ${r}`);
+      process.exit(1);
     }
 
     // `--report`: consistency audit + score + trend vs the last run.

--- a/src/conventions/ci.js
+++ b/src/conventions/ci.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Convention CI gate (IMPL.md §4 — `conventions --ci`).
+ *
+ * Fails CI when a repo's overall convention consistency is below a threshold,
+ * and optionally when it regresses vs the last recorded run. Builds on the
+ * `--report` score. Pure, zero-dependency, bundle-safe.
+ */
+
+const { overallScore } = require('./report');
+
+const DEFAULT_MIN = 0.7;
+const EPS = 1e-9;
+
+/**
+ * Evaluate the consistency gate.
+ * @param {object} result an `extractConventions` result
+ * @param {object} [opts]
+ * @param {number} [opts.min=0.7] minimum overall consistency (0–1)
+ * @param {boolean} [opts.noRegress=false] also fail if the score dropped vs prior
+ * @param {object|null} [prior] the previous snapshot (from `report.snapshot`)
+ * @returns {{ score:number, min:number, ok:boolean, regressed:boolean, reasons:string[] }}
+ */
+function ciGate(result, opts = {}, prior = null) {
+  const min = opts.min != null ? opts.min : DEFAULT_MIN;
+  const score = overallScore(result);
+  const reasons = [];
+  let ok = true;
+
+  if (score < min) {
+    ok = false;
+    reasons.push(`consistency ${(score * 100).toFixed(0)}% below min ${(min * 100).toFixed(0)}%`);
+  }
+
+  let regressed = false;
+  if (opts.noRegress && prior && typeof prior.score === 'number') {
+    if (score < prior.score - EPS) {
+      regressed = true;
+      ok = false;
+      reasons.push(`consistency dropped ${(prior.score * 100).toFixed(0)}% → ${(score * 100).toFixed(0)}%`);
+    }
+  }
+
+  return { score, min, ok, regressed, reasons };
+}
+
+module.exports = { ciGate, DEFAULT_MIN };

--- a/test/integration/conventions-ci.test.js
+++ b/test/integration/conventions-ci.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions --ci` (Layer 3 — CI gate).
+ *   ciGate: min threshold / regression / reasons · CLI exit codes
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { ciGate, DEFAULT_MIN } = require(path.join(ROOT, 'src/conventions/ci'));
+const { snapshot } = require(path.join(ROOT, 'src/conventions/report'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+// conventions result with a given file-naming consistency (export style fixed at 100%).
+const result = (fnPct) => ({
+  fileNaming: { dominant: 'camelCase', dominantPct: fnPct, total: 10, tier: 'x', variants: [] },
+  exportStyle: { dominant: 'named', dominantPct: 1, total: 10, tier: 'consistent', variants: [] },
+  testFramework: 'jest',
+});
+
+// ── ciGate ──────────────────────────────────────────────────────────────────
+test('passes when score >= default min', () => {
+  // fileNaming 0.8 + export 1.0 weighted → 0.9 ≥ 0.70
+  const g = ciGate(result(0.8));
+  assert.strictEqual(g.ok, true);
+  assert.strictEqual(g.min, DEFAULT_MIN);
+  assert.strictEqual(g.reasons.length, 0);
+});
+test('fails when score < min, with a reason', () => {
+  const g = ciGate(result(0.8), { min: 0.95 }); // 0.9 < 0.95
+  assert.strictEqual(g.ok, false);
+  assert.ok(g.reasons.some((r) => /below min/.test(r)));
+});
+test('--min override is honored', () => {
+  const g = ciGate(result(0.2), { min: 0.5 }); // weighted (0.2*10+1*10)/20 = 0.6 ≥ 0.5
+  assert.strictEqual(g.ok, true);
+});
+test('no-regress: fails when score dropped vs prior', () => {
+  const prior = snapshot(result(0.9), '2026-01-01T00:00:00Z'); // score 0.95
+  const g = ciGate(result(0.7), { min: 0.5, noRegress: true }, prior); // score 0.85 < 0.95
+  assert.strictEqual(g.regressed, true);
+  assert.strictEqual(g.ok, false);
+  assert.ok(g.reasons.some((r) => /dropped/.test(r)));
+});
+test('no-regress: passes when no prior (best-effort)', () => {
+  const g = ciGate(result(0.8), { min: 0.5, noRegress: true }, null);
+  assert.strictEqual(g.ok, true);
+  assert.strictEqual(g.regressed, false);
+});
+test('no-regress: passes when score improved', () => {
+  const prior = snapshot(result(0.6), '2026-01-01T00:00:00Z'); // score 0.8
+  const g = ciGate(result(0.9), { min: 0.5, noRegress: true }, prior); // score 0.95 > 0.8
+  assert.strictEqual(g.regressed, false);
+  assert.strictEqual(g.ok, true);
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+function withRepo(files, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-ci-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    for (const [f, c] of Object.entries(files)) fs.writeFileSync(path.join(dir, 'src', f), c);
+    fn(dir);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+test('CLI: consistent repo passes (exit 0)', () => {
+  withRepo({ 'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n' }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--ci'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stdout + res.stderr);
+    assert.ok(/PASS/.test(res.stdout));
+  });
+});
+test('CLI: --min 0.99 fails a mixed repo (exit 1)', () => {
+  withRepo({ 'fooBar.js': 'export const a=1;\n', 'new-thing.js': 'export const b=2;\n' }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--ci', '--min', '0.99'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    assert.ok(/FAIL/.test(res.stdout));
+  });
+});
+test('CLI: --ci --json emits the gate result', () => {
+  withRepo({ 'aaa.js': 'export const a=1;\n' }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--ci', '--json'], { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.strictEqual(typeof data.ok, 'boolean');
+    assert.strictEqual(typeof data.score, 'number');
+  });
+});
+test('CLI: --ci does not write a history snapshot (read-only)', () => {
+  withRepo({ 'aaa.js': 'export const a=1;\n' }, (dir) => {
+    spawnSync('node', [SCRIPT, 'conventions', '--ci'], { cwd: dir, encoding: 'utf8' });
+    assert.ok(!fs.existsSync(path.join(dir, '.context', 'conventions-history.ndjson')), 'ci is read-only');
+  });
+});
+
+console.log(`\nconventions-ci: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 90,
+  "tests": 91,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Adds `sigmap conventions --ci` (IMPL.md §4) — a CI gate that fails when a repo's overall convention consistency falls below a threshold, optionally blocking regressions. Completes the consistency-tracking story started by `--report` (v7.14.0). Closes #322.

## Changes
- `src/conventions/ci.js` (new, zero-dep, bundle-safe): `ciGate(result, opts, prior)` → `{ score, min, ok, regressed, reasons }`. Fails when overall consistency < `min` (default 0.70); with `noRegress`, also fails when the score dropped vs the last snapshot (best-effort). Reuses `overallScore` from `report.js`.
- `gen-context.js`: `conventions --ci [--min <n>] [--no-regress] [--json]` — read-only gate (reads the last history snapshot for `--no-regress`, never appends), exits 1 on failure. Factory added (clean insert).
- `version.json`: derived `tests` 90 → 91.

Example:
```
$ sigmap conventions --ci --min 0.99
[sigmap] conventions --ci  ✗ FAIL — consistency 75% (min 99%)
  • consistency 75% below min 99%
$ echo $?
1
```

Remaining `conventions` flags: `--fix` (largely subsumed by `--conflicts`), `--update` (incremental rescan). The §9 LLM A/B benchmark is the open research item.

## Test plan
- [x] `node test/integration/conventions-ci.test.js` — 10 passed (min / regression / no-prior / CLI exit codes / read-only)
- [x] `node test/integration/all.js` — 85 suites, 0 failures (incl. standalone-bundle smoke test)
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)