### PR TITLE
fix(verify): skip camelCase placeholders & doc-placeholder imports

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -12787,7 +12787,10 @@ __factories["./src/verify/parsers"] = function(module, exports) {
 
   // Illustrative placeholder names the model writes in prose, not repo claims:
   // e.g. example.js, minimal-example.js, sample.ts, demo.js, placeholder.js.
-  const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|$)/i;
+  const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|s?$)/i;
+  // camelCase / Pascal placeholders: myExample.js, exampleConfig.js, fooSample.ts.
+  // Requires a case boundary so ordinary words (resample.js) are NOT suppressed.
+  const PLACEHOLDER_CAMEL_RE = /(?:^|[a-z])(?:Example|Sample|Demo|Placeholder)|(?:^|[-_.])(?:example|sample|demo|placeholder)(?=[A-Z])/;
 
   /**
    * Extract fenced code blocks.
@@ -12843,7 +12846,7 @@ __factories["./src/verify/parsers"] = function(module, exports) {
         if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
         if (LIBRARY_TOKENS.has(p.toLowerCase())) continue;
         const base = p.split('/').pop();
-        if (PLACEHOLDER_RE.test(base)) continue;
+        if (PLACEHOLDER_RE.test(base) || PLACEHOLDER_CAMEL_RE.test(base)) continue;
         if (!seen.has(p)) seen.set(p, i + 1);
       }
     }
@@ -13293,317 +13296,326 @@ module.exports = { renderReportHtml, renderReportMarkdown, escapeHtml };
 
 // ── ./src/verify/hallucination-guard ──
 __factories["./src/verify/hallucination-guard"] = function(module, exports) {
-'use strict';
+  
+  /**
+   * Hallucination Guard — deterministic core (Reliable MVP, v6.15.0).
+   *
+   * Given the text of an AI answer, flag claims that do not match the repo:
+   *   - fake-file      : a referenced path is not on disk
+   *   - fake-test-file : a referenced *test* path is not on disk (sub-type)
+   *   - fake-import    : a relative import does not resolve; a bare import is
+   *                      absent from package.json deps (builtins allow-listed)
+   *   - fake-symbol    : a called function/class is absent from the symbol index
+   *   - fake-npm-script: `npm run X` where X is not a package.json script
+   *
+   * Each issue carries a `confidence` (detection certainty) and, where a near
+   * match exists, a heuristic `suggestion` ("Did you mean …?"). No network, no
+   * LLM. Reuses SigMap primitives (buildSigIndex) but every external dependency
+   * is injectable via `opts` so the core stays unit-testable.
+   */
 
-/**
- * Hallucination Guard — deterministic core (Reliable MVP, v6.15.0).
- *
- * Given the text of an AI answer, flag claims that do not match the repo:
- *   - fake-file      : a referenced path is not on disk
- *   - fake-test-file : a referenced *test* path is not on disk (sub-type)
- *   - fake-import    : a relative import does not resolve; a bare import is
- *                      absent from package.json deps (builtins allow-listed)
- *   - fake-symbol    : a called function/class is absent from the symbol index
- *   - fake-npm-script: `npm run X` where X is not a package.json script
- *
- * Each issue carries a `confidence` (detection certainty) and, where a near
- * match exists, a heuristic `suggestion` ("Did you mean …?"). No network, no
- * LLM. Reuses SigMap primitives (buildSigIndex) but every external dependency
- * is injectable via `opts` so the core stays unit-testable.
- */
+  const fs = require('fs');
+  const path = require('path');
+  const parsers = __require('./src/verify/parsers');
+  const { closestMatch, buildSymbolCandidates, formatSuggestion } = __require('./src/verify/closest-match');
 
-const fs = require('fs');
-const path = require('path');
-const parsers = __require('./src/verify/parsers');
-const { closestMatch, buildSymbolCandidates, formatSuggestion } = __require('./src/verify/closest-match');
+  // A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
+  // a tests/__tests__ directory). Used to flag fake-test-file separately.
+  const TEST_PATH_RE = /(?:\.(?:test|spec)\.[mc]?[jt]sx?$)|(?:(?:^|\/)__tests__\/)|(?:(?:^|\/)test_[^/]+\.py$)|(?:_test\.py$)|(?:(?:^|\/)tests?\/)/i;
+  function isTestPath(p) { return TEST_PATH_RE.test(p); }
 
