### PR TITLE
docs: add StarMapper stargazer-map badge + link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Zero deps](https://img.shields.io/badge/dependencies-zero-22c55e)](package.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-7c6af7.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/manojmallick/sigmap?style=flat&color=f59e0b&logo=github)](https://github.com/manojmallick/sigmap/stargazers)
+[![Stargazer map](https://img.shields.io/badge/StarMapper-view%20star%20map-7c6af7?logo=googlemaps&logoColor=white)](https://starmapper.bruniaux.com/manojmallick/sigmap)
 [![Star History Chart](https://api.star-history.com/svg?repos=manojmallick/sigmap&type=Date)](https://star-history.com/#manojmallick/sigmap&Date)
 [![Discover on ShyPD](https://img.shields.io/badge/ShyPD-Discover-7c6af7?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij48Y2lyY2xlIGN4PSI4IiBjeT0iOCIgcj0iOCIgZmlsbD0id2hpdGUiLz48L3N2Zz4=&logoColor=7c6af7)](https://shypd.ai/tools/sigmap)
 
@@ -240,6 +241,8 @@ sigmap --health
 ## Support
 
 If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/manojmallick/sigmap) helps others find it.
+
+🌍 See where SigMap's stargazers are around the world on the **[StarMapper star map →](https://starmapper.bruniaux.com/manojmallick/sigmap)**.
 
 [Report an issue](https://github.com/manojmallick/sigmap/issues) · [Changelog](CHANGELOG.md)
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -201,5 +201,6 @@ Latest saved benchmark run: **2026-06-19 (v7.24.0)**.
 - Want the core daily flow: [ask](/guide/ask), [validate](/guide/validate), [judge](/guide/judge), [learning](/guide/learning)
 - Using Claude Code or Cursor: [MCP setup](/guide/mcp)
 - Evaluating the launch claims: [Benchmark overview](/guide/benchmark)
+- 🌍 See the community: [where SigMap's stargazers are around the world](https://starmapper.bruniaux.com/manojmallick/sigmap)
 
 </div>

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -121,6 +121,13 @@ test('workflow: Ask → Rank → Context → Validate → Judge → Learn', () =
   assert.ok(src.includes('Ask → Rank') || src.includes('Ask →'), 'workflow not in arrow format');
 });
 
+// ── Community ────────────────────────────────────────────────────────────────
+
+test('community: StarMapper stargazer-map link present', () => {
+  assert.ok(src.includes('https://starmapper.bruniaux.com/manojmallick/sigmap'),
+    'missing StarMapper star-map link');
+});
+
 // ── Section 7: Benchmark ─────────────────────────────────────────────────────
 
 test('benchmark: sigmap-v7.0-main ID present', () => {


### PR DESCRIPTION
## Summary
- Surface the StarMapper stargazer map (517 stars · 37 countries) in the docs · closes #360

## Changes
- `README.md` — StarMapper shields.io badge in the badge row + a 🌍 "stargazers around the world" line in **Support**.
- `docs-vp/index.md` — community link under "Where to go next".
- `test/integration/features/readme-structure.test.js` — assert the StarMapper URL is present.

Note: starmapper.bruniaux.com is a client-rendered SPA with no verifiable badge endpoint, so we use a reliable shields.io static badge linking to the map rather than embedding an unverifiable image.

## Test plan
- [x] `node test/integration/features/readme-structure.test.js` — 52 passed
- [x] `node test/integration/all.js` — 90 passed, 0 failed
- [x] supply-chain: docs/test only — published surface untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)