### PR TITLE
fix(verify): stop flagging Node.js & placeholder filenames as fake files

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -12756,207 +12756,220 @@ module.exports = { checkStarNudge, readUsage, usagePath, showStarNudge, RUN_THRE
 
 // ── ./src/verify/parsers ──
 __factories["./src/verify/parsers"] = function(module, exports) {
-'use strict';
+  
+  /**
+   * Parsers for the Hallucination Guard (verify-ai-output).
+   *
+   * Extract the verifiable claims an AI answer makes about a codebase:
+   *   - file paths it references
+   *   - import / require statements it shows
+   *   - function / class symbols it calls
+   *   - fenced code blocks (so callers can scope checks to code vs prose)
+   *
+   * Everything here is deterministic and offline — pure string analysis.
+   */
 
-/**
- * Parsers for the Hallucination Guard (verify-ai-output).
- *
- * Extract the verifiable claims an AI answer makes about a codebase:
- *   - file paths it references
- *   - import / require statements it shows
- *   - function / class symbols it calls
- *   - fenced code blocks (so callers can scope checks to code vs prose)
- *
- * Everything here is deterministic and offline — pure string analysis.
- */
+  // Extensions we are confident name a source/code/config file (no slash required).
+  const KNOWN_CODE_EXT = new Set([
+    'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'py', 'pyw', 'rb', 'go', 'rs',
+    'java', 'kt', 'swift', 'c', 'h', 'cpp', 'hpp', 'cs', 'php', 'r',
+    'vue', 'svelte', 'css', 'scss', 'less', 'html', 'json', 'yml', 'yaml',
+    'toml', 'xml', 'sql', 'graphql', 'gql', 'proto', 'tf', 'md', 'sh',
+    'gd', 'gdscript',
+  ]);
 
-// Extensions we are confident name a source/code/config file (no slash required).
-const KNOWN_CODE_EXT = new Set([
-  'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'py', 'pyw', 'rb', 'go', 'rs',
-  'java', 'kt', 'swift', 'c', 'h', 'cpp', 'hpp', 'cs', 'php', 'r',
-  'vue', 'svelte', 'css', 'scss', 'less', 'html', 'json', 'yml', 'yaml',
-  'toml', 'xml', 'sql', 'graphql', 'gql', 'proto', 'tf', 'md', 'sh',
-  'gd', 'gdscript',
-]);
+  // Well-known "X.js" runtime/library product names — never repo files.
+  const LIBRARY_TOKENS = new Set([
+    'node.js', 'next.js', 'nuxt.js', 'vue.js', 'react.js', 'express.js', 'koa.js',
+    'nest.js', 'three.js', 'd3.js', 'chart.js', 'ember.js', 'backbone.js',
+    'angular.js', 'meteor.js', 'moment.js', 'anime.js', 'p5.js', 'next.config.js',
+  ]);
 
-/**
- * Extract fenced code blocks.
- * @param {string} text
- * @returns {{ lang: string, content: string, line: number }[]}
- */
-function extractCodeBlocks(text) {
-  const blocks = [];
-  const lines = text.split('\n');
-  let inBlock = false;
-  let lang = '';
-  let buf = [];
-  let startLine = 0;
-  for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(/^```(\w*)/);
-    if (m) {
-      if (!inBlock) {
-        inBlock = true;
-        lang = m[1] || '';
-        buf = [];
-        startLine = i + 2; // first content line (1-based)
-      } else {
-        blocks.push({ lang, content: buf.join('\n'), line: startLine });
-        inBlock = false;
+  // Illustrative placeholder names the model writes in prose, not repo claims:
+  // e.g. example.js, minimal-example.js, sample.ts, demo.js, placeholder.js.
+  const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|$)/i;
+
+  /**
+   * Extract fenced code blocks.
+   * @param {string} text
+   * @returns {{ lang: string, content: string, line: number }[]}
+   */
+  function extractCodeBlocks(text) {
+    const blocks = [];
+    const lines = text.split('\n');
+    let inBlock = false;
+    let lang = '';
+    let buf = [];
+    let startLine = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/^```(\w*)/);
+      if (m) {
+        if (!inBlock) {
+          inBlock = true;
+          lang = m[1] || '';
+          buf = [];
+          startLine = i + 2; // first content line (1-based)
+        } else {
+          blocks.push({ lang, content: buf.join('\n'), line: startLine });
+          inBlock = false;
+        }
+        continue;
       }
-      continue;
+      if (inBlock) buf.push(lines[i]);
     }
-    if (inBlock) buf.push(lines[i]);
+    return blocks;
   }
-  return blocks;
-}
 
