### PR TITLE
fix: default Gemini model to gemini-2.5-flash (2.0-flash retired)

### DIFF
--- a/scripts/run-llm-ablation.mjs
+++ b/scripts/run-llm-ablation.mjs
@@ -12,7 +12,7 @@
  *
  * Providers (auto-detected from the present key; --provider overrides):
  *   anthropic — ANTHROPIC_API_KEY            (default model claude-sonnet-4-6)
- *   gemini    — GEMINI_API_KEY / GOOGLE_API_KEY  (default model gemini-2.0-flash)
+ *   gemini    — GEMINI_API_KEY / GOOGLE_API_KEY  (default model gemini-2.5-flash)
  *
  * Usage:
  *   ANTHROPIC_API_KEY=sk-...  node scripts/run-llm-ablation.mjs
@@ -40,7 +40,7 @@ const modelArg = flag('--model');
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
 const GEMINI_KEY = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
 
-const DEFAULT_MODEL = { anthropic: 'claude-sonnet-4-6', gemini: 'gemini-2.0-flash' };
+const DEFAULT_MODEL = { anthropic: 'claude-sonnet-4-6', gemini: 'gemini-2.5-flash' };
 
 // Resolve the provider: explicit flag, else whichever key is present (Gemini first).
 let provider = flag('--provider');


### PR DESCRIPTION
## Summary
- The §9 ablation runner's default Gemini model `gemini-2.0-flash` now 404s (`NOT_FOUND` — retired by AI Studio). Switch the default to the live **`gemini-2.5-flash`**. The `--model` flag already lets you pick any model.

## Run
```bash
GEMINI_API_KEY=<key> npm run benchmark:llm-ablation                      # uses gemini-2.5-flash
GEMINI_API_KEY=<key> node scripts/run-llm-ablation.mjs --model gemini-2.5-pro
# via npm with a custom model (note the --):
GEMINI_API_KEY=<key> npm run benchmark:llm-ablation -- --model gemini-2.5-pro
```

## Test plan
- [x] `node test/integration/all.js` — 90 suites, 0 failures
- [x] skip path clean; script parses