-// A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
-// a tests/__tests__ directory). Used to flag fake-test-file separately.
-const TEST_PATH_RE = /(?:\.(?:test|spec)\.[mc]?[jt]sx?$)|(?:(?:^|\/)__tests__\/)|(?:(?:^|\/)test_[^/]+\.py$)|(?:_test\.py$)|(?:(?:^|\/)tests?\/)/i;
-function isTestPath(p) { return TEST_PATH_RE.test(p); }
+  const NODE_BUILTINS = new Set([
+    'fs', 'path', 'os', 'util', 'events', 'stream', 'http', 'https', 'crypto',
+    'child_process', 'url', 'querystring', 'assert', 'zlib', 'readline', 'net',
+    'tls', 'dns', 'buffer', 'process', 'vm', 'module', 'console', 'timers',
+    'string_decoder', 'perf_hooks', 'worker_threads', 'cluster', 'dgram', 'v8',
+    'tty', 'repl', 'async_hooks', 'inspector', 'fs/promises', 'path/posix',
+  ]);
 
-const NODE_BUILTINS = new Set([
-  'fs', 'path', 'os', 'util', 'events', 'stream', 'http', 'https', 'crypto',
-  'child_process', 'url', 'querystring', 'assert', 'zlib', 'readline', 'net',
-  'tls', 'dns', 'buffer', 'process', 'vm', 'module', 'console', 'timers',
-  'string_decoder', 'perf_hooks', 'worker_threads', 'cluster', 'dgram', 'v8',
-  'tty', 'repl', 'async_hooks', 'inspector', 'fs/promises', 'path/posix',
-]);
+  const PY_BUILTINS = new Set([
+    'os', 'sys', 're', 'json', 'math', 'typing', 'collections', 'itertools',
+    'functools', 'datetime', 'pathlib', 'subprocess', 'abc', 'dataclasses',
+    'enum', 'io', 'time', 'random', 'logging', 'argparse', 'unittest', 'asyncio',
+    'copy', 'hashlib', 'threading', 'string', 'csv', 'glob', 'shutil', 'tempfile',
+  ]);
 
-const PY_BUILTINS = new Set([
-  'os', 'sys', 're', 'json', 'math', 'typing', 'collections', 'itertools',
-  'functools', 'datetime', 'pathlib', 'subprocess', 'abc', 'dataclasses',
-  'enum', 'io', 'time', 'random', 'logging', 'argparse', 'unittest', 'asyncio',
-  'copy', 'hashlib', 'threading', 'string', 'csv', 'glob', 'shutil', 'tempfile',
-]);
+  const LANG_GLOBALS = new Set([
+    // JS
+    'console', 'require', 'module', 'exports', 'process', 'Object', 'Array',
+    'String', 'Number', 'Boolean', 'Math', 'JSON', 'Date', 'Promise', 'Map',
+    'Set', 'WeakMap', 'WeakSet', 'RegExp', 'Error', 'Symbol', 'parseInt',
+    'parseFloat', 'isNaN', 'setTimeout', 'setInterval', 'clearTimeout', 'fetch',
+    'Buffer', 'Function', 'eval', 'encodeURIComponent', 'decodeURIComponent',
+    // Python
+    'print', 'len', 'range', 'str', 'int', 'float', 'dict', 'list', 'tuple',
+    'set', 'bool', 'open', 'enumerate', 'zip', 'map', 'filter', 'sorted',
+    'sum', 'min', 'max', 'abs', 'isinstance', 'super', 'type', 'getattr',
+    'setattr', 'hasattr',
+  ]);
 
-const LANG_GLOBALS = new Set([
-  // JS
-  'console', 'require', 'module', 'exports', 'process', 'Object', 'Array',
-  'String', 'Number', 'Boolean', 'Math', 'JSON', 'Date', 'Promise', 'Map',
-  'Set', 'WeakMap', 'WeakSet', 'RegExp', 'Error', 'Symbol', 'parseInt',
-  'parseFloat', 'isNaN', 'setTimeout', 'setInterval', 'clearTimeout', 'fetch',
-  'Buffer', 'Function', 'eval', 'encodeURIComponent', 'decodeURIComponent',
-  // Python
-  'print', 'len', 'range', 'str', 'int', 'float', 'dict', 'list', 'tuple',
-  'set', 'bool', 'open', 'enumerate', 'zip', 'map', 'filter', 'sorted',
-  'sum', 'min', 'max', 'abs', 'isinstance', 'super', 'type', 'getattr',
-  'setattr', 'hasattr',
-]);
+  const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
+  const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
 