-/**
- * Extract file-path references (deduped, first-seen line kept).
- * A token counts as a path when it has a `.<letter…>` extension AND
- * either contains a `/` or carries a known code/config extension.
- * @param {string} text
- * @returns {{ path: string, line: number }[]}
- */
-function extractFilePaths(text) {
-  const lines = text.split('\n');
-  const seen = new Map();
-  const re = /(?:^|[\s`"'(\[<])([A-Za-z0-9_][\w./-]*\.[A-Za-z][A-Za-z0-9]*)/g;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    let m;
-    re.lastIndex = 0;
-    while ((m = re.exec(line)) !== null) {
-      const p = m[1];
-      if (/^https?:/i.test(p)) continue;
-      const ext = (p.split('.').pop() || '').toLowerCase();
-      const hasSlash = p.includes('/');
-      if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
-      if (!seen.has(p)) seen.set(p, i + 1);
+  /**
+   * Extract file-path references (deduped, first-seen line kept).
+   * A token counts as a path when it has a `.<letter…>` extension AND
+   * either contains a `/` or carries a known code/config extension.
+   * @param {string} text
+   * @returns {{ path: string, line: number }[]}
+   */
+  function extractFilePaths(text) {
+    const lines = text.split('\n');
+    const seen = new Map();
+    const re = /(?:^|[\s`"'(\[<])([A-Za-z0-9_][\w./-]*\.[A-Za-z][A-Za-z0-9]*)/g;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      let m;
+      re.lastIndex = 0;
+      while ((m = re.exec(line)) !== null) {
+        const p = m[1];
+        if (/^https?:/i.test(p)) continue;
+        const ext = (p.split('.').pop() || '').toLowerCase();
+        const hasSlash = p.includes('/');
+        if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
+        if (LIBRARY_TOKENS.has(p.toLowerCase())) continue;
+        const base = p.split('/').pop();
+        if (PLACEHOLDER_RE.test(base)) continue;
+        if (!seen.has(p)) seen.set(p, i + 1);
+      }
     }
+    return [...seen.entries()].map(([p, line]) => ({ path: p, line }));
   }
-  return [...seen.entries()].map(([p, line]) => ({ path: p, line }));
-}
 
