### PR TITLE
chore(trust): single source of benchmark truth + truthful version.json (H1+H3, #363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Bundle integrity (src/ modules present in gen-context.js __factories)
         run: node scripts/check-bundle.mjs
+      - name: Metrics single-source-of-truth (latest.json → version.json + README)
+        run: npm run check:metrics
       - name: Run unit tests
         run: node test/run.js
       - name: Run integration tests

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ SigMap extracts function and class signatures from your codebase and feeds the r
 
 ## Why SigMap?
 
-- **75.6% hit@5** — right file found in top 5 results (vs 13.6% baseline)
-- **97.0% token reduction** — average across 21 real repos
-- **52.2% task success rate** — up from 10% without context
-- **1.72 prompts per task** — down from 2.84 (39.4% fewer retries)
-- **31 languages supported** — TypeScript, Python, Go, Rust, Java, R, and 25 others
+<!--SM:whyMetrics-->
+- **81.1% hit@5** — right file found in top 5 results (vs 13.6% baseline)
+- **96.5% token reduction** — average across 21 real repos
+- **53.3% task success rate** — up from 10% without context
+- **1.66 prompts per task** — down from 2.84 (41.8% fewer retries)
+<!--/SM:whyMetrics-->
+- **<!--SM:languages-->33<!--/SM:languages--> languages supported** — TypeScript, Python, Go, Rust, Java, R, and more
 - **No vendor lock-in** — works with any AI assistant or local LLM
 - **No API costs** — use local models (Ollama, llama.cpp, vLLM) with zero token fees
 - **Full privacy** — keep your code and context on your machine
@@ -64,7 +66,7 @@ SigMap extracts function and class signatures from your codebase and feeds the r
 
 | Without SigMap | With SigMap |
 |---|---|
-| ❌ Guessing which files are relevant | ✅ Right file in context — 76% of the time |
+| ❌ Guessing which files are relevant | ✅ Right file in context — <!--SM:hitWhole-->81%<!--/SM:hitWhole--> of the time |
 | ❌ Sending the full repo to your AI | ✅ Minimal context — only what matters |
 | ❌ Embeddings / vector DB required | ✅ Grounded answers, no infra needed |
 
@@ -87,16 +89,20 @@ Ask → Rank → Context → Validate → Judge → Learn
 
 ## Benchmark
 
+<!--SM:benchmarkBlock-->
 ```
-Benchmark : sigmap-v7.0-main (21 repositories, including R language)
-Date      : 2026-06-19
+Benchmark : sigmap-v7.24-main (21 repositories, including R language)
+Date      : 2026-06-04
 
-Hit@5          : 75.6%   (baseline 13.6%  — 5.6× lift)
-Token reduction: 97.0%   (across 21 repos)
-Prompt reduction : 39.4% (2.84 → 1.72 prompts per task)
-Task success   : 52.2%   (baseline 10%)
+Hit@5          : 81.1%   (baseline 13.6%  — 6.0× lift)
+Token reduction: 96.5%   (across 21 repos)
+Prompt reduction : 41.8% (2.84 → 1.66 prompts per task)
+Task success   : 53.3%   (baseline 10%)
 Repos tested   : 21 (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift, Ruby, PHP, Scala, Kotlin, and more)
 ```
+<!--/SM:benchmarkBlock-->
+
+<sub>All numbers above are generated from `benchmarks/latest.json` (`npm run metrics:sync`) — never hand-typed.</sub>
 
 Measured on 90 coding tasks across 18 real public repos. No LLM API — fully reproducible.
 
@@ -234,7 +240,7 @@ sigmap --health
 | Benchmark methodology | [benchmark.html](https://sigmap.io/guide/benchmark.html) |
 | Config reference | [config.html](https://sigmap.io/guide/config.html) |
 | Roadmap | [roadmap.html](https://sigmap.io/guide/roadmap.html) |
-| 31 languages | [generalization.html](https://sigmap.io/guide/generalization.html) |
+| <!--SM:languages-->33<!--/SM:languages--> languages | [generalization.html](https://sigmap.io/guide/generalization.html) |
 
 ---
 
@@ -289,7 +295,7 @@ See [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) for the
 
 ---
 
-## 31 languages
+## <!--SM:languages-->33<!--/SM:languages--> languages
 
 TypeScript · JavaScript · Python · Java · Kotlin · Go · Rust · C# · C/C++ · Ruby · PHP · Swift · Dart · Scala · Vue · Svelte · HTML · CSS/SCSS · YAML · Shell · SQL · GraphQL · Terraform · Protobuf · Dockerfile · TOML · XML · Properties · Markdown · R · GDScript
 

--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -1,0 +1,18 @@
+{
+  "benchmark_id": "sigmap-v7.24-main",
+  "benchmark_date": "2026-06-04",
+  "source": "benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction}.json",
+  "repos_token": 21,
+  "repos_retrieval": 18,
+  "metrics": {
+    "hit_at_5": 0.811,
+    "baseline_hit_at_5": 0.136,
+    "retrieval_lift": 6,
+    "overall_token_reduction_pct": 96.5,
+    "task_success_proxy_pct": 53.3,
+    "prompts_per_task": 1.66,
+    "baseline_prompts_per_task": 2.84,
+    "prompt_reduction_pct": 41.8,
+    "graph_boosted_hit_at_5": 0.811
+  }
+}

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -9,21 +9,21 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
-# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Version: 7.24.2 | Benchmark: sigmap-v7.24-main (2026-06-04)
+# Source: auto-generated from package.json, version.json, benchmarks/latest.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 
 ---
 
-## Core metrics (benchmark: sigmap-v7.0-main, 2026-06-19)
+## Core metrics (benchmark: sigmap-v7.24-main, 2026-06-04)
 
 | Metric | Without SigMap | With SigMap |
 |--------|----------------|-------------|
-| Retrieval hit@5 | 13.6% (random) | 75.6% (5.6× lift) |
-| Token reduction | — | 97.0% average |
-| Task success proxy | 10% | 52.2% |
-| Prompts per task | 2.84 | 1.72 (39.4% fewer) |
-| Supported languages | — | 31 |
+| Retrieval hit@5 | 13.6% (random) | 81.1% (6.0× lift) |
+| Token reduction | — | 96.5% average |
+| Task success proxy | 10% | 53.3% |
+| Prompts per task | 2.84 | 1.66 (41.8% fewer) |
+| Supported languages | — | 33 |
 | MCP tools | — | 15 |
 | npm runtime dependencies | — | 0 |
 
@@ -285,9 +285,9 @@ impact = {"depth":3,"includeSigs":true}
 
 ---
 
-## Supported languages (35 extractors)
+## Supported languages (33 extractors)
 
-cpp, csharp, css, dart, dispatch, dockerfile, gdscript, generic, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
+cpp, csharp, css, dart, dockerfile, gdscript, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
 
 ---
 

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -9,8 +9,8 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
-# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Version: 7.24.2 | Benchmark: sigmap-v7.24-main (2026-06-04)
+# Source: auto-generated from package.json, version.json, benchmarks/latest.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 
 ## What SigMap solves
@@ -21,13 +21,13 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - No blast-radius awareness before editing a hub file — `--impact` shows every file a change touches.
 - Pasted stack traces, CI logs, and JSON bloat the prompt — `squeeze` minimizes them and enriches the top frame from the symbol index.
 
-## Core metrics (benchmark: sigmap-v7.0-main, 2026-06-19)
+## Core metrics (benchmark: sigmap-v7.24-main, 2026-06-04)
 
-- hit@5 retrieval: 75.6% vs 13.6% random baseline (5.6× lift)
-- Token reduction: 97.0% average across benchmark repos
-- Task success: 52.2% vs 10% without SigMap
-- Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 31 supported · MCP tools: 15
+- hit@5 retrieval: 81.1% vs 13.6% random baseline (6.0× lift)
+- Token reduction: 96.5% average across benchmark repos
+- Task success: 53.3% vs 10% without SigMap
+- Prompts per task: 1.66 vs 2.84 baseline (41.8% fewer)
+- Languages: 33 supported · MCP tools: 15
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,21 +9,21 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
-# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Version: 7.24.2 | Benchmark: sigmap-v7.24-main (2026-06-04)
+# Source: auto-generated from package.json, version.json, benchmarks/latest.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 
 ---
 
-## Core metrics (benchmark: sigmap-v7.0-main, 2026-06-19)
+## Core metrics (benchmark: sigmap-v7.24-main, 2026-06-04)
 
 | Metric | Without SigMap | With SigMap |
 |--------|----------------|-------------|
-| Retrieval hit@5 | 13.6% (random) | 75.6% (5.6× lift) |
-| Token reduction | — | 97.0% average |
-| Task success proxy | 10% | 52.2% |
-| Prompts per task | 2.84 | 1.72 (39.4% fewer) |
-| Supported languages | — | 31 |
+| Retrieval hit@5 | 13.6% (random) | 81.1% (6.0× lift) |
+| Token reduction | — | 96.5% average |
+| Task success proxy | 10% | 53.3% |
+| Prompts per task | 2.84 | 1.66 (41.8% fewer) |
+| Supported languages | — | 33 |
 | MCP tools | — | 15 |
 | npm runtime dependencies | — | 0 |
 
@@ -285,9 +285,9 @@ impact = {"depth":3,"includeSigs":true}
 
 ---
 
-## Supported languages (35 extractors)
+## Supported languages (33 extractors)
 
-cpp, csharp, css, dart, dispatch, dockerfile, gdscript, generic, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
+cpp, csharp, css, dart, dockerfile, gdscript, go, graphql, html, java, javascript, kotlin, markdown, php, properties, protobuf, python, r, ruby, rust, scala, shell, sql, svelte, swift, terraform, toml, typescript, typescript_react, vue, vue_sfc, xml, yaml
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@ the files relevant to the task — cutting tokens ~97% while keeping answers
 grounded. Deterministic, offline, no embeddings or vector database. Works with
 Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
-# Version: 7.24.2 | Benchmark: sigmap-v7.0-main (2026-06-19)
-# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js
+# Version: 7.24.2 | Benchmark: sigmap-v7.24-main (2026-06-04)
+# Source: auto-generated from package.json, version.json, benchmarks/latest.json, src/mcp/tools.js, src/config/defaults.js
 # Regenerate: npm run generate:llms   |   Validate: npm run validate:llms
 
 ## What SigMap solves
@@ -21,13 +21,13 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - No blast-radius awareness before editing a hub file — `--impact` shows every file a change touches.
 - Pasted stack traces, CI logs, and JSON bloat the prompt — `squeeze` minimizes them and enriches the top frame from the symbol index.
 
-## Core metrics (benchmark: sigmap-v7.0-main, 2026-06-19)
+## Core metrics (benchmark: sigmap-v7.24-main, 2026-06-04)
 
-- hit@5 retrieval: 75.6% vs 13.6% random baseline (5.6× lift)
-- Token reduction: 97.0% average across benchmark repos
-- Task success: 52.2% vs 10% without SigMap
-- Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 31 supported · MCP tools: 15
+- hit@5 retrieval: 81.1% vs 13.6% random baseline (6.0× lift)
+- Token reduction: 96.5% average across benchmark repos
+- Task success: 53.3% vs 10% without SigMap
+- Prompts per task: 1.66 vs 2.84 baseline (41.8% fewer)
+- Languages: 33 supported · MCP tools: 15
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:llms": "node scripts/generate-llms.mjs",
     "validate:llms": "node scripts/validate-llms.mjs",
-    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/check-version-meta.mjs && node scripts/generate-llms.mjs",
+    "metrics:latest": "node scripts/gen-benchmark-latest.mjs",
+    "metrics:sync": "node scripts/gen-benchmark-latest.mjs && node scripts/check-version-meta.mjs --fix && node scripts/sync-metrics.mjs && node scripts/generate-llms.mjs",
+    "check:metrics": "node scripts/gen-benchmark-latest.mjs --check && node scripts/check-version-meta.mjs && node scripts/sync-metrics.mjs --check",
+    "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/gen-benchmark-latest.mjs --check && node scripts/check-version-meta.mjs && node scripts/sync-metrics.mjs --check && node scripts/generate-llms.mjs",
     "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs",
     "benchmark:llm-ablation": "node scripts/run-llm-ablation.mjs"
   },

--- a/scripts/check-version-meta.mjs
+++ b/scripts/check-version-meta.mjs
@@ -3,12 +3,15 @@
  * check-version-meta.mjs — keep version.json's derived counts honest.
  *
  * `version.json` carries metadata that must match the source of truth:
- *   - mcp_tools : number of MCP tools (src/mcp/tools.js `TOOLS`)
- *   - tests     : number of test files (test/**\/*.test.js + tests/**\/*.py)
+ *   - languages  : user-facing language extractors (src/extractors, helpers removed)
+ *   - extractors : total extractor modules (languages + helpers)
+ *   - mcp_tools  : number of MCP tools (src/mcp/tools.js `TOOLS`)
+ *   - tests      : number of test files (test/**\/*.test.js + tests/**\/*.py)
  *
- * `languages` is intentionally NOT derived — the extractor files include
- * non-language helpers (line-anchor, prdiff, todos, deps…) and dupes, so the
- * curated language count is editorial and stays hand-maintained.
+ * All four are derived from source via scripts/lib/source-meta.mjs — the same
+ * derivation the llms.txt generator uses, so the language list can never
+ * diverge (Trust Hygiene H3). Benchmark metrics live in benchmarks/latest.json
+ * and are synced separately by scripts/sync-metrics.mjs.
  *
  * Usage:
  *   node scripts/check-version-meta.mjs        # check; exit 1 on drift
@@ -17,42 +20,24 @@
  * Zero dependencies. Wired into prepublishOnly so a stale value blocks publish.
  */
 
-import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
-import { createRequire } from 'module';
+import { deriveCounts } from './lib/source-meta.mjs';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const require = createRequire(import.meta.url);
-
-/** Count files under `dir` (recursive) whose name matches `re`. */
-function countFiles(dir, re) {
-  let n = 0;
-  let entries;
-  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return 0; }
-  for (const e of entries) {
-    const full = join(dir, e.name);
-    if (e.isDirectory()) n += countFiles(full, re);
-    else if (e.isFile() && re.test(e.name)) n += 1;
-  }
-  return n;
-}
 
 /**
  * Compute the derived metadata from source.
  * @param {string} [root]
- * @returns {{ mcp_tools: number, tests: number }}
+ * @returns {{ languages: number, extractors: number, mcp_tools: number, tests: number }}
  */
 export function computeMeta(root = ROOT) {
-  const { TOOLS } = require(join(root, 'src/mcp/tools.js'));
-  const tests =
-    countFiles(join(root, 'test'), /\.test\.js$/) +
-    countFiles(join(root, 'tests'), /\.py$/);
-  return { mcp_tools: TOOLS.length, tests };
+  return deriveCounts(root);
 }
 
-/** Fields that are derived and gated. */
-const DERIVED = ['mcp_tools', 'tests'];
+/** Fields that are derived and gated, in version.json key order. */
+const DERIVED = ['languages', 'extractors', 'mcp_tools', 'tests'];
 
 function readVersionJson(root) {
   return JSON.parse(readFileSync(join(root, 'version.json'), 'utf8'));
@@ -80,15 +65,19 @@ function main() {
 
   if (drift.length === 0) {
     const m = computeMeta();
-    console.log(`✓ version.json metadata current (mcp_tools=${m.mcp_tools}, tests=${m.tests})`);
+    console.log(`✓ version.json metadata current (languages=${m.languages}, extractors=${m.extractors}, mcp_tools=${m.mcp_tools}, tests=${m.tests})`);
     return 0;
   }
 
   if (fix) {
-    // Preserve formatting/order: only rewrite the drifted numeric fields in place.
+    // Preserve formatting/order: rewrite the drifted numeric fields in place.
     let raw = readFileSync(join(ROOT, 'version.json'), 'utf8');
     for (const d of drift) {
       const re = new RegExp(`("${d.field}"\\s*:\\s*)\\d+`);
+      if (!re.test(raw)) {
+        console.error(`ERROR: version.json has no "${d.field}" field to update — add it first.`);
+        return 1;
+      }
       raw = raw.replace(re, `$1${d.expected}`);
     }
     writeFileSync(join(ROOT, 'version.json'), raw);

--- a/scripts/gen-benchmark-latest.mjs
+++ b/scripts/gen-benchmark-latest.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * gen-benchmark-latest.mjs — single source of benchmark truth (Trust Hygiene H1).
+ *
+ * Derives `benchmarks/latest.json` from the committed benchmark reports
+ * (`benchmarks/reports/*.json`) — the actual measured output. Every public
+ * number (version.json, README, llms.txt) reads from latest.json, so the docs
+ * can never silently diverge from the benchmarks.
+ *
+ *   node scripts/gen-benchmark-latest.mjs          # write benchmarks/latest.json
+ *   node scripts/gen-benchmark-latest.mjs --check   # exit 1 if latest.json is stale
+ *
+ * Zero dependencies. Wired into prepublishOnly so a stale file blocks publish.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const require = createRequire(import.meta.url);
+
+function readReport(root, name) {
+  return JSON.parse(readFileSync(join(root, 'benchmarks', 'reports', name), 'utf8'));
+}
+
+/** Round to `d` decimal places (deterministic). */
+function round(n, d = 1) {
+  const f = 10 ** d;
+  return Math.round(Number(n) * f) / f;
+}
+
+/**
+ * Compute the canonical benchmark object from the committed reports.
+ * @param {string} [root]
+ * @returns {object}
+ */
+export function computeLatest(root = ROOT) {
+  const matrixReport = readReport(root, 'benchmark-matrix.json');
+  const matrix = matrixReport.metrics;
+  const task = readReport(root, 'task-benchmark.json').summary;
+  const tokenReport = readReport(root, 'token-reduction.json');
+  const pkg = require(join(root, 'package.json'));
+
+  const [maj, min] = String(pkg.version).split('.');
+  // Date comes from the run timestamp in the report content (not file mtime).
+  const generated = matrixReport.generated || tokenReport.timestamp || '';
+  const benchmark_date = String(generated).slice(0, 10);
+
+  return {
+    benchmark_id: `sigmap-v${maj}.${min}-main`,
+    benchmark_date,
+    source: 'benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction}.json',
+    repos_token: matrix.reposToken,
+    repos_retrieval: matrix.reposRetrieval,
+    metrics: {
+      hit_at_5: round(matrix.avgHitAt5Pct / 100, 3),
+      baseline_hit_at_5: round(task.hitAt5Without / 100, 3),
+      retrieval_lift: round(matrix.avgHitAt5Pct / task.hitAt5Without, 1),
+      overall_token_reduction_pct: round(matrix.avgReductionPct, 1),
+      task_success_proxy_pct: round(task.correctPct, 1),
+      prompts_per_task: round(task.avgPromptsWith, 2),
+      baseline_prompts_per_task: round(task.avgPromptsWithout, 2),
+      prompt_reduction_pct: round(matrix.taskPromptReductionPct, 1),
+      graph_boosted_hit_at_5: round(matrix.avgHitAt5Pct / 100, 3),
+    },
+  };
+}
+
+const LATEST = join(ROOT, 'benchmarks', 'latest.json');
+const serialize = (obj) => JSON.stringify(obj, null, 2) + '\n';
+
+/**
+ * Whether benchmarks/latest.json matches what the reports would produce.
+ * @param {string} [root]
+ * @returns {boolean}
+ */
+export function latestInSync(root = ROOT) {
+  let have = '';
+  try { have = readFileSync(join(root, 'benchmarks', 'latest.json'), 'utf8'); } catch { have = ''; }
+  return have === serialize(computeLatest(root));
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main() {
+  const check = process.argv.includes('--check');
+  if (check) {
+    if (latestInSync()) {
+      console.log('✓ benchmarks/latest.json is in sync with benchmarks/reports/');
+      return 0;
+    }
+    console.error('ERROR: benchmarks/latest.json is stale vs benchmarks/reports/.');
+    console.error('Run `node scripts/gen-benchmark-latest.mjs` to regenerate, then commit it.');
+    return 1;
+  }
+  writeFileSync(LATEST, serialize(computeLatest()));
+  console.log('✓ wrote benchmarks/latest.json from benchmarks/reports/');
+  return 0;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main());
+}

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -22,6 +22,7 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { tagline, solves, projectDescription, doesNotDo, compliance, positioning } from './llms-manual.mjs';
+import { deriveLanguages } from './lib/source-meta.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
@@ -32,13 +33,12 @@ const pct = (n, d = 1) => `${Number(n).toFixed(d)}%`;
 function gather() {
   const pkg = require(path.join(ROOT, 'package.json'));
   const version = require(path.join(ROOT, 'version.json'));
+  const latest = require(path.join(ROOT, 'benchmarks/latest.json'));
   const { TOOLS } = require(path.join(ROOT, 'src/mcp/tools.js'));
   const { DEFAULTS } = require(path.join(ROOT, 'src/config/defaults.js'));
 
-  const HELPERS = new Set(['line-anchor', 'deps', 'coverage', 'patterns', 'python_ast', 'python_dataclass', 'todos', 'prdiff']);
-  const languages = fs.readdirSync(path.join(ROOT, 'src/extractors'))
-    .filter((f) => f.endsWith('.js')).map((f) => f.replace(/\.js$/, ''))
-    .filter((n) => !HELPERS.has(n)).sort();
+  // Single derivation shared with the version.json gate so the count never diverges.
+  const languages = deriveLanguages(ROOT);
 
   const ADAPTER_HELPERS = new Set(['index', 'llm-full']);
   const adapters = fs.readdirSync(path.join(ROOT, 'packages/adapters'))
@@ -56,23 +56,23 @@ function gather() {
   const repo = String((pkg.repository && pkg.repository.url) || 'https://github.com/manojmallick/sigmap')
     .replace(/^git\+/, '').replace(/\.git$/, '');
   const home = pkg.homepage || 'https://sigmap.io/';
-  return { pkg, version, TOOLS, DEFAULTS, languages, adapters, helpLines, repo, home };
+  return { pkg, version, latest, TOOLS, DEFAULTS, languages, adapters, helpLines, repo, home };
 }
 
 function stamp(d) {
   return [
-    `# Version: ${d.pkg.version} | Benchmark: ${d.version.benchmark_id} (${d.version.benchmark_date})`,
-    '# Source: auto-generated from package.json, version.json, src/mcp/tools.js, src/config/defaults.js',
+    `# Version: ${d.pkg.version} | Benchmark: ${d.latest.benchmark_id} (${d.latest.benchmark_date})`,
+    '# Source: auto-generated from package.json, version.json, benchmarks/latest.json, src/mcp/tools.js, src/config/defaults.js',
     '# Regenerate: npm run generate:llms   |   Validate: npm run validate:llms',
   ].join('\n');
 }
 
 function metricsBullets(d) {
-  const m = d.version.metrics;
+  const m = d.latest.metrics;
   return [
-    `## Core metrics (benchmark: ${d.version.benchmark_id}, ${d.version.benchmark_date})`,
+    `## Core metrics (benchmark: ${d.latest.benchmark_id}, ${d.latest.benchmark_date})`,
     '',
-    `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)} vs ${pct(m.baseline_hit_at_5 * 100)} random baseline (${m.retrieval_lift}× lift)`,
+    `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)} vs ${pct(m.baseline_hit_at_5 * 100)} random baseline (${Number(m.retrieval_lift).toFixed(1)}× lift)`,
     `- Token reduction: ${pct(m.overall_token_reduction_pct)} average across benchmark repos`,
     `- Task success: ${pct(m.task_success_proxy_pct)} vs 10% without SigMap`,
     `- Prompts per task: ${m.prompts_per_task} vs ${m.baseline_prompts_per_task} baseline (${pct(m.prompt_reduction_pct)} fewer)`,
@@ -82,13 +82,13 @@ function metricsBullets(d) {
 }
 
 function metricsTable(d) {
-  const m = d.version.metrics;
+  const m = d.latest.metrics;
   return [
-    `## Core metrics (benchmark: ${d.version.benchmark_id}, ${d.version.benchmark_date})`,
+    `## Core metrics (benchmark: ${d.latest.benchmark_id}, ${d.latest.benchmark_date})`,
     '',
     '| Metric | Without SigMap | With SigMap |',
     '|--------|----------------|-------------|',
-    `| Retrieval hit@5 | ${pct(m.baseline_hit_at_5 * 100)} (random) | ${pct(m.hit_at_5 * 100)} (${m.retrieval_lift}× lift) |`,
+    `| Retrieval hit@5 | ${pct(m.baseline_hit_at_5 * 100)} (random) | ${pct(m.hit_at_5 * 100)} (${Number(m.retrieval_lift).toFixed(1)}× lift) |`,
     `| Token reduction | — | ${pct(m.overall_token_reduction_pct)} average |`,
     `| Task success proxy | 10% | ${pct(m.task_success_proxy_pct)} |`,
     `| Prompts per task | ${m.prompts_per_task < m.baseline_prompts_per_task ? m.baseline_prompts_per_task : '—'} | ${m.prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer) |`,

--- a/scripts/lib/source-meta.mjs
+++ b/scripts/lib/source-meta.mjs
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * source-meta.mjs — single derivation of SigMap's source-derived counts.
+ *
+ * One place computes the language list, extractor/test/MCP-tool counts so the
+ * llms.txt generator and the version.json metadata gate can never disagree
+ * (Trust Hygiene H3). Zero dependencies; pure functions of the repo root.
+ */
+
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Extractor modules that are infrastructure, not user-facing languages
+ * (helpers, the dispatcher, the generic fallback). Excluded from the language
+ * list / count, but still counted as extractor modules.
+ */
+export const EXTRACTOR_HELPERS = new Set([
+  'line-anchor', 'deps', 'coverage', 'patterns', 'python_ast',
+  'python_dataclass', 'todos', 'prdiff', 'dispatch', 'generic',
+]);
+
+/** All extractor module basenames (`.js`) under src/extractors, sorted. */
+export function extractorModules(root) {
+  return readdirSync(join(root, 'src', 'extractors'))
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => f.replace(/\.js$/, ''))
+    .sort();
+}
+
+/** Total number of extractor modules (languages + helpers). */
+export function countExtractors(root) {
+  return extractorModules(root).length;
+}
+
+/** User-facing language extractor names (helpers removed), sorted. */
+export function deriveLanguages(root) {
+  return extractorModules(root).filter((n) => !EXTRACTOR_HELPERS.has(n));
+}
+
+/** Count files under `dir` (recursive) whose name matches `re`. */
+function countFiles(dir, re) {
+  let n = 0;
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return 0; }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) n += countFiles(full, re);
+    else if (e.isFile() && re.test(e.name)) n += 1;
+  }
+  return n;
+}
+
+/** Number of test files: test/**\/*.test.js + tests/**\/*.py */
+export function countTests(root) {
+  return countFiles(join(root, 'test'), /\.test\.js$/) +
+         countFiles(join(root, 'tests'), /\.py$/);
+}
+
+/** Number of MCP tools registered in src/mcp/tools.js. */
+export function countMcpTools(root) {
+  const { TOOLS } = require(join(root, 'src', 'mcp', 'tools.js'));
+  return TOOLS.length;
+}
+
+/** All source-derived counts for version.json. */
+export function deriveCounts(root) {
+  return {
+    languages: deriveLanguages(root).length,
+    extractors: countExtractors(root),
+    mcp_tools: countMcpTools(root),
+    tests: countTests(root),
+  };
+}

--- a/scripts/sync-metrics.mjs
+++ b/scripts/sync-metrics.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * sync-metrics.mjs — every public benchmark number reads from one file (H1).
+ *
+ * `benchmarks/latest.json` is the single source of truth (generated from the
+ * benchmark reports by scripts/gen-benchmark-latest.mjs). This script pushes it
+ * into the human-facing surfaces so a hand-typed metric can never drift:
+ *   - version.json   : benchmark_id, benchmark_date, metrics
+ *   - README.md      : numbers inside <!--SM:KEY-->…<!--/SM:KEY--> markers
+ *
+ *   node scripts/sync-metrics.mjs          # write version.json + README.md
+ *   node scripts/sync-metrics.mjs --check   # exit 1 if either is stale
+ *
+ * Zero dependencies. Wired into prepublishOnly so a stale value blocks publish.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { computeLatest } from './gen-benchmark-latest.mjs';
+import { deriveLanguages } from './lib/source-meta.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const pct = (n, d = 1) => `${Number(n).toFixed(d)}%`;
+
+// ── version.json ──────────────────────────────────────────────────────────────
+/** Expected version.json text with benchmark fields synced from latest.json. */
+export function expectedVersionJson(root = ROOT) {
+  const latest = computeLatest(root);
+  const vj = JSON.parse(readFileSync(join(root, 'version.json'), 'utf8'));
+  vj.benchmark_date = latest.benchmark_date;
+  vj.benchmark_id = latest.benchmark_id;
+  vj.metrics = latest.metrics;
+  return JSON.stringify(vj, null, 2) + '\n';
+}
+
+// ── README.md ─────────────────────────────────────────────────────────────────
+/** Map of marker KEY → rendered replacement text. */
+export function renderTokens(root = ROOT) {
+  const latest = computeLatest(root);
+  const m = latest.metrics;
+  const languages = deriveLanguages(root).length;
+
+  const bullets = [
+    `- **${pct(m.hit_at_5 * 100)} hit@5** — right file found in top 5 results (vs ${pct(m.baseline_hit_at_5 * 100)} baseline)`,
+    `- **${pct(m.overall_token_reduction_pct)} token reduction** — average across ${latest.repos_token} real repos`,
+    `- **${pct(m.task_success_proxy_pct)} task success rate** — up from 10% without context`,
+    `- **${m.prompts_per_task} prompts per task** — down from ${m.baseline_prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer retries)`,
+  ].join('\n');
+
+  // The fenced code block, rendered whole (markers sit *outside* the fence so
+  // they stay invisible in rendered markdown).
+  const block = [
+    '```',
+    `Benchmark : ${latest.benchmark_id} (${latest.repos_token} repositories, including R language)`,
+    `Date      : ${latest.benchmark_date}`,
+    '',
+    `Hit@5          : ${pct(m.hit_at_5 * 100)}   (baseline ${pct(m.baseline_hit_at_5 * 100)}  — ${Number(m.retrieval_lift).toFixed(1)}× lift)`,
+    `Token reduction: ${pct(m.overall_token_reduction_pct)}   (across ${latest.repos_token} repos)`,
+    `Prompt reduction : ${pct(m.prompt_reduction_pct)} (${m.baseline_prompts_per_task} → ${m.prompts_per_task} prompts per task)`,
+    `Task success   : ${pct(m.task_success_proxy_pct)}   (baseline 10%)`,
+    `Repos tested   : ${latest.repos_token} (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift, Ruby, PHP, Scala, Kotlin, and more)`,
+    '```',
+  ].join('\n');
+
+  return {
+    whyMetrics: `\n${bullets}\n`,
+    benchmarkBlock: `\n${block}\n`,
+    hitWhole: `${Math.round(m.hit_at_5 * 100)}%`,
+    languages: String(languages),
+  };
+}
+
+/** Apply marker tokens to README text. Returns the updated text. */
+export function applyTokens(text, tokens) {
+  let out = text;
+  for (const [key, value] of Object.entries(tokens)) {
+    const re = new RegExp(`(<!--SM:${key}-->)[\\s\\S]*?(<!--/SM:${key}-->)`, 'g');
+    if (!re.test(out)) throw new Error(`README marker missing: <!--SM:${key}-->`);
+    out = out.replace(re, `$1${value}$2`);
+  }
+  return out;
+}
+
+export function expectedReadme(root = ROOT) {
+  const text = readFileSync(join(root, 'README.md'), 'utf8');
+  return applyTokens(text, renderTokens(root));
+}
+
+// ── drift ─────────────────────────────────────────────────────────────────────
+/** @returns {string[]} list of out-of-sync surface names ([] = clean) */
+export function findDrift(root = ROOT) {
+  const out = [];
+  if (readFileSync(join(root, 'version.json'), 'utf8') !== expectedVersionJson(root)) out.push('version.json');
+  if (readFileSync(join(root, 'README.md'), 'utf8') !== expectedReadme(root)) out.push('README.md');
+  return out;
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main() {
+  const check = process.argv.includes('--check');
+  if (check) {
+    const drift = findDrift();
+    if (drift.length === 0) {
+      console.log('✓ version.json + README.md metrics in sync with benchmarks/latest.json');
+      return 0;
+    }
+    console.error(`ERROR: stale metrics in: ${drift.join(', ')}`);
+    console.error('Run `node scripts/sync-metrics.mjs` to sync them from benchmarks/latest.json, then commit.');
+    return 1;
+  }
+  writeFileSync(join(ROOT, 'version.json'), expectedVersionJson());
+  writeFileSync(join(ROOT, 'README.md'), expectedReadme());
+  console.log('✓ synced version.json + README.md from benchmarks/latest.json');
+  return 0;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main());
+}

--- a/test/integration/benchmark-latest.test.js
+++ b/test/integration/benchmark-latest.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * Single source of benchmark truth (scripts/gen-benchmark-latest.mjs).
+ * latest.json is derived from benchmarks/reports/ and gated for drift (H1).
+ * Run: node test/integration/benchmark-latest.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'scripts', 'gen-benchmark-latest.mjs');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+(async () => {
+  const mod = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
+  const { computeLatest, latestInSync } = mod;
+
+  test('computeLatest mirrors the committed benchmark reports', () => {
+    const matrix = require(path.join(ROOT, 'benchmarks/reports/benchmark-matrix.json')).metrics;
+    const task = require(path.join(ROOT, 'benchmarks/reports/task-benchmark.json')).summary;
+    const out = computeLatest(ROOT);
+    const round3 = (n) => Math.round(n * 1000) / 1000;
+    assert.strictEqual(out.metrics.hit_at_5, round3(matrix.avgHitAt5Pct / 100));
+    assert.strictEqual(out.metrics.task_success_proxy_pct, task.correctPct);
+    assert.strictEqual(out.metrics.prompts_per_task, task.avgPromptsWith);
+    assert.strictEqual(out.repos_token, matrix.reposToken);
+    assert.ok(/^sigmap-v\d+\.\d+-main$/.test(out.benchmark_id), out.benchmark_id);
+    assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(out.benchmark_date), out.benchmark_date);
+  });
+
+  test('benchmarks/latest.json is committed and in sync', () => {
+    assert.ok(fs.existsSync(path.join(ROOT, 'benchmarks/latest.json')));
+    assert.strictEqual(latestInSync(ROOT), true);
+  });
+
+  test('committed latest.json equals computeLatest output exactly', () => {
+    const have = fs.readFileSync(path.join(ROOT, 'benchmarks/latest.json'), 'utf8');
+    assert.strictEqual(have, JSON.stringify(computeLatest(ROOT), null, 2) + '\n');
+  });
+
+  test('version.json metrics match latest.json (single source of truth)', () => {
+    const vj = require(path.join(ROOT, 'version.json'));
+    const latest = computeLatest(ROOT);
+    assert.deepStrictEqual(vj.metrics, latest.metrics);
+    assert.strictEqual(vj.benchmark_id, latest.benchmark_id);
+    assert.strictEqual(vj.benchmark_date, latest.benchmark_date);
+  });
+
+  test('CLI --check passes (exit 0) on the committed repo', () => {
+    const out = execFileSync(process.execPath, [SCRIPT, '--check'], { cwd: ROOT, encoding: 'utf8' });
+    assert.ok(/in sync/.test(out), out);
+  });
+
+  test('computeLatest is deterministic against a hermetic fixture', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-bench-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'benchmarks', 'reports'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version: '9.9.9' }));
+      fs.writeFileSync(path.join(dir, 'benchmarks/reports/benchmark-matrix.json'), JSON.stringify({
+        generated: '2031-01-02T03:04:05.000Z',
+        metrics: { reposToken: 7, reposRetrieval: 5, avgReductionPct: 90, avgHitAt5Pct: 80, taskPromptReductionPct: 30 },
+      }));
+      fs.writeFileSync(path.join(dir, 'benchmarks/reports/task-benchmark.json'), JSON.stringify({
+        summary: { correctPct: 50, avgPromptsWith: 1.5, avgPromptsWithout: 3, hitAt5Without: 10 },
+      }));
+      fs.writeFileSync(path.join(dir, 'benchmarks/reports/token-reduction.json'), JSON.stringify({ timestamp: 'x' }));
+      const out = computeLatest(dir);
+      assert.strictEqual(out.benchmark_id, 'sigmap-v9.9-main');
+      assert.strictEqual(out.benchmark_date, '2031-01-02');
+      assert.strictEqual(out.metrics.hit_at_5, 0.8);
+      assert.strictEqual(out.metrics.baseline_hit_at_5, 0.1);
+      assert.strictEqual(out.metrics.retrieval_lift, 8); // 80 / 10
+      assert.strictEqual(out.repos_token, 7);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  console.log(`\nbenchmark-latest: ${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -27,6 +27,10 @@ function test(name, fn) {
 
 const src = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
 const versionMeta = JSON.parse(fs.readFileSync(path.join(ROOT, 'version.json'), 'utf8'));
+const M = versionMeta.metrics;
+// Metrics are derived from benchmarks/latest.json (Trust Hygiene H1) — assert
+// against the single source of truth, never against hand-typed literals.
+const pct1 = (n) => `${Number(n).toFixed(1)}%`;
 
 console.log('\nv5.9.1 README conversion tests\n');
 
@@ -69,16 +73,16 @@ test('what-it-is: short explanation present', () => {
 
 // ── Section 4: Why SigMap ─────────────────────────────────────────────────────
 
-test('why: 75.6% hit@5 mentioned', () => {
-  assert.ok(src.includes('75.6%'), 'missing 75.6% hit@5');
+test('why: hit@5 (from version.json) mentioned', () => {
+  assert.ok(src.includes(pct1(M.hit_at_5 * 100)), `missing ${pct1(M.hit_at_5 * 100)} hit@5`);
 });
 
-test('why: 13.6% baseline mentioned', () => {
-  assert.ok(src.includes('13.6%'), 'missing 13.6% baseline');
+test('why: baseline (from version.json) mentioned', () => {
+  assert.ok(src.includes(pct1(M.baseline_hit_at_5 * 100)), `missing ${pct1(M.baseline_hit_at_5 * 100)} baseline`);
 });
 
-test('why: token reduction 97.0% mentioned', () => {
-  assert.ok(src.includes('97.0%'), 'missing 97.0% token reduction');
+test('why: token reduction (from version.json) mentioned', () => {
+  assert.ok(src.includes(pct1(M.overall_token_reduction_pct)), `missing ${pct1(M.overall_token_reduction_pct)} token reduction`);
 });
 
 // ── Section 5: Replace section ────────────────────────────────────────────────
@@ -130,28 +134,28 @@ test('community: StarMapper stargazer-map link present', () => {
 
 // ── Section 7: Benchmark ─────────────────────────────────────────────────────
 
-test('benchmark: sigmap-v7.0-main ID present', () => {
-  assert.ok(src.includes('sigmap-v7.0-main'), 'missing sigmap-v7.0-main benchmark ID');
+test('benchmark: benchmark_id (from version.json) present', () => {
+  assert.ok(src.includes(versionMeta.benchmark_id), `missing ${versionMeta.benchmark_id} benchmark ID`);
 });
 
 test('benchmark: version.json benchmark_date present', () => {
   assert.ok(src.includes(versionMeta.benchmark_date), `missing benchmark date ${versionMeta.benchmark_date}`);
 });
 
-test('benchmark: Hit@5 75.6% present', () => {
-  assert.ok(src.includes('75.6%'), 'missing Hit@5 75.6%');
+test('benchmark: Hit@5 (from version.json) present', () => {
+  assert.ok(src.includes(pct1(M.hit_at_5 * 100)), `missing Hit@5 ${pct1(M.hit_at_5 * 100)}`);
 });
 
-test('benchmark: baseline 13.6% present', () => {
-  assert.ok(src.includes('13.6%'), 'missing baseline 13.6%');
+test('benchmark: baseline (from version.json) present', () => {
+  assert.ok(src.includes(pct1(M.baseline_hit_at_5 * 100)), `missing baseline ${pct1(M.baseline_hit_at_5 * 100)}`);
 });
 
-test('benchmark: prompt reduction 39.4% present', () => {
-  assert.ok(src.includes('39.4%'), 'missing prompt reduction 39.4%');
+test('benchmark: prompt reduction (from version.json) present', () => {
+  assert.ok(src.includes(pct1(M.prompt_reduction_pct)), `missing prompt reduction ${pct1(M.prompt_reduction_pct)}`);
 });
 
-test('benchmark: task success 52.2% present', () => {
-  assert.ok(src.includes('52.2%'), 'missing task success 52.2%');
+test('benchmark: task success (from version.json) present', () => {
+  assert.ok(src.includes(pct1(M.task_success_proxy_pct)), `missing task success ${pct1(M.task_success_proxy_pct)}`);
 });
 
 // ── Section 8: Install ────────────────────────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -64,9 +64,17 @@ test('version.json: retrieval_lift field exists and is a number >= 5', () => {
     `expected retrieval_lift >= 5, got ${v.metrics.retrieval_lift}`);
 });
 
-test('version.json: languages is 31', () => {
+test('version.json: languages is a derived positive integer (>= 31)', () => {
+  // Derived from src/extractors (Trust Hygiene H3) — not a hand-pinned literal.
+  // The version-meta gate (test/integration/version-meta.test.js) enforces the
+  // exact value; here we only assert it stays a sane positive count.
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.languages, 31);
+  assert.ok(Number.isInteger(v.languages) && v.languages >= 31, `languages=${v.languages}`);
+});
+
+test('version.json: extractors field is derived (>= languages)', () => {
+  const v = JSON.parse(readRoot('version.json'));
+  assert.ok(Number.isInteger(v.extractors) && v.extractors >= v.languages, `extractors=${v.extractors}`);
 });
 
 test('version.json: mcp_tools is 15', () => {

--- a/test/integration/readme-metrics.test.js
+++ b/test/integration/readme-metrics.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * README + version.json metrics sync (scripts/sync-metrics.mjs).
+ * Every public number reads from benchmarks/latest.json via markers (H1).
+ * Run: node test/integration/readme-metrics.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'scripts', 'sync-metrics.mjs');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+(async () => {
+  const mod = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
+  const { renderTokens, applyTokens, findDrift } = mod;
+
+  const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+
+  test('committed README + version.json are in sync with latest.json', () => {
+    assert.deepStrictEqual(findDrift(ROOT), []);
+  });
+
+  test('CLI --check passes (exit 0) on the committed repo', () => {
+    const out = execFileSync(process.execPath, [SCRIPT, '--check'], { cwd: ROOT, encoding: 'utf8' });
+    assert.ok(/in sync/.test(out), out);
+  });
+
+  test('README declares every marker key that renderTokens produces', () => {
+    for (const key of Object.keys(renderTokens(ROOT))) {
+      assert.ok(readme.includes(`<!--SM:${key}-->`), `missing open marker for ${key}`);
+      assert.ok(readme.includes(`<!--/SM:${key}-->`), `missing close marker for ${key}`);
+    }
+  });
+
+  test('renderTokens derives values from latest.json, not hand-typed', () => {
+    const latest = require(path.join(ROOT, 'benchmarks/latest.json'));
+    const t = renderTokens(ROOT);
+    assert.strictEqual(t.hitWhole, `${Math.round(latest.metrics.hit_at_5 * 100)}%`);
+    assert.ok(t.benchmarkBlock.includes(latest.benchmark_id), 'benchmark block carries the id');
+    assert.ok(t.whyMetrics.includes(`${(latest.metrics.hit_at_5 * 100).toFixed(1)}%`), 'bullets carry hit@5');
+  });
+
+  test('applyTokens replaces marker content and is idempotent', () => {
+    const sample = 'x <!--SM:hitWhole-->OLD<!--/SM:hitWhole--> y';
+    const once = applyTokens(sample, { hitWhole: '81%' });
+    assert.strictEqual(once, 'x <!--SM:hitWhole-->81%<!--/SM:hitWhole--> y');
+    assert.strictEqual(applyTokens(once, { hitWhole: '81%' }), once);
+  });
+
+  test('applyTokens throws when a declared marker is absent', () => {
+    assert.throws(() => applyTokens('no markers here', { hitWhole: '81%' }), /marker missing/);
+  });
+
+  test('no stale pre-Trust-Hygiene metric survives in README', () => {
+    for (const stale of ['75.6%', '97.0%', '52.2%', '1.72 prompts', '5.6× lift', '31 languages']) {
+      assert.ok(!readme.includes(stale), `stale metric still present: ${stale}`);
+    }
+  });
+
+  console.log(`\nreadme-metrics: ${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();

--- a/test/integration/version-meta.test.js
+++ b/test/integration/version-meta.test.js
@@ -2,7 +2,8 @@
 
 /**
  * version.json metadata gate (scripts/check-version-meta.mjs).
- * Ensures derived counts (mcp_tools, tests) stay in sync with source.
+ * Ensures derived counts (languages, extractors, mcp_tools, tests) stay in sync
+ * with source via scripts/lib/source-meta.mjs (Trust Hygiene H3).
  * Run: node test/integration/version-meta.test.js
  */
 
@@ -21,6 +22,23 @@ function test(name, fn) {
   catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
 }
 
+/** Build a minimal hermetic repo for drift testing. */
+function makeFakeRepo(versionMeta) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-vmeta-'));
+  fs.mkdirSync(path.join(dir, 'src', 'mcp'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'src', 'extractors'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
+  // 3 extractor modules, one of which is a helper → 2 languages, 3 extractors.
+  fs.writeFileSync(path.join(dir, 'src', 'extractors', 'javascript.js'), '// js\n');
+  fs.writeFileSync(path.join(dir, 'src', 'extractors', 'python.js'), '// py\n');
+  fs.writeFileSync(path.join(dir, 'src', 'extractors', 'line-anchor.js'), '// helper\n');
+  fs.writeFileSync(path.join(dir, 'src', 'mcp', 'tools.js'),
+    'module.exports = { TOOLS: [{name:"a"},{name:"b"}] };\n');
+  fs.writeFileSync(path.join(dir, 'test', 'x.test.js'), '// test\n');
+  fs.writeFileSync(path.join(dir, 'version.json'), JSON.stringify(versionMeta, null, 2));
+  return dir;
+}
+
 (async () => {
   const mod = await import('url').then((u) => import(u.pathToFileURL(SCRIPT).href));
   const { computeMeta, findMetaDrift } = mod;
@@ -30,9 +48,12 @@ function test(name, fn) {
     assert.strictEqual(computeMeta(ROOT).mcp_tools, TOOLS.length);
   });
 
-  test('computeMeta: tests count is a positive integer', () => {
-    const { tests } = computeMeta(ROOT);
-    assert.ok(Number.isInteger(tests) && tests > 0, `tests=${tests}`);
+  test('computeMeta: derives languages, extractors, tests as positive ints', () => {
+    const m = computeMeta(ROOT);
+    for (const k of ['languages', 'extractors', 'tests']) {
+      assert.ok(Number.isInteger(m[k]) && m[k] > 0, `${k}=${m[k]}`);
+    }
+    assert.ok(m.extractors >= m.languages, 'extractors >= languages (helpers included)');
   });
 
   test('version.json is in sync (no drift) on the committed repo', () => {
@@ -44,29 +65,38 @@ function test(name, fn) {
     assert.ok(/metadata current/.test(out), out);
   });
 
-  test('findMetaDrift: detects a tampered version.json (hermetic temp root)', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-vmeta-'));
+  test('languages is now DERIVED (in the gated set), not editorial', () => {
+    assert.ok(computeMeta(ROOT).languages > 0);
+    const dir = makeFakeRepo({ version: '1.0.0', languages: 99, extractors: 3, mcp_tools: 2, tests: 1 });
     try {
-      // minimal fake repo: src/mcp/tools.js with 2 tools, one test file
-      fs.mkdirSync(path.join(dir, 'src', 'mcp'), { recursive: true });
-      fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'src', 'mcp', 'tools.js'),
-        'module.exports = { TOOLS: [{name:"a"},{name:"b"}] };\n');
-      fs.writeFileSync(path.join(dir, 'test', 'x.test.js'), '// test\n');
-      fs.writeFileSync(path.join(dir, 'version.json'),
-        JSON.stringify({ version: '1.0.0', mcp_tools: 99, tests: 1, languages: 31 }, null, 2));
       const drift = findMetaDrift(dir);
-      const fields = drift.map((d) => d.field).sort();
-      assert.deepStrictEqual(fields, ['mcp_tools']); // tests=1 matches, mcp_tools 99≠2
+      assert.deepStrictEqual(drift.map((d) => d.field), ['languages']);
+      assert.strictEqual(drift[0].expected, 2); // javascript + python, helper excluded
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('findMetaDrift: detects tampered mcp_tools (hermetic temp root)', () => {
+    const dir = makeFakeRepo({ version: '1.0.0', languages: 2, extractors: 3, mcp_tools: 99, tests: 1 });
+    try {
+      const drift = findMetaDrift(dir);
+      assert.deepStrictEqual(drift.map((d) => d.field), ['mcp_tools']);
       assert.strictEqual(drift[0].expected, 2);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test('languages is left editorial (not in derived drift set)', () => {
-    const drift = findMetaDrift(ROOT);
-    assert.ok(!drift.some((d) => d.field === 'languages'));
+  test('findMetaDrift: detects tampered extractors (hermetic temp root)', () => {
+    const dir = makeFakeRepo({ version: '1.0.0', languages: 2, extractors: 999, mcp_tools: 2, tests: 1 });
+    try {
+      const drift = findMetaDrift(dir);
+      assert.deepStrictEqual(drift.map((d) => d.field), ['extractors']);
+      assert.strictEqual(drift[0].expected, 3);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   console.log(`\nversion-meta: ${pass} passed, ${fail} failed`);

--- a/version.json
+++ b/version.json
@@ -1,20 +1,21 @@
 {
   "version": "7.24.2",
-  "benchmark_date": "2026-06-19",
-  "benchmark_id": "sigmap-v7.0-main",
-  "languages": 31,
+  "benchmark_date": "2026-06-04",
+  "benchmark_id": "sigmap-v7.24-main",
+  "languages": 33,
+  "extractors": 42,
   "mcp_tools": 15,
-  "tests": 96,
+  "tests": 98,
   "metrics": {
-    "hit_at_5": 0.756,
+    "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,
-    "prompt_reduction_pct": 39.4,
-    "task_success_proxy_pct": 52.2,
-    "prompts_per_task": 1.72,
+    "retrieval_lift": 6,
+    "overall_token_reduction_pct": 96.5,
+    "task_success_proxy_pct": 53.3,
+    "prompts_per_task": 1.66,
     "baseline_prompts_per_task": 2.84,
-    "overall_token_reduction_pct": 97,
-    "retrieval_lift": 5.6,
-    "graph_boosted_hit_at_5": 0.756
+    "prompt_reduction_pct": 41.8,
+    "graph_boosted_hit_at_5": 0.811
   },
   "ablation": {
     "benchmark_id": "sigmap-v7.24-ablation",


### PR DESCRIPTION
Closes #363 — v7.25.x "Trust Hygiene" **H1 + H3**.

## What & why
SigMap's pitch is trust/determinism, but its self-reported numbers had drifted: the committed benchmark **reports** said hit@5 81.1% / token 96.5% / task 53.3% / 1.66 prompts, while README, `version.json`, and `llms.txt` published 75.6% / 97.0% / 52.2% / 1.72 — hand-typed and rotting. This makes one generated file the single source of truth and has everything read from it, gated in CI.

## H1 — single source of benchmark truth
- **`benchmarks/latest.json`** generated from `benchmarks/reports/*.json` (`scripts/gen-benchmark-latest.mjs`, `--check` drift gate).
- **`version.json`** `metrics` + `benchmark_id` + `benchmark_date` synced from it (`scripts/sync-metrics.mjs`).
- **`README.md`** numbers injected between `<!--SM:KEY-->` markers from `latest.json` (markers sit outside code fences so they stay invisible).
- **`llms.txt` / `llms-full.txt`** generator reads metrics from `latest.json`.
- Every hand-typed metric removed. Published numbers now match the reports:
  - hit@5 **75.6% → 81.1%**, lift **5.6× → 6.0×**, token reduction **97.0% → 96.5%**, task success **52.2% → 53.3%**, prompts **1.72 → 1.66**.

## H3 — truthful version.json
- `languages` / `extractors` / `mcp_tools` / `tests` auto-derived via **`scripts/lib/source-meta.mjs`** — the *same* derivation the llms generator uses, so the language count can never diverge again.
- `languages` **31 → 33** (was stale); added `extractors` (**42**).

## Gates
- `npm run check:metrics` wired into **`prepublishOnly`** and **CI** (`.github/workflows/ci.yml`). Drift fails the build.
- `npm run metrics:sync` regenerates the whole chain (latest.json → version.json → README → llms).

## Tests
- New: `benchmark-latest.test.js`, `readme-metrics.test.js`; extended `version-meta.test.js`.
- De-brittled `features/readme-structure.test.js` + `features/version-json.test.js` to assert against the source of truth instead of hand-pinned literals.
- Full suite green: **unit 23/23, integration 92/92**.

## Supply-chain gate
Local audit **PASS** — no shell spawns · no install scripts · `main` exports the API · no fingerprinting · tarball steady (404KB, 142 files; new scripts/benchmarks are dev-only, not in `files`). External scanners re-grade after `/ship`.

## Out of scope (follow-ups)
- **H2** reproducible bundle build, **H4** document hidden CLI/MCP surface — separate issues.
- Docs-site numbers (`docs/`, `docs-vp/guide`, SVGs) are regenerated from `version.json` by `/update-docs` at release; not touched here.

> Release flow: merge to develop → `/update-docs` → `/ship`.