-const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
-const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
+  // Obvious documentation-placeholder imports the model writes in illustrative
+  // snippets — not real dependency claims. e.g. @scope/utils, some-module, ./local-file.
+  const PLACEHOLDER_IMPORT_RE = new RegExp([
+    '^@(?:scope|org|your-org|my-org|company|example)(?:/|$)', // @scope/utils
+    '(?:^|/)(?:some|your|my)-(?:module|package|lib|component|file|dep)(?:$|/)', // some-module
+    '(?:^|/)(?:local-file|your-file|my-file|module-name|package-name|your-package|example-package)(?:$|/)',
+    '(?:^|/)path/to/', // ./path/to/x
+  ].join('|'), 'i');
 
-/**
- * Build the set of known symbol identifiers from the SigMap signature index,
- * plus `{ name, file, line }` candidates (for closest-match suggestions).
- */
-function buildSymbolSet(cwd) {
-  const set = new Set();
-  let fileKeys = [];
-  let symbolCandidates = [];
-  try {
-    const { buildSigIndex } = __require('./src/retrieval/ranker');
-    const idx = buildSigIndex(cwd);
-    fileKeys = [...idx.keys()];
-    for (const sigs of idx.values()) {
-      for (const sig of sigs) {
-        const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
-        const ids = cleaned.match(/[A-Za-z_$][\w$]*/g) || [];
-        for (const id of ids) set.add(id);
-      }
-    }
-    symbolCandidates = buildSymbolCandidates(idx);
-  } catch (_) {}
-  return { set, fileKeys, symbolCandidates };
-}
-
-/** Load declared dependency names from package.json. */
-function loadDeps(cwd) {
-  const deps = new Set();
-  let hasPkg = false;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
-    hasPkg = true;
-    for (const k of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
-      if (pkg[k] && typeof pkg[k] === 'object') {
-        for (const name of Object.keys(pkg[k])) deps.add(name);
-      }
-    }
-  } catch (_) {}
-  return { deps, hasPkg };
-}
-
-/** Load the set of npm script names declared in package.json. */
-function loadScripts(cwd) {
-  const scripts = new Set();
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
-    if (pkg.scripts && typeof pkg.scripts === 'object') {
-      for (const name of Object.keys(pkg.scripts)) scripts.add(name);
-    }
-  } catch (_) {}
-  return scripts;
-}
-
-/** Default file-existence check: resolve a referenced path against cwd. */
-function defaultFileExists(cwd, ref) {
-  const clean = ref.replace(/^\.\//, '');
-  for (const c of [path.resolve(cwd, clean), path.resolve(cwd, ref)]) {
+  /**
+   * Build the set of known symbol identifiers from the SigMap signature index,
+   * plus `{ name, file, line }` candidates (for closest-match suggestions).
+   */
+  function buildSymbolSet(cwd) {
+    const set = new Set();
+    let fileKeys = [];
+    let symbolCandidates = [];
     try {
-      if (fs.existsSync(c)) return true;
-    } catch (_) {}
-  }
-  return false;
-}
-
-/** Default relative-import resolver: fs candidates + basename match in index. */
-function defaultRelativeResolvable(cwd, mod, fileBasenames) {
-  const base = path.resolve(cwd, mod);
-  for (const e of REL_EXTS) {
-    try {
-      if (fs.existsSync(base + e)) return true;
-    } catch (_) {}
-  }
-  for (const idx of REL_INDEX) {
-    try {
-      if (fs.existsSync(path.join(base, idx))) return true;
-    } catch (_) {}
-  }
-  // Fall back to basename match against the indexed file set (the answer's
-  // import is relative to a file we cannot know, so a name match is enough
-  // to avoid false positives).
-  const wantBase = path.basename(mod).replace(/\.[^.]+$/, '').toLowerCase();
-  return fileBasenames.has(wantBase);
-}
-
-/**
- * Verify an AI answer against the repository.
- *
- * Each issue has the shape:
- *   { type, value, line, location, message, confidence, suggestion }
- * where `confidence` is the *detection* certainty ('high' for path/dep/script
- * checks, 'medium' for symbol checks) and `suggestion` is a heuristic
- * closest-match hint (or null).
- *
- * @param {string} answerText
- * @param {string} cwd
- * @param {object} [opts]
- * @param {Set<string>} [opts.symbolSet]      override known symbols
- * @param {Array}       [opts.symbolCandidates] override { name, file, line } list
- * @param {Array<string>} [opts.fileCandidates]  override repo file paths (suggestions)
- * @param {Set<string>} [opts.deps]           override package deps
- * @param {Set<string>} [opts.scripts]        override package.json script names
- * @param {boolean}     [opts.hasPkg]         whether a package.json exists
- * @param {(ref: string) => boolean} [opts.fileExists]          override file check
- * @param {(mod: string) => boolean} [opts.relativeResolvable]  override rel-import check
- * @returns {{ issues: object[], summary: object }}
- */
-function verify(answerText, cwd, opts = {}) {
-  let symbolSet = opts.symbolSet;
-  let fileBasenames = opts.fileBasenames;
-  let symbolCandidates = opts.symbolCandidates || [];
-  let fileCandidates = opts.fileCandidates || [];
-  if (!symbolSet) {
-    const built = buildSymbolSet(cwd);
-    symbolSet = built.set;
-    fileBasenames = new Set(built.fileKeys.map(
-      (k) => path.basename(k).replace(/\.[^.]+$/, '').toLowerCase()
-    ));
-    symbolCandidates = built.symbolCandidates;
-    fileCandidates = built.fileKeys;
-  }
-  if (!fileBasenames) fileBasenames = new Set();
-
-  let deps = opts.deps;
-  let hasPkg = opts.hasPkg;
-  if (!deps) {
-    const loaded = loadDeps(cwd);
-    deps = loaded.deps;
-    if (hasPkg === undefined) hasPkg = loaded.hasPkg;
-  }
-  const scripts = opts.scripts || (hasPkg ? loadScripts(cwd) : new Set());
-
-  const fileExists = opts.fileExists || ((ref) => defaultFileExists(cwd, ref));
-  const relativeResolvable = opts.relativeResolvable
-    || ((mod) => defaultRelativeResolvable(cwd, mod, fileBasenames));
-
-  // Pre-derive basename candidates for file suggestions (compare on basename so
-  // a wrong directory still surfaces the right file).
-  const fileBasenameCandidates = fileCandidates.map((f) => ({ name: path.basename(f), file: f }));
-
-  const issues = [];
-  const dedupe = new Set();
-  const add = (issue) => {
-    const key = `${issue.type}::${issue.value}`;
-    if (dedupe.has(key)) return;
-    dedupe.add(key);
-    if (!('suggestion' in issue)) issue.suggestion = null;
-    issue.location = `L${issue.line}`;
-    issues.push(issue);
-  };
-
-  // 1. fake-file / fake-test-file
-  for (const { path: p, line } of parsers.extractFilePaths(answerText)) {
-    if (fileExists(p)) continue;
-    const isTest = isTestPath(p);
-    const match = closestMatch(path.basename(p), fileBasenameCandidates, { minLen: 4 });
-    add({
-      type: isTest ? 'fake-test-file' : 'fake-file',
-      value: p,
-      line,
-      message: `${isTest ? 'Test file' : 'File'} not found on disk: ${p}`,
-      confidence: 'high',
-      suggestion: match ? formatSuggestion(match, false) : null,
-    });
-  }
-
-  // 2. fake-import
-  for (const imp of parsers.extractImports(answerText)) {
-    if (imp.relative) {
-      if (!relativeResolvable(imp.module)) {
-        add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}`, confidence: 'high' });
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const idx = buildSigIndex(cwd);
+      fileKeys = [...idx.keys()];
+      for (const sigs of idx.values()) {
+        for (const sig of sigs) {
+          const cleaned = String(sig).replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+          const ids = cleaned.match(/[A-Za-z_$][\w$]*/g) || [];
+          for (const id of ids) set.add(id);
+        }
       }
-      continue;
+      symbolCandidates = buildSymbolCandidates(idx);
+    } catch (_) {}
+    return { set, fileKeys, symbolCandidates };
+  }
+
+  /** Load declared dependency names from package.json. */
+  function loadDeps(cwd) {
+    const deps = new Set();
+    let hasPkg = false;
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      hasPkg = true;
+      for (const k of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+        if (pkg[k] && typeof pkg[k] === 'object') {
+          for (const name of Object.keys(pkg[k])) deps.add(name);
+        }
+      }
+    } catch (_) {}
+    return { deps, hasPkg };
+  }
+
+  /** Load the set of npm script names declared in package.json. */
+  function loadScripts(cwd) {
+    const scripts = new Set();
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      if (pkg.scripts && typeof pkg.scripts === 'object') {
+        for (const name of Object.keys(pkg.scripts)) scripts.add(name);
+      }
+    } catch (_) {}
+    return scripts;
+  }
+
+  /** Default file-existence check: resolve a referenced path against cwd. */
+  function defaultFileExists(cwd, ref) {
+    const clean = ref.replace(/^\.\//, '');
+    for (const c of [path.resolve(cwd, clean), path.resolve(cwd, ref)]) {
+      try {
+        if (fs.existsSync(c)) return true;
+      } catch (_) {}
     }
-    // Bare module — only verifiable for JS when a package.json exists.
-    const top = imp.module.split('/')[0];
-    if (imp.kind === 'js') {
-      if (!hasPkg) continue;
-      if (NODE_BUILTINS.has(imp.module) || NODE_BUILTINS.has(top)) continue;
-      if (top.startsWith('@')) {
-        const scoped = imp.module.split('/').slice(0, 2).join('/');
-        if (deps.has(scoped) || deps.has(imp.module)) continue;
-      } else if (deps.has(top) || deps.has(imp.module)) {
+    return false;
+  }
+
+  /** Default relative-import resolver: fs candidates + basename match in index. */
+  function defaultRelativeResolvable(cwd, mod, fileBasenames) {
+    const base = path.resolve(cwd, mod);
+    for (const e of REL_EXTS) {
+      try {
+        if (fs.existsSync(base + e)) return true;
+      } catch (_) {}
+    }
+    for (const idx of REL_INDEX) {
+      try {
+        if (fs.existsSync(path.join(base, idx))) return true;
+      } catch (_) {}
+    }
+    // Fall back to basename match against the indexed file set (the answer's
+    // import is relative to a file we cannot know, so a name match is enough
+    // to avoid false positives).
+    const wantBase = path.basename(mod).replace(/\.[^.]+$/, '').toLowerCase();
+    return fileBasenames.has(wantBase);
+  }
+
+  /**
+   * Verify an AI answer against the repository.
+   *
+   * Each issue has the shape:
+   *   { type, value, line, location, message, confidence, suggestion }
+   * where `confidence` is the *detection* certainty ('high' for path/dep/script
+   * checks, 'medium' for symbol checks) and `suggestion` is a heuristic
+   * closest-match hint (or null).
+   *
+   * @param {string} answerText
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {Set<string>} [opts.symbolSet]      override known symbols
+   * @param {Array}       [opts.symbolCandidates] override { name, file, line } list
+   * @param {Array<string>} [opts.fileCandidates]  override repo file paths (suggestions)
+   * @param {Set<string>} [opts.deps]           override package deps
+   * @param {Set<string>} [opts.scripts]        override package.json script names
+   * @param {boolean}     [opts.hasPkg]         whether a package.json exists
+   * @param {(ref: string) => boolean} [opts.fileExists]          override file check
+   * @param {(mod: string) => boolean} [opts.relativeResolvable]  override rel-import check
+   * @returns {{ issues: object[], summary: object }}
+   */
+  function verify(answerText, cwd, opts = {}) {
+    let symbolSet = opts.symbolSet;
+    let fileBasenames = opts.fileBasenames;
+    let symbolCandidates = opts.symbolCandidates || [];
+    let fileCandidates = opts.fileCandidates || [];
+    if (!symbolSet) {
+      const built = buildSymbolSet(cwd);
+      symbolSet = built.set;
+      fileBasenames = new Set(built.fileKeys.map(
+        (k) => path.basename(k).replace(/\.[^.]+$/, '').toLowerCase()
+      ));
+      symbolCandidates = built.symbolCandidates;
+      fileCandidates = built.fileKeys;
+    }
+    if (!fileBasenames) fileBasenames = new Set();
+
+    let deps = opts.deps;
+    let hasPkg = opts.hasPkg;
+    if (!deps) {
+      const loaded = loadDeps(cwd);
+      deps = loaded.deps;
+      if (hasPkg === undefined) hasPkg = loaded.hasPkg;
+    }
+    const scripts = opts.scripts || (hasPkg ? loadScripts(cwd) : new Set());
+
+    const fileExists = opts.fileExists || ((ref) => defaultFileExists(cwd, ref));
+    const relativeResolvable = opts.relativeResolvable
+      || ((mod) => defaultRelativeResolvable(cwd, mod, fileBasenames));
+
+    // Pre-derive basename candidates for file suggestions (compare on basename so
+    // a wrong directory still surfaces the right file).
+    const fileBasenameCandidates = fileCandidates.map((f) => ({ name: path.basename(f), file: f }));
+
+    const issues = [];
+    const dedupe = new Set();
+    const add = (issue) => {
+      const key = `${issue.type}::${issue.value}`;
+      if (dedupe.has(key)) return;
+      dedupe.add(key);
+      if (!('suggestion' in issue)) issue.suggestion = null;
+      issue.location = `L${issue.line}`;
+      issues.push(issue);
+    };
+
+    // 1. fake-file / fake-test-file
+    for (const { path: p, line } of parsers.extractFilePaths(answerText)) {
+      if (fileExists(p)) continue;
+      const isTest = isTestPath(p);
+      const match = closestMatch(path.basename(p), fileBasenameCandidates, { minLen: 4 });
+      add({
+        type: isTest ? 'fake-test-file' : 'fake-file',
+        value: p,
+        line,
+        message: `${isTest ? 'Test file' : 'File'} not found on disk: ${p}`,
+        confidence: 'high',
+        suggestion: match ? formatSuggestion(match, false) : null,
+      });
+    }
+
+    // 2. fake-import
+    for (const imp of parsers.extractImports(answerText)) {
+      if (PLACEHOLDER_IMPORT_RE.test(imp.module)) continue;
+      if (imp.relative) {
+        if (!relativeResolvable(imp.module)) {
+          add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}`, confidence: 'high' });
+        }
         continue;
       }
-      const match = closestMatch(top, [...deps], { minLen: 3 });
-      add({
-        type: 'fake-import',
-        value: imp.module,
-        line: imp.line,
-        message: `Package not in dependencies: ${imp.module}`,
-        confidence: 'high',
-        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
-      });
+      // Bare module — only verifiable for JS when a package.json exists.
+      const top = imp.module.split('/')[0];
+      if (imp.kind === 'js') {
+        if (!hasPkg) continue;
+        if (NODE_BUILTINS.has(imp.module) || NODE_BUILTINS.has(top)) continue;
+        if (top.startsWith('@')) {
+          const scoped = imp.module.split('/').slice(0, 2).join('/');
+          if (deps.has(scoped) || deps.has(imp.module)) continue;
+        } else if (deps.has(top) || deps.has(imp.module)) {
+          continue;
+        }
+        const match = closestMatch(top, [...deps], { minLen: 3 });
+        add({
+          type: 'fake-import',
+          value: imp.module,
+          line: imp.line,
+          message: `Package not in dependencies: ${imp.module}`,
+          confidence: 'high',
+          suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+        });
+      }
+      // Python bare imports: stdlib is unbounded offline — skip to keep precision.
     }
