### PR TITLE
feat: LLM A/B hallucination ablation harness (IMPL §9)

### DIFF
--- a/benchmarks/llm-ablation-tasks.json
+++ b/benchmarks/llm-ablation-tasks.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "LLM A/B hallucination ablation corpus (IMPL §9). Each task is a code-gen prompt about THIS repo. Run with: npm run benchmark:llm-ablation (needs ANTHROPIC_API_KEY).",
+  "tasks": [
+    {
+      "id": "rank-call",
+      "prompt": "Write a Node snippet that ranks files for the query \"auth flow\" using SigMap's core API. Reference the exact exported function and its signature. Use real file paths and symbol names from this repository."
+    },
+    {
+      "id": "extract-conventions",
+      "prompt": "Show how to extract a repo's coding conventions programmatically with SigMap's internal modules. Name the exact module path and the function that returns the conventions, with correct arguments."
+    },
+    {
+      "id": "verify-output",
+      "prompt": "Write a script that runs SigMap's hallucination guard over an answer file and exits non-zero on any finding. Reference the real CLI command and the real exported verify function."
+    },
+    {
+      "id": "scaffold-call",
+      "prompt": "Call SigMap's scaffold proposal function directly to propose a filename for a new module, passing a conventions result. Use the exact module path, function name, and return-shape fields."
+    }
+  ]
+}

