### PR TITLE
docs(surface): document the real CLI/MCP/adapter surface (H4, #366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ volta install sigmap
 | `openai` | `.github/openai-context.md` | OpenAI API, Aider, local Ollama/llama.cpp |
 | `gemini` | `.github/gemini-context.md` | Google Gemini |
 | `codex` | `AGENTS.md` | OpenAI Codex (legacy) |
+| `willow` | _Willow MCP store (HTTP POST — no file)_ | [Willow](https://github.com/rudi193-cmd/willow-1.9) knowledge store |
 
 ```bash
 sigmap --adapter copilot   # default — works with Copilot, OpenCode
@@ -190,10 +191,27 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 10 on-demand tools for Claude Code and Cursor:
+**MCP server** — 15 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp
+```
+
+Tools: `read_context`, `search_signatures`, `get_map`, `create_checkpoint`, `get_routing`, `explain_file`, `list_modules`, `query_context`, `get_impact`, `get_lines`, `read_memory`, `get_callee_signatures`, plus the live-index notifications `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, and `sigmap_notify_file_deleted`. Full reference: [llms-full.txt](llms-full.txt).
+
+---
+
+## Grounded creation & guardrails
+
+Verify AI work against the live index instead of trusting it blind:
+
+```bash
+sigmap conventions                  # extract the repo's file-naming / export / test conventions
+sigmap scaffold "<name>"            # propose a convention-matched file/dir (refuses if conventions conflict)
+sigmap verify-plan <plan.md>        # check a plan: do the files/symbols exist? blast radius? scope?
+sigmap verify-ai-output <answer.md> # flag fabricated files/imports/symbols/tests in an AI answer
+sigmap review-pr                    # audit a diff: scope drift, god-node edits, missing tests, security files
+sigmap create "<task>"             # run the whole pipeline: scaffold → verify-plan → verify-ai-output → review-pr
 ```
 
 ---

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -100,6 +100,11 @@ sigmap --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited
 sigmap verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
 sigmap verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
 sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+sigmap conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
+sigmap scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
+sigmap verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
+sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely

--- a/gen-context.js
+++ b/gen-context.js
@@ -15603,6 +15603,11 @@ Usage:
   ${cmd} verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
   ${cmd} verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
   ${cmd} verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+  ${cmd} conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
+  ${cmd} scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
+  ${cmd} verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
+  ${cmd} review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+  ${cmd} create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
   ${cmd} squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
   ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
   ${cmd} ask "<query>" --no-squeeze        Disable input minimization entirely

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -100,6 +100,11 @@ sigmap --impact <file> --depth <n>       BFS depth limit (default 3, 0=unlimited
 sigmap verify-ai-output <answer.md>      Flag fake files/tests/imports/symbols/npm-scripts in an AI answer
 sigmap verify-ai-output <answer.md> --json    Hallucination report as JSON (exits 1 if issues)
 sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (red/amber/green)
+sigmap conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
+sigmap scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
+sigmap verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
+sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely

--- a/test/integration/surface-docs.test.js
+++ b/test/integration/surface-docs.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Documented-surface gate (Trust Hygiene H4).
+ * The CLI `--help`, README MCP count, and README adapter table must match the
+ * real shipped surface so the docs can never silently undersell it again.
+ * Run: node test/integration/surface-docs.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const README = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+const { TOOLS } = require(path.join(ROOT, 'src/mcp/tools.js'));
+const { listAdapters } = require(path.join(ROOT, 'packages/adapters/index.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+const help = execFileSync(process.execPath, [path.join(ROOT, 'gen-context.js'), '--help'], { encoding: 'utf8' });
+
+// The grounded-creation pipeline + conventions — wired commands that were
+// previously absent from --help.
+const COMMANDS = ['conventions', 'scaffold', 'verify-plan', 'review-pr', 'create'];
+
+for (const cmd of COMMANDS) {
+  test(`--help lists "${cmd}"`, () => {
+    const re = new RegExp(`(sigmap|gen-context)\\s+${cmd}\\b`);
+    assert.ok(re.test(help), `"${cmd}" not found in --help command list`);
+  });
+}
+
+test('README documents every grounded-creation command', () => {
+  for (const cmd of COMMANDS) {
+    assert.ok(README.includes(`sigmap ${cmd}`), `README missing "sigmap ${cmd}"`);
+  }
+});
+
+test('README states the real MCP tool count (derived from TOOLS)', () => {
+  assert.ok(README.includes(`${TOOLS.length} on-demand tools`),
+    `README must say "${TOOLS.length} on-demand tools" (TOOLS has ${TOOLS.length})`);
+});
+
+test('README does not undercount MCP tools (no stale "10 on-demand tools")', () => {
+  // Guard the specific stale claim this gate was created to fix.
+  if (TOOLS.length !== 10) {
+    assert.ok(!README.includes('10 on-demand tools'), 'stale "10 on-demand tools" still in README');
+  }
+});
+
+test('README adapter table lists every registered adapter', () => {
+  for (const name of listAdapters()) {
+    assert.ok(README.includes('`' + name + '`'), `README missing adapter \`${name}\``);
+  }
+});
+
+console.log(`\nsurface-docs: ${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 15,
-  "tests": 98,
+  "tests": 99,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #366 — v7.25.x "Trust Hygiene" **H4** (final installment after H1+H3 in v7.25.0).

## Summary
SigMap shipped more surface than it documented. This makes the docs match reality so the trust pitch holds.

## Changes
- **`gen-context.js` `--help`**: adds the five wired-but-undocumented commands — `conventions`, `scaffold`, `verify-plan`, `review-pr`, `create` (the grounded-creation pipeline) — with usage + flags.
- **`README.md`**: MCP count corrected **10 → 15** (with the full tool list + link); new **"Grounded creation & guardrails"** section documenting the commands; the **`willow`** adapter added to the integrations table (all 8 adapters now listed).
- **`test/integration/surface-docs.test.js`** (new): pins the documented surface to source — `--help` must list the commands, README's MCP count must equal `TOOLS.length`, and every `listAdapters()` entry must appear in the README table. Drift now fails CI.
- **`llms-full.txt`** regenerated (its CLI section is auto-derived from `--help`; MCP section from `src/mcp/tools.js`). `version.json` `tests` 98 → 99 (derived).

## Test plan
- [x] `node test/integration/surface-docs.test.js` — 9/9
- [x] `node test/integration/all.js` — 93/93
- [x] unit + r-language suites pass
- [x] `npm run check:metrics` · `check-bundle` · `validate:llms` — green
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 406KB)

## Milestone
Completes the v7.25.x Trust Hygiene milestone's documentation goals. **H2** (reproducible bundle build) remains the one open initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