-    // Python bare imports: stdlib is unbounded offline — skip to keep precision.
+
+    // 3. fake-symbol
+    if (symbolSet.size > 0) {
+      for (const { name, line } of parsers.extractSymbols(answerText)) {
+        if (symbolSet.has(name)) continue;
+        if (LANG_GLOBALS.has(name) || NODE_BUILTINS.has(name) || PY_BUILTINS.has(name)) continue;
+        const match = closestMatch(name, symbolCandidates, { minLen: 4 });
+        add({
+          type: 'fake-symbol',
+          value: name,
+          line,
+          message: `Symbol not found in repo index: ${name}()`,
+          confidence: 'medium',
+          suggestion: match ? formatSuggestion(match, true) : null,
+        });
+      }
+    }
+
+    // 4. fake-npm-script
+    if (hasPkg && scripts.size > 0) {
+      for (const { name, line } of parsers.extractNpmScripts(answerText)) {
+        if (scripts.has(name)) continue;
+        const match = closestMatch(name, [...scripts], { minLen: 2 });
+        add({
+          type: 'fake-npm-script',
+          value: name,
+          line,
+          message: `npm script not in package.json: ${name}`,
+          confidence: 'high',
+          suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
+        });
+      }
+    }
+
+    issues.sort((a, b) => a.line - b.line);
+
+    const byType = {
+      'fake-file': 0, 'fake-test-file': 0, 'fake-import': 0,
+      'fake-symbol': 0, 'fake-npm-script': 0,
+    };
+    for (const i of issues) byType[i.type] = (byType[i.type] || 0) + 1;
+
+    const summary = {
+      total: issues.length,
+      byType,
+      clean: issues.length === 0,
+      symbolsIndexed: symbolSet.size,
+      withSuggestion: issues.filter((i) => i.suggestion).length,
+    };
+
+    return { issues, summary };
   }
 