--- a/gen-context.js
+++ b/gen-context.js
@@ -31,6 +31,123 @@ function __require(key) {
 // ── ./src/create/orchestrate ──
 // ── ./src/conventions/report ──
 // ── ./src/conventions/ci ──
+// ── ./src/eval/llm-ablation ──
+__factories["./src/eval/llm-ablation"] = function(module, exports) {
+  
+  /**
+   * LLM A/B hallucination ablation (IMPL.md §9) — the honest measurement.
+   *
+   * Runs a model twice per task — (A) no SigMap context, (B) with SigMap
+   * grounding — pipes both outputs through the hallucination guard, and reports
+   * the measured delta in flagged codebase-fact errors. The model call is
+   * INJECTED (`complete(prompt) → text`), so the harness itself is pure and
+   * offline-testable; the live model adapter lives in `scripts/run-llm-ablation.mjs`.
+   * Zero-dependency, bundle-safe (no network here).
+   */
+
+  const { verify } = __require('./src/verify/hallucination-guard');
+
+  /**
+   * Build the SigMap grounding block for a repo — what we prepend to a task
+   * prompt in arm B. Conventions (the house style) + the known-symbol list
+   * (so the model can reference real names instead of guessing).
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {number} [opts.maxSymbols=80]
+   * @returns {string}
+   */
+  function buildGrounding(cwd, opts = {}) {
+    const maxSymbols = opts.maxSymbols != null ? opts.maxSymbols : 80;
+    const parts = [];
+
+    try {
+      const { extractConventions } = __require('./src/conventions/extract');
+      const { renderConventionsBlock } = __require('./src/conventions/inject');
+      const { loadConfig } = __require('./src/config/loader');
+      let files = [];
+      try {
+        const cfg = loadConfig(cwd);
+        const { buildSigIndex } = __require('./src/retrieval/ranker');
+        files = [...buildSigIndex(cwd).keys()];
+        void cfg;
+      } catch (_) {}
+      const conv = extractConventions(cwd, files);
+      parts.push(renderConventionsBlock(conv));
+    } catch (_) {}
+
+    try {
+      const { buildSymbolSet } = __require('./src/verify/hallucination-guard');
+      const { set } = buildSymbolSet(cwd);
+      const names = [...set].slice(0, maxSymbols);
+      if (names.length) parts.push(`## Known symbols (reference these exactly)\n${names.join(', ')}`);
+    } catch (_) {}
+
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Count flagged codebase-fact errors in an answer (the §9 metric).
+   * @param {string} answerText
+   * @param {string} cwd
+   * @returns {number}
+   */
+  function scoreAnswer(answerText, cwd) {
+    try {
+      const { summary } = verify(String(answerText || ''), cwd);
+      return summary.total || 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  /**
+   * Run the A/B ablation over a task corpus.
+   * @param {Array<{id:string, prompt:string}>} tasks
+   * @param {string} cwd
+   * @param {(prompt:string, meta:object)=>string} complete injected model call
+   * @param {object} [opts]
+   * @param {string} [opts.grounding] precomputed grounding (else built from cwd)
+   * @returns {{ tasks: object[], aggregate: object }}
+   */
+  function runAblation(tasks, cwd, complete, opts = {}) {
+    const grounding = opts.grounding != null ? opts.grounding : buildGrounding(cwd);
+    const rows = [];
+    let sumA = 0;
+    let sumB = 0;
+
+    for (const task of tasks || []) {
+      const basePrompt = task.prompt || '';
+      const groundedPrompt = grounding ? `${grounding}\n\n---\n\n${basePrompt}` : basePrompt;
+
+      const outA = String(complete(basePrompt, { id: task.id, grounded: false }) || '');
+      const outB = String(complete(groundedPrompt, { id: task.id, grounded: true }) || '');
+
+      const aFlagged = scoreAnswer(outA, cwd);
+      const bFlagged = scoreAnswer(outB, cwd);
+      sumA += aFlagged;
+      sumB += bFlagged;
+      rows.push({ id: task.id, aFlagged, bFlagged });
+    }
+
+    const n = rows.length;
+    const per100 = (sum) => (n > 0 ? (sum / n) * 100 : 0);
+    return {
+      tasks: rows,
+      aggregate: {
+        n,
+        withoutFlagged: sumA,
+        withFlagged: sumB,
+        delta: sumA - sumB,
+        withoutPer100: per100(sumA),
+        withPer100: per100(sumB),
+      },
+    };
+  }
+
+  module.exports = { buildGrounding, scoreAnswer, runAblation };
+  
+};
+
 __factories["./src/conventions/ci"] = function(module, exports) {
   
   /**

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "generate:llms": "node scripts/generate-llms.mjs",
     "validate:llms": "node scripts/validate-llms.mjs",
     "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/check-version-meta.mjs && node scripts/generate-llms.mjs",
-    "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs"
+    "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs",
+    "benchmark:llm-ablation": "node scripts/run-llm-ablation.mjs"
   },
   "files": [
     "gen-context.js",

--- a/scripts/run-llm-ablation.mjs
+++ b/scripts/run-llm-ablation.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * SigMap LLM A/B hallucination ablation (IMPL.md §9) — the live runner.
+ *
+ * Runs a model twice per task — (A) no SigMap context, (B) with SigMap
+ * grounding — pipes both outputs through the hallucination guard, and reports
+ * the measured delta in flagged codebase-fact errors per 100 outputs.
+ *
+ * The pure harness lives in src/eval/llm-ablation.js (offline-testable). This
+ * script only supplies the live model call + I/O, so the network touch is
+ * confined to scripts/ (never the published library surface).
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... node scripts/run-llm-ablation.mjs
+ *   ANTHROPIC_API_KEY=sk-... node scripts/run-llm-ablation.mjs --save --model claude-sonnet-4-6
+ *
+ * Without an API key it prints guidance and exits 0 (skip — never fails CI).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const { runAblation } = require(path.join(ROOT, 'src/eval/llm-ablation.js'));
+
+const save = process.argv.includes('--save');
+const modelIdx = process.argv.indexOf('--model');
+const MODEL = modelIdx !== -1 && process.argv[modelIdx + 1] ? process.argv[modelIdx + 1] : 'claude-sonnet-4-6';
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+
+function loadTasks() {
+  const p = path.join(ROOT, 'benchmarks', 'llm-ablation-tasks.json');
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')).tasks || []; } catch (_) { return []; }
+}
+
+/** Live model call → completion text. One network request per call. */
+async function anthropicComplete(prompt) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 1024, messages: [{ role: 'user', content: prompt }] }),
+  });
+  if (!res.ok) throw new Error(`Anthropic API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return (data.content || []).map((b) => b.text || '').join('\n');
+}
+
+async function main() {
+  const tasks = loadTasks();
+  if (tasks.length === 0) {
+    console.error('No tasks in benchmarks/llm-ablation-tasks.json.');
+    process.exit(1);
+  }
+
+  if (!API_KEY) {
+    console.log('SigMap LLM A/B ablation (IMPL §9)\n');
+    console.log('  ⚠ ANTHROPIC_API_KEY not set — skipping the live run.');
+    console.log(`  The harness is ready: ${tasks.length} tasks in benchmarks/llm-ablation-tasks.json.`);
+    console.log('  Run live with:  ANTHROPIC_API_KEY=sk-... npm run benchmark:llm-ablation');
+    process.exit(0);
+  }
+
+  console.log(`SigMap LLM A/B ablation — ${MODEL}, ${tasks.length} tasks (2 calls each)\n`);
+
+  // Resolve all calls (the injected `complete` is async-aware via await below).
+  const cache = new Map();
+  const complete = (prompt) => cache.get(prompt);
+  // Pre-fill the cache by running each prompt once (ungrounded + grounded are distinct strings).
+  const { buildGrounding } = require(path.join(ROOT, 'src/eval/llm-ablation.js'));
+  const grounding = buildGrounding(ROOT);
+  for (const t of tasks) {
+    const grounded = grounding ? `${grounding}\n\n---\n\n${t.prompt}` : t.prompt;
+    for (const p of [t.prompt, grounded]) {
+      if (!cache.has(p)) { process.stdout.write(`  · calling model (${t.id})…\n`); cache.set(p, await anthropicComplete(p)); }
+    }
+  }
+
+  const result = runAblation(tasks, ROOT, complete, { grounding });
+  const a = result.aggregate;
+
+  console.log('\n  Task                  without  with');
+  console.log('  ' + '─'.repeat(40));
+  for (const r of result.tasks) {
+    console.log(`  ${String(r.id).padEnd(20)} ${String(r.aFlagged).padStart(6)} ${String(r.bFlagged).padStart(5)}`);
+  }
+  console.log('  ' + '─'.repeat(40));
+  console.log(`  flagged errors per 100 outputs:  without ${a.withoutPer100.toFixed(0)}  →  with ${a.withPer100.toFixed(0)}`);
+  console.log(`  measured delta: ${a.delta} fewer flagged across ${a.n} tasks`);
+
+  if (save) {
+    const out = path.join(ROOT, 'benchmarks', 'reports', 'llm-ablation.json');
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, JSON.stringify({ benchmark: 'llm-ablation', model: MODEL, ...result }, null, 2));
+    console.log(`\n  saved → benchmarks/reports/llm-ablation.json`);
+  }
+}
+
+main().catch((e) => { console.error(`[llm-ablation] ${e.message}`); process.exit(1); });

--- a/src/eval/llm-ablation.js
+++ b/src/eval/llm-ablation.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * LLM A/B hallucination ablation (IMPL.md §9) — the honest measurement.
+ *
+ * Runs a model twice per task — (A) no SigMap context, (B) with SigMap
+ * grounding — pipes both outputs through the hallucination guard, and reports
+ * the measured delta in flagged codebase-fact errors. The model call is
+ * INJECTED (`complete(prompt) → text`), so the harness itself is pure and
+ * offline-testable; the live model adapter lives in `scripts/run-llm-ablation.mjs`.
+ * Zero-dependency, bundle-safe (no network here).
+ */
+
+const { verify } = require('../verify/hallucination-guard');
+
+/**
+ * Build the SigMap grounding block for a repo — what we prepend to a task
+ * prompt in arm B. Conventions (the house style) + the known-symbol list
+ * (so the model can reference real names instead of guessing).
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {number} [opts.maxSymbols=80]
+ * @returns {string}
+ */
+function buildGrounding(cwd, opts = {}) {
+  const maxSymbols = opts.maxSymbols != null ? opts.maxSymbols : 80;
+  const parts = [];
+
+  try {
+    const { extractConventions } = require('../conventions/extract');
+    const { renderConventionsBlock } = require('../conventions/inject');
+    const { loadConfig } = require('../config/loader');
+    let files = [];
+    try {
+      const cfg = loadConfig(cwd);
+      const { buildSigIndex } = require('../retrieval/ranker');
+      files = [...buildSigIndex(cwd).keys()];
+      void cfg;
+    } catch (_) {}
+    const conv = extractConventions(cwd, files);
+    parts.push(renderConventionsBlock(conv));
+  } catch (_) {}
+
+  try {
+    const { buildSymbolSet } = require('../verify/hallucination-guard');
+    const { set } = buildSymbolSet(cwd);
+    const names = [...set].slice(0, maxSymbols);
+    if (names.length) parts.push(`## Known symbols (reference these exactly)\n${names.join(', ')}`);
+  } catch (_) {}
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Count flagged codebase-fact errors in an answer (the §9 metric).
+ * @param {string} answerText
+ * @param {string} cwd
+ * @returns {number}
+ */
+function scoreAnswer(answerText, cwd) {
+  try {
+    const { summary } = verify(String(answerText || ''), cwd);
+    return summary.total || 0;
+  } catch (_) {
+    return 0;
+  }
+}
+
+/**
+ * Run the A/B ablation over a task corpus.
+ * @param {Array<{id:string, prompt:string}>} tasks
+ * @param {string} cwd
+ * @param {(prompt:string, meta:object)=>string} complete injected model call
+ * @param {object} [opts]
+ * @param {string} [opts.grounding] precomputed grounding (else built from cwd)
+ * @returns {{ tasks: object[], aggregate: object }}
+ */
+function runAblation(tasks, cwd, complete, opts = {}) {
+  const grounding = opts.grounding != null ? opts.grounding : buildGrounding(cwd);
+  const rows = [];
+  let sumA = 0;
+  let sumB = 0;
+
+  for (const task of tasks || []) {
+    const basePrompt = task.prompt || '';
+    const groundedPrompt = grounding ? `${grounding}\n\n---\n\n${basePrompt}` : basePrompt;
+
+    const outA = String(complete(basePrompt, { id: task.id, grounded: false }) || '');
+    const outB = String(complete(groundedPrompt, { id: task.id, grounded: true }) || '');
+
+    const aFlagged = scoreAnswer(outA, cwd);
+    const bFlagged = scoreAnswer(outB, cwd);
+    sumA += aFlagged;
+    sumB += bFlagged;
+    rows.push({ id: task.id, aFlagged, bFlagged });
+  }
+
+  const n = rows.length;
+  const per100 = (sum) => (n > 0 ? (sum / n) * 100 : 0);
+  return {
+    tasks: rows,
+    aggregate: {
+      n,
+      withoutFlagged: sumA,
+      withFlagged: sumB,
+      delta: sumA - sumB,
+      withoutPer100: per100(sumA),
+      withPer100: per100(sumB),
+    },
+  };
+}
+
+module.exports = { buildGrounding, scoreAnswer, runAblation };

--- a/test/integration/llm-ablation.test.js
+++ b/test/integration/llm-ablation.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * Integration tests for the LLM A/B ablation harness (IMPL §9).
+ *   buildGrounding · scoreAnswer · runAblation (injected completer) · script skip
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync, execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'scripts', 'run-llm-ablation.mjs');
+const { buildGrounding, scoreAnswer, runAblation } = require(path.join(ROOT, 'src/eval/llm-ablation'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+// A repo with one real symbol + a generated index, so verify() can flag fakes.
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ablation-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'core.js'),
+      'function realCoreFn(x){ return x; }\nmodule.exports = { realCoreFn };\n');
+    execFileSync(process.execPath, [path.join(ROOT, 'gen-context.js')], { cwd: dir, stdio: 'ignore' });
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── buildGrounding ──────────────────────────────────────────────────────────
+test('buildGrounding: non-empty, includes conventions + known symbols', () => {
+  withRepo((dir) => {
+    const g = buildGrounding(dir);
+    assert.ok(g.length > 0, 'grounding is non-empty');
+    assert.ok(/Conventions/.test(g), 'has conventions block');
+    assert.ok(/realCoreFn/.test(g), 'lists the real symbol');
+  });
+});
+
+// ── scoreAnswer ─────────────────────────────────────────────────────────────
+test('scoreAnswer: flags a fake symbol, clears a real one', () => {
+  withRepo((dir) => {
+    const fake = scoreAnswer('Call `totallyFakeSymbol(...)` in `src/ghost.js`.', dir);
+    const real = scoreAnswer('Use `realCoreFn(...)`.', dir);
+    assert.ok(fake > 0, `fake answer should flag, got ${fake}`);
+    assert.ok(fake > real, `fake (${fake}) should flag more than real (${real})`);
+  });
+});
+
+// ── runAblation ─────────────────────────────────────────────────────────────
+test('runAblation: injected completer; aggregate has the A/B shape', () => {
+  withRepo((dir) => {
+    const tasks = [{ id: 't1', prompt: 'write code' }];
+    // completer ignores grounding, always real → both arms clean
+    const complete = () => 'Use `realCoreFn(...)`.';
+    const r = runAblation(tasks, dir, complete);
+    assert.strictEqual(r.tasks.length, 1);
+    for (const k of ['n', 'withoutFlagged', 'withFlagged', 'delta', 'withoutPer100', 'withPer100']) {
+      assert.ok(k in r.aggregate, `aggregate has ${k}`);
+    }
+    assert.strictEqual(r.aggregate.n, 1);
+  });
+});
+test('runAblation: grounding reduces flagged errors (delta > 0)', () => {
+  withRepo((dir) => {
+    const tasks = [{ id: 't1', prompt: 'P1' }, { id: 't2', prompt: 'P2' }];
+    // Hallucinate ONLY when the prompt lacks the grounding marker (a known symbol).
+    const complete = (prompt) => (/realCoreFn/.test(prompt)
+      ? 'Use `realCoreFn(...)`.'                       // grounded → real
+      : 'Call `madeUpSymbolXyz(...)` in `src/none.js`.'); // ungrounded → 2 fakes
+    const r = runAblation(tasks, dir, complete);
+    assert.ok(r.aggregate.withoutFlagged > 0, 'ungrounded arm flags errors');
+    assert.strictEqual(r.aggregate.withFlagged, 0, 'grounded arm is clean');
+    assert.ok(r.aggregate.delta > 0, `delta should be positive, got ${r.aggregate.delta}`);
+  });
+});
+test('runAblation: calls completer twice per task (ungrounded + grounded)', () => {
+  withRepo((dir) => {
+    let calls = 0;
+    const complete = () => { calls++; return 'Use `realCoreFn(...)`.'; };
+    runAblation([{ id: 'a', prompt: 'x' }, { id: 'b', prompt: 'y' }], dir, complete, { grounding: 'G' });
+    assert.strictEqual(calls, 4, 'two tasks × two arms = 4 calls');
+  });
+});
+
+// ── script (skip path) ──────────────────────────────────────────────────────
+test('script: exits 0 with guidance when ANTHROPIC_API_KEY is absent', () => {
+  const env = { ...process.env };
+  delete env.ANTHROPIC_API_KEY;
+  const res = spawnSync('node', [SCRIPT], { cwd: ROOT, encoding: 'utf8', env });
+  assert.strictEqual(res.status, 0, res.stderr);
+  assert.ok(/ANTHROPIC_API_KEY not set/.test(res.stdout), 'prints skip guidance');
+  assert.ok(/harness is ready/.test(res.stdout));
+});
+
+console.log(`\nllm-ablation: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 91,
+  "tests": 92,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Builds the §9 measurement behind the whole grounded-codegen plan: an **A/B hallucination ablation** — run a model twice per task (no context vs SigMap grounding), pipe both outputs through the hallucination guard, and report the measured delta in flagged codebase-fact errors. The pure harness is **fully offline-testable** (the model call is injected); a thin script runs it live once an API key is present. Closes #325.

## Changes
- `src/eval/llm-ablation.js` (new, zero-dep, bundle-safe, **no network**):
  - `buildGrounding(cwd)` — conventions block + known-symbol list (the grounding for arm B)
  - `scoreAnswer(text, cwd)` — flagged codebase-fact errors via `verify`
  - `runAblation(tasks, cwd, complete, opts)` — runs each task ungrounded + grounded, scores both, aggregates `{ n, withoutFlagged, withFlagged, delta, withoutPer100, withPer100 }`; **`complete` is injected**
- `scripts/run-llm-ablation.mjs` — live runner (Anthropic via `ANTHROPIC_API_KEY`); **without a key it prints guidance and exits 0** (skip — never fails CI). The network `fetch` lives only here, not in the published `src/` surface.
- `benchmarks/llm-ablation-tasks.json` — starter corpus; `npm run benchmark:llm-ablation`.
- `version.json`: derived `tests` 91 → 92.

This turns IMPL §9 from "offline coverage proxy only" into "the real A/B is ready to run" — the moment a key is available, `npm run benchmark:llm-ablation` produces the measured hallucination delta.

## Test plan
- [x] `node test/integration/llm-ablation.test.js` — 6 passed (grounding / scoreAnswer / injected completer / **delta>0 when grounding helps** / 2-calls-per-task / script skip path)
- [x] `node test/integration/all.js` — 86 suites, 0 failures (incl. standalone-bundle smoke test)
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS — no shell spawns · no install scripts · main exports API · no fingerprinting; the `fetch` is confined to `scripts/` (outside the published surface)