### PR TITLE
release: v7.24.2 — StarMapper stargazer map in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Format: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [7.24.2] — 2026-06-19
+
+Patch release — surface the StarMapper stargazer map in the docs.
+
+### Added
+- **StarMapper stargazer-map badge + link (#360):** the README badge row gains a StarMapper badge and the Support section a "stargazers around the world" link; the docs site adds a community link — all pointing to the [StarMapper map](https://starmapper.bruniaux.com/manojmallick/sigmap) (517 stars across 37 countries). StarMapper is a client-rendered SPA with no verifiable badge endpoint, so a reliable shields.io static badge links to the map rather than embedding an unverifiable image. A README-structure test pins the StarMapper URL.
+
+---
+
 ## [7.24.1] — 2026-06-19
 
 Patch release — publish the first measured §9 grounding result.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,9 @@ To ensure proper attribution:
 
 We welcome contributions! See [Contributing](./docs/CONTRIBUTING.md) for guidelines.
 
+### Recent Contributors (v7.24.2)
+- **@manojmallick** — docs: surface the StarMapper stargazer map (517 stars · 37 countries) — README badge + Support link, docs community link, README-structure test (#360, PR #361)
+
 ### Recent Contributors (v7.24.1)
 - **@manojmallick** — docs: publish the first measured §9 grounding result (`version.json` `ablation`) — 5×100 repo-fact tasks on Gemini: grounding cut flagged codebase-fact errors from 99.8 [99–100] to 0.2 [0–1] per 100 (factual-recall grounding)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Zero deps](https://img.shields.io/badge/dependencies-zero-22c55e)](package.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-7c6af7.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/manojmallick/sigmap?style=flat&color=f59e0b&logo=github)](https://github.com/manojmallick/sigmap/stargazers)
+[![Stargazer map](https://img.shields.io/badge/StarMapper-view%20star%20map-7c6af7?logo=googlemaps&logoColor=white)](https://starmapper.bruniaux.com/manojmallick/sigmap)
 [![Star History Chart](https://api.star-history.com/svg?repos=manojmallick/sigmap&type=Date)](https://star-history.com/#manojmallick/sigmap&Date)
 [![Discover on ShyPD](https://img.shields.io/badge/ShyPD-Discover-7c6af7?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij48Y2lyY2xlIGN4PSI4IiBjeT0iOCIgcj0iOCIgZmlsbD0id2hpdGUiLz48L3N2Zz4=&logoColor=7c6af7)](https://shypd.ai/tools/sigmap)
 
@@ -240,6 +241,8 @@ sigmap --health
 ## Support
 
 If SigMap saves you context or API spend, a ⭐ on [GitHub](https://github.com/manojmallick/sigmap) helps others find it.
+
+🌍 See where SigMap's stargazers are around the world on the **[StarMapper star map →](https://starmapper.bruniaux.com/manojmallick/sigmap)**.
 
 [Report an issue](https://github.com/manojmallick/sigmap/issues) · [Changelog](CHANGELOG.md)
 

--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -39,7 +39,7 @@ This is the landing page for the public benchmark story. It answers four differe
 
 ## Official v7.0.0 snapshot (with R language support)
 
-Latest saved benchmark run: **2026-06-19 (v7.24.0)**
+Latest saved benchmark run: **2026-06-19 (v7.24.2)**
 
 | Metric | Result |
 |---|---:|

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -34,7 +34,7 @@ Token reduction is the mechanism. This benchmark shows the operational consequen
 - how much code would be hidden without SigMap?
 - what does that mean for API cost?
 
-Latest saved run: **2026-06-19 (v7.24.0)**
+Latest saved run: **2026-06-19 (v7.24.2)**
 
 ## Headline numbers
 

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-19 (v7.24.0)**
+Latest saved run: **2026-06-19 (v7.24.2)**
 
 **Result:** SigMap finds the right file in the top 5 far more often than chance — **76% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 

--- a/docs-vp/guide/roadmap.md
+++ b/docs-vp/guide/roadmap.md
@@ -22,7 +22,7 @@ head:
 
 Sixty-eight versions shipped. MIT open source from day one.
 
-**Stats:** 97.0% overall token reduction · 1,174 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
+**Stats:** 97.0% overall token reduction · 1,175 tests passing · 15 MCP tools · 31 languages · 17-language source resolver · 0 npm deps
 
 ## Token reduction by version
 
@@ -825,6 +825,16 @@ Two milestones in one release. **`verify-ai-output` Reliable MVP** (#232) grows 
 **Tags:** `verify-ai-output` · `fake-test-file` · `fake-npm-script` · `closest-match` · `--report` · `note` · `status` · `read_memory` · `11 MCP tools` · `PR #232` · `PR #233`
 
 **Impact:** 5-detector Hallucination Guard + heuristic suggestions; 11 MCP tools (was 10); 42 new tests (29 verify + 13 memory); 949 tests passing.
+
+---
+
+### v7.24.2 — StarMapper stargazer map in the docs ✓ (2026-06-19)
+
+**Patch release — surface the community.** SigMap has 517 stars across 37 countries; the [StarMapper map](https://starmapper.bruniaux.com/manojmallick/sigmap) visualizes where. This release adds a StarMapper badge to the README badge row, a "stargazers around the world" link in Support, and a community link on the docs site. StarMapper is a client-rendered SPA with no verifiable badge endpoint, so a reliable shields.io static badge links to the map rather than embedding an unverifiable image; a README-structure test pins the URL.
+
+**Tags:** `docs` · `starmapper` · `community` · `badge`
+
+**Impact:** docs-only; +1 test (1,175 passing).
 
 ---
 

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-19 (v7.24.0)** — Now includes R language support (ggplot2, dplyr, shiny)
+Latest saved run: **2026-06-19 (v7.24.2)** — Now includes R language support (ggplot2, dplyr, shiny)
 
 This page answers the question people care about most:
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,9 +78,9 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.24.1</span>
+  <span><strong>Release:</strong> v7.24.2</span>
   <span>·</span>
-  <span>First measured §9 grounding result — with exact-signature grounding, fabricated file-location claims fell from <strong>99.8 → 0.2 per 100</strong> (5×100 repo-fact tasks, Gemini); factual-recall grounding</span>
+  <span>Docs: added the <a href="https://starmapper.bruniaux.com/manojmallick/sigmap">StarMapper</a> stargazer map (517 stars across 37 countries). Latest result still stands — §9 grounding cut fabricated file-location claims <strong>99.8 → 0.2 per 100</strong></span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
   <span><strong>Benchmark:</strong> sigmap-v7.0-main</span>
@@ -176,7 +176,7 @@ See the full [end-to-end walkthrough](/guide/walkthrough) to watch this in actio
 | Overall token reduction | — | **97.0%** |
 | GPT-4o overflow repos | 16/21 | **0/21** |
 
-Latest saved benchmark run: **2026-06-19 (v7.24.0)**.
+Latest saved benchmark run: **2026-06-19 (v7.24.2)**.
 
 </div>
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -201,5 +201,6 @@ Latest saved benchmark run: **2026-06-19 (v7.24.0)**.
 - Want the core daily flow: [ask](/guide/ask), [validate](/guide/validate), [judge](/guide/judge), [learning](/guide/learning)
 - Using Claude Code or Cursor: [MCP setup](/guide/mcp)
 - Evaluating the launch claims: [Benchmark overview](/guide/benchmark)
+- 🌍 See the community: [where SigMap's stargazers are around the world](https://starmapper.bruniaux.com/manojmallick/sigmap)
 
 </div>

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.1 | Benchmark: sigmap-v7.0-main (2026-06-19)
+# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.1 | Benchmark: sigmap-v7.0-main (2026-06-19)
+# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -8102,7 +8102,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const SERVER_INFO = {
     name: 'sigmap',
-    version: '7.24.1',
+    version: '7.24.2',
     description: 'SigMap MCP server — code signatures on demand',
   };
 
@@ -13805,7 +13805,7 @@ function __tryGit(args, opts = {}) {
   catch (_) { return ''; }
 }
 
-const VERSION = '7.24.1';
+const VERSION = '7.24.2';
 const MARKER = '\n\n## Auto-generated signatures\n<!-- Updated by gen-context.js -->\n';
 
 function requireSourceOrBundled(key) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.1 | Benchmark: sigmap-v7.0-main (2026-06-19)
+# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.1 | Benchmark: sigmap-v7.0-main (2026-06-19)
+# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
 # Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap",
-  "version": "7.24.1",
+  "version": "7.24.2",
   "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
   "main": "packages/core/index.js",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-cli",
-  "version": "7.24.1",
+  "version": "7.24.2",
   "description": "SigMap CLI wrapper — thin adapter for programmatic CLI invocation",
   "main": "index.js",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmap-core",
-  "version": "7.24.1",
+  "version": "7.24.2",
   "description": "SigMap core library — zero-dependency code signature extraction, retrieval, and security scanning",
   "main": "index.js",
   "keywords": [

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -18,7 +18,7 @@ const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, exp
 
 const SERVER_INFO = {
   name: 'sigmap',
-  version: '7.24.1',
+  version: '7.24.2',
   description: 'SigMap MCP server — code signatures on demand',
 };
 

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -121,6 +121,13 @@ test('workflow: Ask → Rank → Context → Validate → Judge → Learn', () =
   assert.ok(src.includes('Ask → Rank') || src.includes('Ask →'), 'workflow not in arrow format');
 });
 
+// ── Community ────────────────────────────────────────────────────────────────
+
+test('community: StarMapper stargazer-map link present', () => {
+  assert.ok(src.includes('https://starmapper.bruniaux.com/manojmallick/sigmap'),
+    'missing StarMapper star-map link');
+});
+
 // ── Section 7: Benchmark ─────────────────────────────────────────────────────
 
 test('benchmark: sigmap-v7.0-main ID present', () => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.24.1",
+  "version": "7.24.2",
   "benchmark_date": "2026-06-19",
   "benchmark_id": "sigmap-v7.0-main",
   "languages": 31,
@@ -26,9 +26,15 @@
     "tasks": 100,
     "runs": 5,
     "without_grounding_per_100_mean": 99.8,
-    "without_grounding_per_100_range": [99, 100],
+    "without_grounding_per_100_range": [
+      99,
+      100
+    ],
     "with_grounding_per_100_mean": 0.2,
-    "with_grounding_per_100_range": [0, 1],
+    "with_grounding_per_100_range": [
+      0,
+      1
+    ],
     "reduction_per_100_mean": 99.6,
     "note": "Factual-recall grounding: 'which file defines <name>?' The grounded arm is given exact signatures grouped by file; the ungrounded arm has no repo knowledge and fabricates a plausible-but-wrong path. Measures faithful use of provided context, not generative code correctness."
   }


### PR DESCRIPTION
## Summary
- Ship **v7.24.2** to `main` · surfaces the StarMapper stargazer map (517 stars across 37 countries) in the README + docs (#360/#361).

## Changes
- README StarMapper badge + Support link; docs index community link; README-structure test pins the URL.
- Docs/version: CHANGELOG 7.24.2, version sync (ablation block preserved), roadmap/index, benchmark matrix re-run (identical), saved-run tags → v7.24.2, llms.txt ×4.

## Test plan
- [x] `node test/integration/all.js` — 90 passed, 0 failed
- [x] benchmark matrix re-run — 97.0% token · 75.6% hit@5 · 39.4% prompt reduction