-  // 3. fake-symbol
-  if (symbolSet.size > 0) {
-    for (const { name, line } of parsers.extractSymbols(answerText)) {
-      if (symbolSet.has(name)) continue;
-      if (LANG_GLOBALS.has(name) || NODE_BUILTINS.has(name) || PY_BUILTINS.has(name)) continue;
-      const match = closestMatch(name, symbolCandidates, { minLen: 4 });
-      add({
-        type: 'fake-symbol',
-        value: name,
-        line,
-        message: `Symbol not found in repo index: ${name}()`,
-        confidence: 'medium',
-        suggestion: match ? formatSuggestion(match, true) : null,
-      });
-    }
-  }
-
-  // 4. fake-npm-script
-  if (hasPkg && scripts.size > 0) {
-    for (const { name, line } of parsers.extractNpmScripts(answerText)) {
-      if (scripts.has(name)) continue;
-      const match = closestMatch(name, [...scripts], { minLen: 2 });
-      add({
-        type: 'fake-npm-script',
-        value: name,
-        line,
-        message: `npm script not in package.json: ${name}`,
-        confidence: 'high',
-        suggestion: match ? formatSuggestion({ name: match.name }, false) : null,
-      });
-    }
-  }
-
-  issues.sort((a, b) => a.line - b.line);
-
-  const byType = {
-    'fake-file': 0, 'fake-test-file': 0, 'fake-import': 0,
-    'fake-symbol': 0, 'fake-npm-script': 0,
-  };
-  for (const i of issues) byType[i.type] = (byType[i.type] || 0) + 1;
-
-  const summary = {
-    total: issues.length,
-    byType,
-    clean: issues.length === 0,
-    symbolsIndexed: symbolSet.size,
-    withSuggestion: issues.filter((i) => i.suggestion).length,
-  };
-
-  return { issues, summary };
-}
-
-module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath };
-
+  module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath };
+  
 };
 
 const fs = require('fs');

