### PR TITLE
feat: sigmap conventions --fix — exhaustive rename/move checklist

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -32,6 +32,68 @@ function __require(key) {
 // ── ./src/conventions/report ──
 // ── ./src/conventions/ci ──
 // ── ./src/eval/llm-ablation ──
+// ── ./src/conventions/fix ──
+__factories["./src/conventions/fix"] = function(module, exports) {
+  
+  /**
+   * Convention fix list (IMPL.md §4 — `conventions --fix`).
+   *
+   * The complete, actionable rename checklist: every scoped source file whose
+   * name doesn't match the dominant file-naming convention, with full from→to
+   * paths. Distinct from `--conflicts` (a diagnostic summary with up to 3 example
+   * basenames) — `--fix` lists *every* offending file with its real path, ready
+   * to paste into a task or PR. Pure, zero-dependency, bundle-safe.
+   */
+
+  const path = require('path');
+  const { classifyNaming } = __require('./src/conventions/extract');
+  const { toNamingStyle } = __require('./src/conventions/conflicts');
+
+  const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+  const PY_EXTS = new Set(['.py']);
+  const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+  const TEST_RE = /\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/;
+
+  /** Rename a file path's basename to the target naming style (keep dir + ext). */
+  function _renamePath(relPath, style) {
+    const dir = relPath.includes('/') ? relPath.slice(0, relPath.lastIndexOf('/') + 1) : '';
+    const base = relPath.includes('/') ? relPath.slice(relPath.lastIndexOf('/') + 1) : relPath;
+    const dot = base.indexOf('.');
+    const stem = dot > 0 ? base.slice(0, dot) : base;
+    const ext = dot > 0 ? base.slice(dot) : '';
+    return `${dir}${toNamingStyle(stem, style)}${ext}`;
+  }
+
+  /**
+   * Build the exhaustive rename checklist for the dominant file-naming convention.
+   * @param {string} cwd repo root (for relative paths)
+   * @param {string[]} files absolute source paths (e.g. from buildFileList)
+   * @param {object} conventions an `extractConventions` result (for the dominant style)
+   * @returns {{ dominant: string|null, renames: Array<{from:string,to:string,fromStyle:string}>, count: number }}
+   */
+  function buildFixList(cwd, files, conventions) {
+    const dominant = conventions && conventions.fileNaming && conventions.fileNaming.dominant;
+    if (!dominant) return { dominant: null, renames: [], count: 0 };
+
+    const renames = [];
+    for (const f of files || []) {
+      if (!SCOPED_EXTS.has(path.extname(f).toLowerCase())) continue;
+      if (TEST_RE.test(f)) continue;
+      const base = path.basename(f);
+      const style = classifyNaming(base);
+      if (style === 'other' || style === dominant) continue;
+      const rel = path.relative(cwd, f).replace(/\\/g, '/');
+      renames.push({ from: rel, to: _renamePath(rel, dominant), fromStyle: style });
+    }
+    renames.sort((a, b) => a.from.localeCompare(b.from));
+    return { dominant, renames, count: renames.length };
+  }
+
+  module.exports = { buildFixList };
+  
+};
+
 __factories["./src/eval/llm-ablation"] = function(module, exports) {
   
   /**
@@ -16577,6 +16639,28 @@ function main() {
         process.exit(1);
       }
       console.log(`[sigmap] conventions → injected block into ${path.relative(cwd, claudePath) || 'CLAUDE.md'}`);
+      process.exit(0);
+    }
+
+    // `--fix`: exhaustive rename checklist — every file not matching the dominant style.
+    if (args.includes('--fix')) {
+      const { buildFixList } = requireSourceOrBundled('./src/conventions/fix');
+      const fixList = buildFixList(cwd, files, result);
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify(fixList) + '\n');
+        process.exit(0);
+      }
+      console.log('[sigmap] conventions --fix  (TS/JS/Python)');
+      if (!fixList.dominant) {
+        console.log('  no dominant file-naming convention — nothing to fix');
+        process.exit(0);
+      }
+      if (fixList.count === 0) {
+        console.log(`  ✓ no fixes needed — every file matches ${fixList.dominant}`);
+        process.exit(0);
+      }
+      console.log(`  ${fixList.count} file${fixList.count === 1 ? '' : 's'} to rename to ${fixList.dominant}:`);
+      for (const r of fixList.renames) console.log(`  - [ ] ${r.from}  →  ${r.to}`);
       process.exit(0);
     }
 

--- a/src/conventions/fix.js
+++ b/src/conventions/fix.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Convention fix list (IMPL.md §4 — `conventions --fix`).
+ *
+ * The complete, actionable rename checklist: every scoped source file whose
+ * name doesn't match the dominant file-naming convention, with full from→to
+ * paths. Distinct from `--conflicts` (a diagnostic summary with up to 3 example
+ * basenames) — `--fix` lists *every* offending file with its real path, ready
+ * to paste into a task or PR. Pure, zero-dependency, bundle-safe.
+ */
+
+const path = require('path');
+const { classifyNaming } = require('./extract');
+const { toNamingStyle } = require('./conflicts');
+
+const JS_TS_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const PY_EXTS = new Set(['.py']);
+const SCOPED_EXTS = new Set([...JS_TS_EXTS, ...PY_EXTS]);
+
+const TEST_RE = /\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.py$/;
+
+/** Rename a file path's basename to the target naming style (keep dir + ext). */
+function _renamePath(relPath, style) {
+  const dir = relPath.includes('/') ? relPath.slice(0, relPath.lastIndexOf('/') + 1) : '';
+  const base = relPath.includes('/') ? relPath.slice(relPath.lastIndexOf('/') + 1) : relPath;
+  const dot = base.indexOf('.');
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  const ext = dot > 0 ? base.slice(dot) : '';
+  return `${dir}${toNamingStyle(stem, style)}${ext}`;
+}
+
+/**
+ * Build the exhaustive rename checklist for the dominant file-naming convention.
+ * @param {string} cwd repo root (for relative paths)
+ * @param {string[]} files absolute source paths (e.g. from buildFileList)
+ * @param {object} conventions an `extractConventions` result (for the dominant style)
+ * @returns {{ dominant: string|null, renames: Array<{from:string,to:string,fromStyle:string}>, count: number }}
+ */
+function buildFixList(cwd, files, conventions) {
+  const dominant = conventions && conventions.fileNaming && conventions.fileNaming.dominant;
+  if (!dominant) return { dominant: null, renames: [], count: 0 };
+
+  const renames = [];
+  for (const f of files || []) {
+    if (!SCOPED_EXTS.has(path.extname(f).toLowerCase())) continue;
+    if (TEST_RE.test(f)) continue;
+    const base = path.basename(f);
+    const style = classifyNaming(base);
+    if (style === 'other' || style === dominant) continue;
+    const rel = path.relative(cwd, f).replace(/\\/g, '/');
+    renames.push({ from: rel, to: _renamePath(rel, dominant), fromStyle: style });
+  }
+  renames.sort((a, b) => a.from.localeCompare(b.from));
+  return { dominant, renames, count: renames.length };
+}
+
+module.exports = { buildFixList };

--- a/test/integration/conventions-fix.test.js
+++ b/test/integration/conventions-fix.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap conventions --fix` (Layer 3 — rename checklist).
+ *   buildFixList: full-path renames / empty cases · CLI
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+const { buildFixList } = require(path.join(ROOT, 'src/conventions/fix'));
+const { extractConventions } = require(path.join(ROOT, 'src/conventions/extract'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.error(`  FAIL  ${name}`); console.error(`        ${err.message}`); failed++; }
+}
+
+function withRepo(files, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-fix-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    for (const [f, c] of Object.entries(files)) fs.writeFileSync(path.join(dir, 'src', f), c);
+    fn(dir, Object.keys(files).map((f) => path.join(dir, 'src', f)));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+// ── buildFixList ────────────────────────────────────────────────────────────
+test('lists every non-matching file with full from→to paths', () => {
+  withRepo({
+    'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n', 'aaa.js': 'export const e=5;\n',
+    'user-service.js': 'export const c=3;\n', 'data_store.js': 'export const d=4;\n',
+  }, (dir, files) => {
+    const conv = extractConventions(dir, files); // camelCase dominant (3 of 5)
+    const r = buildFixList(dir, files, conv);
+    assert.strictEqual(r.dominant, 'camelCase');
+    assert.strictEqual(r.count, 2, 'two non-matching files');
+    const froms = r.renames.map((x) => x.from).sort();
+    assert.deepStrictEqual(froms, ['src/data_store.js', 'src/user-service.js']);
+    const us = r.renames.find((x) => x.from === 'src/user-service.js');
+    assert.strictEqual(us.to, 'src/userService.js', 'full-path rename to dominant style');
+    assert.strictEqual(us.fromStyle, 'kebab-case');
+  });
+});
+test('empty when every file already matches', () => {
+  withRepo({ 'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n' }, (dir, files) => {
+    const r = buildFixList(dir, files, extractConventions(dir, files));
+    assert.strictEqual(r.count, 0);
+    assert.deepStrictEqual(r.renames, []);
+  });
+});
+test('empty when there is no dominant convention', () => {
+  const r = buildFixList(process.cwd(), [], { fileNaming: { dominant: null } });
+  assert.strictEqual(r.dominant, null);
+  assert.strictEqual(r.count, 0);
+});
+test('skips test files', () => {
+  withRepo({
+    'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n',
+    'some-thing.test.js': 'test()\n',
+  }, (dir, files) => {
+    const r = buildFixList(dir, files, extractConventions(dir, files));
+    assert.ok(!r.renames.some((x) => /\.test\./.test(x.from)), 'no test files in the checklist');
+  });
+});
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+test('CLI: --fix prints a checkbox checklist for a mixed repo', () => {
+  withRepo({
+    'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n', 'quux.js': 'export const e=5;\n',
+    'user-service.js': 'export const c=3;\n',
+  }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--fix'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/to rename to camelCase/.test(res.stdout));
+    assert.ok(/- \[ \] src\/user-service\.js\s+→\s+src\/userService\.js/.test(res.stdout), res.stdout);
+  });
+});
+test('CLI: --fix on a clean repo says no fixes needed', () => {
+  withRepo({ 'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n' }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--fix'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 0);
+    assert.ok(/no fixes needed/.test(res.stdout));
+  });
+});
+test('CLI: --fix --json emits the list', () => {
+  withRepo({ 'fooBar.js': 'export const a=1;\n', 'bazQux.js': 'export const b=2;\n', 'cc.js': 'export const e=5;\n', 'a-b.js': 'export const c=3;\n' }, (dir) => {
+    const res = spawnSync('node', [SCRIPT, 'conventions', '--fix', '--json'], { cwd: dir, encoding: 'utf8' });
+    const data = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.ok(Array.isArray(data.renames));
+    assert.strictEqual(typeof data.count, 'number');
+  });
+});
+
+console.log(`\nconventions-fix: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
   "mcp_tools": 15,
-  "tests": 92,
+  "tests": 93,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Adds `sigmap conventions --fix` (IMPL.md §4) — the complete, actionable rename checklist: **every** source file whose name doesn't match the dominant convention, with full from→to paths, ready to paste into a task/PR. Distinct from `--conflicts` (a diagnostic summary with up to 3 example basenames). Closes #328.

## Changes
- `src/conventions/fix.js` (new, zero-dep, bundle-safe): `buildFixList(cwd, files, conventions)` → `{ dominant, renames: [{from,to,fromStyle}], count }` — full-path renames for every non-test source file not matching the dominant file-naming style; empty when all match or no dominant. Reuses `classifyNaming` + `toNamingStyle`.
- `gen-context.js`: `conventions --fix [--json]` — checkbox checklist + count, or "no fixes needed"; read-only (never performs renames). Factory added.
- `version.json`: derived `tests` 92 → 93.

On this repo it lists 30 files (e.g. `src/cache/sig-cache.js → src/cache/sigCache.js`).

This was the last meaningful `conventions` flag. Remaining IMPL items after this: `--update` (perf), scaffold persistence, `init` block — all minor polish.

## Test plan
- [x] `node test/integration/conventions-fix.test.js` — 7 passed (full paths / empty cases / skips tests / CLI)
- [x] `node test/integration/all.js` — 87 suites, 0 failures (incl. standalone-bundle smoke test)
- [x] bundle / version-meta gates pass
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)