-/**
- * Extract import / require statements.
- * @param {string} text
- * @returns {{ module: string, kind: 'js'|'py', relative: boolean, line: number, raw: string }[]}
- */
-function extractImports(text) {
-  const lines = text.split('\n');
-  const out = [];
-  const push = (module, kind, line, raw) => {
-    if (!module) return;
-    out.push({ module, kind, relative: /^[./]/.test(module), line, raw: raw.trim() });
+  /**
+   * Extract import / require statements.
+   * @param {string} text
+   * @returns {{ module: string, kind: 'js'|'py', relative: boolean, line: number, raw: string }[]}
+   */
+  function extractImports(text) {
+    const lines = text.split('\n');
+    const out = [];
+    const push = (module, kind, line, raw) => {
+      if (!module) return;
+      out.push({ module, kind, relative: /^[./]/.test(module), line, raw: raw.trim() });
+    };
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      let m;
+      // JS/TS: import ... from 'x'  |  export ... from 'x'
+      if ((m = line.match(/\b(?:import|export)\b[^'"]*\bfrom\s*['"]([^'"]+)['"]/))) {
+        push(m[1], 'js', i + 1, line);
+      } else if ((m = line.match(/\bimport\s*['"]([^'"]+)['"]/))) {
+        // side-effect import 'x'
+        push(m[1], 'js', i + 1, line);
+      }
+      // require('x') / dynamic import('x') — may co-occur, scan separately
+      const reqRe = /\b(?:require|import)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+      let r;
+      while ((r = reqRe.exec(line)) !== null) push(r[1], 'js', i + 1, line);
+
+      // TS: import X = require('mod')
+      if ((m = line.match(/\bimport\s+[A-Za-z_$][\w$]*\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/))) {
+        push(m[1], 'js', i + 1, line);
+      }
+
+      // Python: from x import y  |  import x
+      if ((m = line.match(/^\s*from\s+([.\w]+)\s+import\b/))) {
+        push(m[1], 'py', i + 1, line);
+      } else if ((m = line.match(/^\s*import\s+([A-Za-z_][\w.]*)/))) {
+        push(m[1], 'py', i + 1, line);
+      }
+    }
+
+    // Multi-line JS/TS imports, e.g.
+    //   import {
+    //     A as B,
+    //   } from './mod';
+    // The per-line pass above misses these because `from '…'` sits on a later
+    // line. Trigger only when the opening line has no quote and no `from` yet,
+    // then gather forward until the source string appears.
+    for (let i = 0; i < lines.length; i++) {
+      const start = lines[i];
+      if (!/^\s*(?:import|export)\b/.test(start)) continue;
+      if (/['"]/.test(start) || /\bfrom\b/.test(start)) continue; // single-line, already handled
+      let joined = start;
+      for (let j = i + 1; j < Math.min(lines.length, i + 12); j++) {
+        joined += ' ' + lines[j];
+        const fm = joined.match(/\bfrom\s*['"]([^'"]+)['"]/);
+        if (fm) { push(fm[1], 'js', i + 1, start.trim()); break; }
+        if (/['"]/.test(lines[j]) && !/\bfrom\b/.test(joined)) break; // a string that isn't a source — bail
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Extract npm/pnpm/yarn script invocations (`npm run <name>`).
+   * Only the explicit `run` form is matched, to avoid confusing package-manager
+   * subcommands (`yarn add`, `pnpm install`) with script names.
+   * @param {string} text
+   * @returns {{ name: string, line: number }[]}
+   */
+  function extractNpmScripts(text) {
+    const lines = text.split('\n');
+    const out = [];
+    const seen = new Set();
+    const re = /\b(?:npm|pnpm|yarn)\s+run(?:-script)?\s+([A-Za-z0-9:_-]+)/g;
+    for (let i = 0; i < lines.length; i++) {
+      let m;
+      re.lastIndex = 0;
+      while ((m = re.exec(lines[i])) !== null) {
+        const name = m[1];
+        if (seen.has(name)) continue;
+        seen.add(name);
+        out.push({ name, line: i + 1 });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Extract function/class symbol references that look like calls.
+   * Restricted to backtick-wrapped calls (`foo(...)`) for high precision.
+   * @param {string} text
+   * @returns {{ name: string, line: number }[]}
+   */
+  function extractSymbols(text) {
+    const lines = text.split('\n');
+    const out = [];
+    const seen = new Set();
+    const re = /`([A-Za-z_$][\w$]*)\s*\([^`]*\)`/g;
+    for (let i = 0; i < lines.length; i++) {
+      let m;
+      re.lastIndex = 0;
+      while ((m = re.exec(lines[i])) !== null) {
+        const name = m[1];
+        const key = name + '@' + (i + 1);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({ name, line: i + 1 });
+      }
+    }
+    return out;
+  }
+
+  module.exports = {
+    extractCodeBlocks,
+    extractFilePaths,
+    extractImports,
+    extractSymbols,
+    extractNpmScripts,
   };
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    let m;
-    // JS/TS: import ... from 'x'  |  export ... from 'x'
-    if ((m = line.match(/\b(?:import|export)\b[^'"]*\bfrom\s*['"]([^'"]+)['"]/))) {
-      push(m[1], 'js', i + 1, line);
-    } else if ((m = line.match(/\bimport\s*['"]([^'"]+)['"]/))) {
-      // side-effect import 'x'
-      push(m[1], 'js', i + 1, line);
-    }
-    // require('x') / dynamic import('x') — may co-occur, scan separately
-    const reqRe = /\b(?:require|import)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
-    let r;
-    while ((r = reqRe.exec(line)) !== null) push(r[1], 'js', i + 1, line);
-
-    // TS: import X = require('mod')
-    if ((m = line.match(/\bimport\s+[A-Za-z_$][\w$]*\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/))) {
-      push(m[1], 'js', i + 1, line);
-    }
-
-    // Python: from x import y  |  import x
-    if ((m = line.match(/^\s*from\s+([.\w]+)\s+import\b/))) {
-      push(m[1], 'py', i + 1, line);
-    } else if ((m = line.match(/^\s*import\s+([A-Za-z_][\w.]*)/))) {
-      push(m[1], 'py', i + 1, line);
-    }
-  }
-
-  // Multi-line JS/TS imports, e.g.
-  //   import {
-  //     A as B,
-  //   } from './mod';
-  // The per-line pass above misses these because `from '…'` sits on a later
-  // line. Trigger only when the opening line has no quote and no `from` yet,
-  // then gather forward until the source string appears.
-  for (let i = 0; i < lines.length; i++) {
-    const start = lines[i];
-    if (!/^\s*(?:import|export)\b/.test(start)) continue;
-    if (/['"]/.test(start) || /\bfrom\b/.test(start)) continue; // single-line, already handled
-    let joined = start;
-    for (let j = i + 1; j < Math.min(lines.length, i + 12); j++) {
-      joined += ' ' + lines[j];
-      const fm = joined.match(/\bfrom\s*['"]([^'"]+)['"]/);
-      if (fm) { push(fm[1], 'js', i + 1, start.trim()); break; }
-      if (/['"]/.test(lines[j]) && !/\bfrom\b/.test(joined)) break; // a string that isn't a source — bail
-    }
-  }
-  return out;
-}
-
-/**
- * Extract npm/pnpm/yarn script invocations (`npm run <name>`).
- * Only the explicit `run` form is matched, to avoid confusing package-manager
- * subcommands (`yarn add`, `pnpm install`) with script names.
- * @param {string} text
- * @returns {{ name: string, line: number }[]}
- */
-function extractNpmScripts(text) {
-  const lines = text.split('\n');
-  const out = [];
-  const seen = new Set();
-  const re = /\b(?:npm|pnpm|yarn)\s+run(?:-script)?\s+([A-Za-z0-9:_-]+)/g;
-  for (let i = 0; i < lines.length; i++) {
-    let m;
-    re.lastIndex = 0;
-    while ((m = re.exec(lines[i])) !== null) {
-      const name = m[1];
-      if (seen.has(name)) continue;
-      seen.add(name);
-      out.push({ name, line: i + 1 });
-    }
-  }
-  return out;
-}
-
-/**
- * Extract function/class symbol references that look like calls.
- * Restricted to backtick-wrapped calls (`foo(...)`) for high precision.
- * @param {string} text
- * @returns {{ name: string, line: number }[]}
- */
-function extractSymbols(text) {
-  const lines = text.split('\n');
-  const out = [];
-  const seen = new Set();
-  const re = /`([A-Za-z_$][\w$]*)\s*\([^`]*\)`/g;
-  for (let i = 0; i < lines.length; i++) {
-    let m;
-    re.lastIndex = 0;
-    while ((m = re.exec(lines[i])) !== null) {
-      const name = m[1];
-      const key = name + '@' + (i + 1);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push({ name, line: i + 1 });
-    }
-  }
-  return out;
-}
-
-module.exports = {
-  extractCodeBlocks,
-  extractFilePaths,
-  extractImports,
-  extractSymbols,
-  extractNpmScripts,
-};
-
+  
 };
 
 // ── ./src/verify/closest-match ──

--- a/src/verify/parsers.js
+++ b/src/verify/parsers.js
@@ -21,6 +21,17 @@ const KNOWN_CODE_EXT = new Set([
   'gd', 'gdscript',
 ]);
 
+// Well-known "X.js" runtime/library product names — never repo files.
+const LIBRARY_TOKENS = new Set([
+  'node.js', 'next.js', 'nuxt.js', 'vue.js', 'react.js', 'express.js', 'koa.js',
+  'nest.js', 'three.js', 'd3.js', 'chart.js', 'ember.js', 'backbone.js',
+  'angular.js', 'meteor.js', 'moment.js', 'anime.js', 'p5.js', 'next.config.js',
+]);
+
+// Illustrative placeholder names the model writes in prose, not repo claims:
+// e.g. example.js, minimal-example.js, sample.ts, demo.js, placeholder.js.
+const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|$)/i;
+
 /**
  * Extract fenced code blocks.
  * @param {string} text
@@ -73,6 +84,9 @@ function extractFilePaths(text) {
       const ext = (p.split('.').pop() || '').toLowerCase();
       const hasSlash = p.includes('/');
       if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
+      if (LIBRARY_TOKENS.has(p.toLowerCase())) continue;
+      const base = p.split('/').pop();
+      if (PLACEHOLDER_RE.test(base)) continue;
       if (!seen.has(p)) seen.set(p, i + 1);
     }
   }

--- a/test/integration/verify-ai-output.test.js
+++ b/test/integration/verify-ai-output.test.js
@@ -60,6 +60,34 @@ test('extractFilePaths finds paths, skips URLs and version numbers', () => {
   assert.ok(!paths.includes('6.13.0'), 'should skip version numbers');
 });
 
+test('extractFilePaths skips runtime/library product names (Node.js, Next.js, …)', () => {
+  const text = 'Write a minimal Node.js example. It uses Next.js, Vue.js, Express.js and D3.js.';
+  const paths = parsers.extractFilePaths(text).map((p) => p.path.toLowerCase());
+  for (const lib of ['node.js', 'next.js', 'vue.js', 'express.js', 'd3.js']) {
+    assert.ok(!paths.includes(lib), `should not flag library token ${lib}`);
+  }
+});
+
+test('extractFilePaths skips illustrative placeholder filenames', () => {
+  const text = [
+    'Save this as `example.js`.',
+    'See `minimal-example.js` and `example-coverage-walk.js`.',
+    'Try `sample.ts`, `demo.py`, and `placeholder.js`.',
+  ].join('\n');
+  const paths = parsers.extractFilePaths(text).map((p) => p.path);
+  for (const ph of ['example.js', 'minimal-example.js', 'example-coverage-walk.js', 'sample.ts', 'demo.py', 'placeholder.js']) {
+    assert.ok(!paths.includes(ph), `should not flag placeholder ${ph}`);
+  }
+});
+
+test('extractFilePaths still extracts genuine repo-shaped paths (no over-suppression)', () => {
+  const text = 'Edit `src/foo/bar.js`, `src/config/loader.js`, `main.js`, and `index.ts`.';
+  const paths = parsers.extractFilePaths(text).map((p) => p.path);
+  for (const real of ['src/foo/bar.js', 'src/config/loader.js', 'main.js', 'index.ts']) {
+    assert.ok(paths.includes(real), `should still extract ${real}`);
+  }
+});
+
 test('extractImports finds js + py imports and flags relative vs bare', () => {
   const text = [
     "import { rank } from './ranker';",
@@ -101,6 +129,13 @@ test('fake-file flagged when path absent', () => {
   const { issues } = verify('See `src/ghost.js` and `src/index.js`.', '/x', baseOpts);
   const files = issues.filter((i) => i.type === 'fake-file').map((i) => i.value);
   assert.deepStrictEqual(files, ['src/ghost.js']);
+});
+
+test('verify(): Node.js + example.js prose yields no fake-file; real fake path still flags', () => {
+  const text = 'Here is a minimal Node.js example saved as `example.js` that also touches `src/ghost.js`.';
+  const { issues } = verify(text, '/x', baseOpts);
+  const files = issues.filter((i) => i.type === 'fake-file').map((i) => i.value);
+  assert.deepStrictEqual(files, ['src/ghost.js'], 'only the genuine fake path is flagged');
 });
 
 test('fake-import flagged for unresolved relative + missing bare package', () => {


### PR DESCRIPTION
## Summary
- Hardens `verify-ai-output`'s file-path extractor against false positives · closes #347
- Removes the dominant false-positive class in the §9 ablation (22 of ~34 flags were literally "Node.js"), turning the directional +16 delta into a clean, publishable number — and a real quality fix for every `verify-ai-output` user.

## Changes
- `src/verify/parsers.js` (`extractFilePaths`): skip two classes, without weakening real detection
  - **Library/runtime tokens** — denylist of well-known `X.js` product names (`node.js`, `next.js`, `nuxt.js`, `vue.js`, `react.js`, `express.js`, `three.js`, `d3.js`, `chart.js`, …), matched case-insensitively on the whole token.
  - **Illustrative placeholders** — basenames containing `example`/`sample`/`demo`/`placeholder` as a word (catches `example.js`, `minimal-example.js`, `example-coverage-walk.js`).
  - Ambiguous-but-common real names (`main`, `index`, `app`, `test`) are **intentionally not** skipped, so genuine hallucinations still flag.
- `gen-context.js`: regenerated the bundled `src/verify/parsers` factory (standalone-binary parity).
- `test/integration/verify-ai-output.test.js`: +4 tests (library tokens, placeholders, no over-suppression, `verify()` end-to-end).

## Test plan
- [x] `node test/integration/verify-ai-output.test.js` — 33 passed
- [x] `node test/integration/all.js` — 90 passed, 0 failed
- [x] `node scripts/check-bundle.mjs` — all factories present
- [x] Supply-chain local audit — no shell spawns · no install scripts · main exports API · no fingerprinting

🤖 Generated with [Claude Code](https://claude.com/claude-code)