--- a/src/verify/hallucination-guard.js
+++ b/src/verify/hallucination-guard.js
@@ -59,6 +59,15 @@ const LANG_GLOBALS = new Set([
 const REL_EXTS = ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.json', '.py', '.r', '.R', '.vue'];
 const REL_INDEX = ['index.js', 'index.ts', 'index.tsx', 'index.jsx', '__init__.py'];
 
+// Obvious documentation-placeholder imports the model writes in illustrative
+// snippets — not real dependency claims. e.g. @scope/utils, some-module, ./local-file.
+const PLACEHOLDER_IMPORT_RE = new RegExp([
+  '^@(?:scope|org|your-org|my-org|company|example)(?:/|$)', // @scope/utils
+  '(?:^|/)(?:some|your|my)-(?:module|package|lib|component|file|dep)(?:$|/)', // some-module
+  '(?:^|/)(?:local-file|your-file|my-file|module-name|package-name|your-package|example-package)(?:$|/)',
+  '(?:^|/)path/to/', // ./path/to/x
+].join('|'), 'i');
+
 /**
  * Build the set of known symbol identifiers from the SigMap signature index,
  * plus `{ name, file, line }` candidates (for closest-match suggestions).
@@ -225,6 +234,7 @@ function verify(answerText, cwd, opts = {}) {
 
   // 2. fake-import
   for (const imp of parsers.extractImports(answerText)) {
+    if (PLACEHOLDER_IMPORT_RE.test(imp.module)) continue;
     if (imp.relative) {
       if (!relativeResolvable(imp.module)) {
         add({ type: 'fake-import', value: imp.module, line: imp.line, message: `Import does not resolve: ${imp.module}`, confidence: 'high' });

--- a/src/verify/parsers.js
+++ b/src/verify/parsers.js
@@ -30,7 +30,10 @@ const LIBRARY_TOKENS = new Set([
 
 // Illustrative placeholder names the model writes in prose, not repo claims:
 // e.g. example.js, minimal-example.js, sample.ts, demo.js, placeholder.js.
-const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|$)/i;
+const PLACEHOLDER_RE = /(?:^|[-_.])(?:example|sample|demo|placeholder)(?:[-_.]|s?$)/i;
+// camelCase / Pascal placeholders: myExample.js, exampleConfig.js, fooSample.ts.
+// Requires a case boundary so ordinary words (resample.js) are NOT suppressed.
+const PLACEHOLDER_CAMEL_RE = /(?:^|[a-z])(?:Example|Sample|Demo|Placeholder)|(?:^|[-_.])(?:example|sample|demo|placeholder)(?=[A-Z])/;
 
 /**
  * Extract fenced code blocks.
@@ -86,7 +89,7 @@ function extractFilePaths(text) {
       if (!hasSlash && !KNOWN_CODE_EXT.has(ext)) continue;
       if (LIBRARY_TOKENS.has(p.toLowerCase())) continue;
       const base = p.split('/').pop();
-      if (PLACEHOLDER_RE.test(base)) continue;
+      if (PLACEHOLDER_RE.test(base) || PLACEHOLDER_CAMEL_RE.test(base)) continue;
       if (!seen.has(p)) seen.set(p, i + 1);
     }
   }

--- a/test/integration/verify-ai-output.test.js
+++ b/test/integration/verify-ai-output.test.js
@@ -80,6 +80,16 @@ test('extractFilePaths skips illustrative placeholder filenames', () => {
   }
 });
 
+test('extractFilePaths skips camelCase/Pascal placeholders, keeps ordinary words', () => {
+  const text = 'Save `myExample.js` and `exampleConfig.ts` and `fooSample.js`; but `resample.js` and `src/foo/bar.js` are real.';
+  const paths = parsers.extractFilePaths(text).map((p) => p.path);
+  for (const ph of ['myExample.js', 'exampleConfig.ts', 'fooSample.js']) {
+    assert.ok(!paths.includes(ph), `should not flag camelCase placeholder ${ph}`);
+  }
+  assert.ok(paths.includes('resample.js'), 'resample.js is an ordinary word — must still extract');
+  assert.ok(paths.includes('src/foo/bar.js'), 'genuine path must still extract');
+});
+
 test('extractFilePaths still extracts genuine repo-shaped paths (no over-suppression)', () => {
   const text = 'Edit `src/foo/bar.js`, `src/config/loader.js`, `main.js`, and `index.ts`.';
   const paths = parsers.extractFilePaths(text).map((p) => p.path);
@@ -148,6 +158,20 @@ test('fake-import flagged for unresolved relative + missing bare package', () =>
   const { issues } = verify(text, '/x', baseOpts);
   const imps = issues.filter((i) => i.type === 'fake-import').map((i) => i.value).sort();
   assert.deepStrictEqual(imps, ['./nope', 'ghost-pkg']);
+});
+
+test('fake-import skips doc-placeholder imports, still flags genuine ones', () => {
+  const text = [
+    "import a from '@scope/utils';",   // placeholder scope → skip
+    "import b from 'some-module';",    // placeholder bare → skip
+    "import c from './local-file';",   // placeholder relative → skip
+    "import d from './path/to/thing';",// placeholder path → skip
+    "import e from 'ghost-pkg';",      // genuine missing dep → flag
+    "import f from './nope';",         // genuine unresolved relative → flag
+  ].join('\n');
+  const { issues } = verify(text, '/x', baseOpts);
+  const imps = issues.filter((i) => i.type === 'fake-import').map((i) => i.value).sort();
+  assert.deepStrictEqual(imps, ['./nope', 'ghost-pkg'], 'only genuine imports flagged');
 });
 
 test('fake-symbol flagged for unknown symbol; real symbol passes', () => {


### PR DESCRIPTION
## Summary
- Clears the **two remaining** `verify-ai-output` false-positive classes surfaced by the §9 ablation re-run after #347 · closes #350
- In that run grounding genuinely fixed **6 mis-path flags**, but the guard re-flagged **4 illustrative tokens** (net +2). Suppressing those 4 exposes the true ~+6 grounding delta.

## Changes
- `src/verify/parsers.js` — `extractFilePaths` also skips camelCase/Pascal placeholders (`myExample.js`, `exampleConfig.ts`) via a case-boundary rule; ordinary words (`resample.js`) and genuine paths still flag.
- `src/verify/hallucination-guard.js` — `fake-import` skips obvious documentation placeholders (`@scope/utils`, `some-module`, `./local-file`, `./path/to/...`); genuine missing packages / unresolved relatives still flag.
- `gen-context.js` — regenerated bundled factories for both modules (standalone-binary parity).
- `test/integration/verify-ai-output.test.js` — +2 tests.

## Test plan
- [x] `node test/integration/verify-ai-output.test.js` — 35 passed
- [x] `node test/integration/all.js` — 90 passed, 0 failed
- [x] `node scripts/check-bundle.mjs` — all factories present
- [x] Supply-chain local audit — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)