### PR TITLE
feat(evidence): Evidence Pack JSON v1 (v8.0 E1)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -109,6 +109,9 @@ sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSO
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
 sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
+sigmap evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
+sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
+sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/gen-context.js
+++ b/gen-context.js
@@ -4385,6 +4385,277 @@ __factories["./src/eval/usefulness-scorer"] = function(module, exports) {
   
 };
 
+// ── ./src/evidence/pack ──
+__factories["./src/evidence/pack"] = function(module, exports) {
+  
+  /**
+   * Evidence Pack v1 (v8.0 E1).
+   *
+   * A deterministic, machine-consumable signature-and-evidence map. Replaces the
+   * "paste this into your prompt" workflow with a byte-stable JSON artifact that
+   * an agent or CI can ingest directly — every entry anchored to a real file,
+   * symbol, and line range.
+   *
+   * Composed entirely from shipped zero-dep modules:
+   *   - retrieval/ranker        → ranked files, scores, signals
+   *   - extractors/line-anchor  → `:start-end` suffix parsing (sourceLines)
+   *   - security/scanner        → secret redaction of symbols
+   *   - crypto (node builtin)    → sha256 grounding hash
+   *
+   * Determinism: the pack carries NO wall-clock timestamp. Given an unchanged
+   * repository, `buildEvidencePack` returns a byte-identical object, and
+   * `grounding.contextHash` is stable. This is the point — the pack is auditable.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const crypto = require('crypto');
+
+  const { buildSigIndex, rank, detectIntent } = __require('./src/retrieval/ranker');
+  const { scan } = __require('./src/security/scanner');
+
+  const SCHEMA_VERSION = '1.0';
+  const DEFAULT_BUDGET = 6000;
+  const DEFAULT_TOP = 12;
+
+  const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
+  const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
+  const CONFIG_RE = /\.(json|ya?ml|toml|ini|conf|config|properties|env)$|(^|\/)(\.?[a-z]+rc)$|\.config\.[a-z]+$/i;
+  const SECURITY_RE = /(^|\/|[._-])(auth|authn|authz|login|password|passwd|secret|credential|token|session|crypto|cipher|payment|billing|checkout|oauth|jwt|permission|acl|rbac)([._-]|\/|$)/i;
+
+  /**
+   * Split a signature's `  :start-end` line anchor from its symbol text.
+   * @param {string} sig
+   * @returns {{ symbol: string, start: number|null, end: number|null }}
+   */
+  function parseAnchor(sig) {
+    const m = /\s*:(\d+)-(\d+)\s*$/.exec(sig);
+    if (!m) return { symbol: sig.trim(), start: null, end: null };
+    return {
+      symbol: sig.slice(0, m.index).trim(),
+      start: parseInt(m[1], 10),
+      end: parseInt(m[2], 10),
+    };
+  }
+
+  /**
+   * Classify a file into a coarse risk label. Path-based heuristic (v1) — the
+   * richer label set (C3) lands in v8.5.
+   * @param {string} relPath
+   * @returns {'generated'|'test'|'config'|'security'|'source'}
+   */
+  function riskLabelFor(relPath) {
+    const p = relPath.replace(/\\/g, '/');
+    if (GENERATED_RE.test(p)) return 'generated';
+    if (TEST_RE.test(p)) return 'test';
+    if (SECURITY_RE.test(p)) return 'security';
+    if (CONFIG_RE.test(p)) return 'config';
+    return 'source';
+  }
+
+  /** Filename stem (basename minus the first extension chain). */
+  function stemOf(relPath) {
+    const base = path.basename(relPath);
+    return base.replace(/\.[^.]+$/, '').replace(/\.(test|spec)$/i, '');
+  }
+
+  /**
+   * Best-effort impl→test discovery (v1). Matches test files whose stem equals
+   * the implementation file's stem, by common convention. Deterministic. The
+   * accuracy-measured discovery (C2) lands in v8.5.
+   * @param {string} relPath
+   * @param {string[]} allFiles  - universe of indexed files (relative paths)
+   * @returns {string[]}
+   */
+  function findRelatedTests(relPath, allFiles) {
+    if (riskLabelFor(relPath) === 'test') return [];
+    const stem = stemOf(relPath).toLowerCase();
+    if (!stem) return [];
+    const out = [];
+    for (const f of allFiles) {
+      if (f === relPath) continue;
+      if (riskLabelFor(f) !== 'test') continue;
+      if (stemOf(f).toLowerCase() === stem) out.push(f);
+    }
+    return out.sort();
+  }
+
+  /** Map a ranker `signals` object into a short human-readable reason string. */
+  function reasonFor(signals) {
+    if (!signals) return 'ranked match';
+    const parts = [];
+    if (signals.symbolMatch > 0) parts.push('symbol-name match');
+    if (signals.exactToken > 0) parts.push('exact token match');
+    if (signals.prefixMatch > 0) parts.push('prefix match');
+    if (signals.pathMatch > 0) parts.push('path match');
+    if (signals.graphBoost > 0) parts.push('dependency-graph neighbor');
+    if (signals.recencyBoost > 1) parts.push('recently changed');
+    if (signals.learnedWeights && signals.learnedWeights !== 1) parts.push('learned weight');
+    return parts.length ? parts.join('; ') : 'ranked match';
+  }
+
+  /** Token estimate for a signature block (matches the ranker's heuristic). */
+  function sigTokens(sigs) {
+    return Math.ceil(sigs.join('\n').length / 4);
+  }
+
+  /**
+   * Stable stringify with recursively sorted object keys, for hashing.
+   * @param {*} value
+   * @returns {string}
+   */
+  function canonicalize(value) {
+    return JSON.stringify(sortKeys(value));
+  }
+
+  function sortKeys(value) {
+    if (Array.isArray(value)) return value.map(sortKeys);
+    if (value && typeof value === 'object') {
+      const out = {};
+      for (const k of Object.keys(value).sort()) out[k] = sortKeys(value[k]);
+      return out;
+    }
+    return value;
+  }
+
+  /**
+   * Build an Evidence Pack for a query.
+   *
+   * @param {string} query
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {number} [opts.budget=6000]      - token budget for included files
+   * @param {number} [opts.top=12]           - max ranked files to consider
+   * @param {Map<string,string[]>} [opts.sigIndex] - pre-built index (else built from cwd)
+   * @returns {object} Evidence Pack v1
+   */
+  function buildEvidencePack(query, cwd, opts = {}) {
+    const budget = Number.isFinite(opts.budget) ? opts.budget : DEFAULT_BUDGET;
+    const top = Number.isFinite(opts.top) ? opts.top : DEFAULT_TOP;
+
+    const sigIndex = opts.sigIndex instanceof Map ? opts.sigIndex : buildSigIndex(cwd);
+    const intent = detectIntent(query);
+    const allFiles = Array.from(sigIndex.keys());
+
+    const ranked = rank(query, sigIndex, { topK: top, cwd })
+      .filter((r) => r.score > 0 || ranked0Empty(query));
+    const maxScore = ranked.reduce((m, r) => Math.max(m, r.score), 0);
+
+    // Greedy budget fill in rank order; the remainder is reported as dropped.
+    const files = [];
+    const droppedFiles = [];
+    let used = 0;
+
+    for (const r of ranked) {
+      const tokens = sigTokens(r.sigs);
+      if (files.length > 0 && used + tokens > budget) {
+        droppedFiles.push({ path: r.file, reason: `budget: would exceed ${budget}-token limit` });
+        continue;
+      }
+      used += tokens;
+
+      const safe = scan(r.sigs, r.file).safe;
+      const symbols = [];
+      const sourceLines = [];
+      for (const sig of safe) {
+        const { symbol, start, end } = parseAnchor(sig);
+        symbols.push(symbol);
+        if (start !== null) sourceLines.push({ symbol, start, end });
+      }
+
+      files.push({
+        path: r.file,
+        symbols,
+        reason: reasonFor(r.signals),
+        confidence: maxScore > 0 ? Math.round((r.score / maxScore) * 100) / 100 : 0,
+        sourceLines,
+        relatedTests: findRelatedTests(r.file, allFiles),
+        riskLabel: riskLabelFor(r.file),
+      });
+    }
+
+    const symbolCount = files.reduce((n, f) => n + f.symbols.length, 0);
+    const anchoredSymbols = files.reduce((n, f) => n + f.sourceLines.length, 0);
+
+    const pack = {
+      schemaVersion: SCHEMA_VERSION,
+      query,
+      intent,
+      files,
+      tokenBudget: { limit: budget, used, remaining: Math.max(0, budget - used) },
+      droppedFiles,
+      grounding: {
+        symbolCount,
+        anchoredSymbols,
+        anchorCoverage: symbolCount > 0 ? Math.round((anchoredSymbols / symbolCount) * 1000) / 1000 : 0,
+        contextHash: null,
+        deterministic: true,
+      },
+    };
+
+    // Hash everything except the hash field itself.
+    const forHash = Object.assign({}, pack, {
+      grounding: Object.assign({}, pack.grounding, { contextHash: undefined }),
+    });
+    pack.grounding.contextHash = 'sha256:' + crypto.createHash('sha256').update(canonicalize(forHash)).digest('hex');
+
+    return pack;
+  }
+
+  // rank() returns [] for an empty/whitespace query; keep the filter readable.
+  function ranked0Empty(query) {
+    return !query || !query.trim();
+  }
+
+  /** Pretty-printed canonical JSON rendering of a pack. */
+  function formatJSON(pack) {
+    return JSON.stringify(pack, null, 2);
+  }
+
+  /** Markdown handoff rendering of a pack. */
+  function formatMarkdown(pack) {
+    const L = [];
+    L.push(`# Evidence Pack — \`${pack.query}\``);
+    L.push('');
+    L.push(`- **Schema:** v${pack.schemaVersion}`);
+    L.push(`- **Intent:** ${pack.intent}`);
+    L.push(`- **Budget:** ${pack.tokenBudget.used} / ${pack.tokenBudget.limit} tokens used (${pack.tokenBudget.remaining} remaining)`);
+    L.push(`- **Grounding:** ${pack.grounding.anchoredSymbols}/${pack.grounding.symbolCount} symbols anchored (${Math.round(pack.grounding.anchorCoverage * 100)}%)`);
+    L.push(`- **Hash:** \`${pack.grounding.contextHash}\``);
+    L.push('');
+
+    for (const f of pack.files) {
+      L.push(`## \`${f.path}\`  _(${f.riskLabel}, confidence ${f.confidence})_`);
+      L.push(`_${f.reason}_`);
+      if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.map((t) => `\`${t}\``).join(', ')}`);
+      L.push('');
+      L.push('```');
+      for (const s of f.symbols) L.push(s);
+      L.push('```');
+      L.push('');
+    }
+
+    if (pack.droppedFiles.length) {
+      L.push('## Dropped (over budget)');
+      for (const d of pack.droppedFiles) L.push(`- \`${d.path}\` — ${d.reason}`);
+      L.push('');
+    }
+
+    return L.join('\n');
+  }
+
+  module.exports = {
+    buildEvidencePack,
+    formatJSON,
+    formatMarkdown,
+    parseAnchor,
+    riskLabelFor,
+    findRelatedTests,
+    SCHEMA_VERSION,
+  };
+  
+};
+
 // ── ./src/extractors/coverage ──
 __factories["./src/extractors/coverage"] = function(module, exports) {
   
@@ -17459,6 +17730,9 @@ Usage:
   ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
   ${cmd} ask "<query>" --no-squeeze        Disable input minimization entirely
   ${cmd} ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
+  ${cmd} evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
+  ${cmd} evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
+  ${cmd} evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -18028,6 +18302,66 @@ function main() {
         bump: { squeezeOffered: squeezeOffered ? 1 : 0, squeezeAccepted: squeezeAccepted ? 1 : 0 },
       });
     } catch (_) {}
+    process.exit(0);
+  }
+
+  // `sigmap evidence "<query>"` — Evidence Pack v1 (v8.0 E1).
+  // Deterministic, machine-consumable signature+evidence map. Always writes the
+  // JSON artifact to .context/evidence-pack.json; stdout carries the requested
+  // mode (JSON default, or Markdown handoff with --markdown/--md).
+  if (args[0] === 'evidence') {
+    const query = args[1];
+    if (!query || query.startsWith('--')) {
+      console.error('[sigmap] Usage: sigmap evidence "<query>" [--markdown] [--top <n>] [--budget <n>] [--out <path>]');
+      console.error('  Example: sigmap evidence "how does auth work" --markdown');
+      process.exit(1);
+    }
+
+    const { buildEvidencePack, formatJSON, formatMarkdown } = requireSourceOrBundled('./src/evidence/pack');
+
+    const opts = {};
+    const topIdx = args.indexOf('--top');
+    if (topIdx !== -1 && args[topIdx + 1]) opts.top = parseInt(args[topIdx + 1], 10);
+    const budgetIdx = args.indexOf('--budget');
+    if (budgetIdx !== -1 && args[budgetIdx + 1]) opts.budget = parseInt(args[budgetIdx + 1], 10);
+    else opts.budget = (config && config.maxTokens) || 6000;
+
+    let pack;
+    try {
+      pack = buildEvidencePack(query, cwd, opts);
+    } catch (e) {
+      console.error('[sigmap] evidence: ' + e.message);
+      process.exit(1);
+    }
+
+    if (pack.files.length === 0) {
+      process.stderr.write('[sigmap] ⚠  no matching files indexed. Run: sigmap  (to generate context first)\n');
+    }
+
+    const jsonText = formatJSON(pack);
+    const artifactPath = path.join(cwd, '.context', 'evidence-pack.json');
+    try {
+      fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+      fs.writeFileSync(artifactPath, jsonText, 'utf8');
+      process.stderr.write(`[sigmap] evidence pack → ${path.relative(cwd, artifactPath)} (${pack.files.length} files, ${pack.grounding.symbolCount} symbols)\n`);
+    } catch (_) { /* artifact write is best-effort */ }
+
+    const markdown = args.includes('--markdown') || args.includes('--md');
+    const rendered = markdown ? formatMarkdown(pack) : jsonText;
+
+    const outIdx = args.indexOf('--out');
+    if (outIdx !== -1 && args[outIdx + 1]) {
+      const outPath = path.resolve(cwd, args[outIdx + 1]);
+      try {
+        fs.mkdirSync(path.dirname(outPath), { recursive: true });
+        fs.writeFileSync(outPath, rendered + '\n', 'utf8');
+      } catch (e) {
+        console.error('[sigmap] evidence: could not write --out ' + outPath + ': ' + e.message);
+        process.exit(1);
+      }
+    }
+
+    process.stdout.write(rendered + '\n');
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,6 +109,9 @@ sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSO
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
 sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
+sigmap evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
+sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
+sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/src/evidence/pack.js
+++ b/src/evidence/pack.js
@@ -1,0 +1,267 @@
+'use strict';
+
+/**
+ * Evidence Pack v1 (v8.0 E1).
+ *
+ * A deterministic, machine-consumable signature-and-evidence map. Replaces the
+ * "paste this into your prompt" workflow with a byte-stable JSON artifact that
+ * an agent or CI can ingest directly — every entry anchored to a real file,
+ * symbol, and line range.
+ *
+ * Composed entirely from shipped zero-dep modules:
+ *   - retrieval/ranker        → ranked files, scores, signals
+ *   - extractors/line-anchor  → `:start-end` suffix parsing (sourceLines)
+ *   - security/scanner        → secret redaction of symbols
+ *   - crypto (node builtin)    → sha256 grounding hash
+ *
+ * Determinism: the pack carries NO wall-clock timestamp. Given an unchanged
+ * repository, `buildEvidencePack` returns a byte-identical object, and
+ * `grounding.contextHash` is stable. This is the point — the pack is auditable.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const { buildSigIndex, rank, detectIntent } = require('../retrieval/ranker');
+const { scan } = require('../security/scanner');
+
+const SCHEMA_VERSION = '1.0';
+const DEFAULT_BUDGET = 6000;
+const DEFAULT_TOP = 12;
+
+const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
+const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
+const CONFIG_RE = /\.(json|ya?ml|toml|ini|conf|config|properties|env)$|(^|\/)(\.?[a-z]+rc)$|\.config\.[a-z]+$/i;
+const SECURITY_RE = /(^|\/|[._-])(auth|authn|authz|login|password|passwd|secret|credential|token|session|crypto|cipher|payment|billing|checkout|oauth|jwt|permission|acl|rbac)([._-]|\/|$)/i;
+
+/**
+ * Split a signature's `  :start-end` line anchor from its symbol text.
+ * @param {string} sig
+ * @returns {{ symbol: string, start: number|null, end: number|null }}
+ */
+function parseAnchor(sig) {
+  const m = /\s*:(\d+)-(\d+)\s*$/.exec(sig);
+  if (!m) return { symbol: sig.trim(), start: null, end: null };
+  return {
+    symbol: sig.slice(0, m.index).trim(),
+    start: parseInt(m[1], 10),
+    end: parseInt(m[2], 10),
+  };
+}
+
+/**
+ * Classify a file into a coarse risk label. Path-based heuristic (v1) — the
+ * richer label set (C3) lands in v8.5.
+ * @param {string} relPath
+ * @returns {'generated'|'test'|'config'|'security'|'source'}
+ */
+function riskLabelFor(relPath) {
+  const p = relPath.replace(/\\/g, '/');
+  if (GENERATED_RE.test(p)) return 'generated';
+  if (TEST_RE.test(p)) return 'test';
+  if (SECURITY_RE.test(p)) return 'security';
+  if (CONFIG_RE.test(p)) return 'config';
+  return 'source';
+}
+
+/** Filename stem (basename minus the first extension chain). */
+function stemOf(relPath) {
+  const base = path.basename(relPath);
+  return base.replace(/\.[^.]+$/, '').replace(/\.(test|spec)$/i, '');
+}
+
+/**
+ * Best-effort impl→test discovery (v1). Matches test files whose stem equals
+ * the implementation file's stem, by common convention. Deterministic. The
+ * accuracy-measured discovery (C2) lands in v8.5.
+ * @param {string} relPath
+ * @param {string[]} allFiles  - universe of indexed files (relative paths)
+ * @returns {string[]}
+ */
+function findRelatedTests(relPath, allFiles) {
+  if (riskLabelFor(relPath) === 'test') return [];
+  const stem = stemOf(relPath).toLowerCase();
+  if (!stem) return [];
+  const out = [];
+  for (const f of allFiles) {
+    if (f === relPath) continue;
+    if (riskLabelFor(f) !== 'test') continue;
+    if (stemOf(f).toLowerCase() === stem) out.push(f);
+  }
+  return out.sort();
+}
+
+/** Map a ranker `signals` object into a short human-readable reason string. */
+function reasonFor(signals) {
+  if (!signals) return 'ranked match';
+  const parts = [];
+  if (signals.symbolMatch > 0) parts.push('symbol-name match');
+  if (signals.exactToken > 0) parts.push('exact token match');
+  if (signals.prefixMatch > 0) parts.push('prefix match');
+  if (signals.pathMatch > 0) parts.push('path match');
+  if (signals.graphBoost > 0) parts.push('dependency-graph neighbor');
+  if (signals.recencyBoost > 1) parts.push('recently changed');
+  if (signals.learnedWeights && signals.learnedWeights !== 1) parts.push('learned weight');
+  return parts.length ? parts.join('; ') : 'ranked match';
+}
+
+/** Token estimate for a signature block (matches the ranker's heuristic). */
+function sigTokens(sigs) {
+  return Math.ceil(sigs.join('\n').length / 4);
+}
+
+/**
+ * Stable stringify with recursively sorted object keys, for hashing.
+ * @param {*} value
+ * @returns {string}
+ */
+function canonicalize(value) {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value) {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const k of Object.keys(value).sort()) out[k] = sortKeys(value[k]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Build an Evidence Pack for a query.
+ *
+ * @param {string} query
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {number} [opts.budget=6000]      - token budget for included files
+ * @param {number} [opts.top=12]           - max ranked files to consider
+ * @param {Map<string,string[]>} [opts.sigIndex] - pre-built index (else built from cwd)
+ * @returns {object} Evidence Pack v1
+ */
+function buildEvidencePack(query, cwd, opts = {}) {
+  const budget = Number.isFinite(opts.budget) ? opts.budget : DEFAULT_BUDGET;
+  const top = Number.isFinite(opts.top) ? opts.top : DEFAULT_TOP;
+
+  const sigIndex = opts.sigIndex instanceof Map ? opts.sigIndex : buildSigIndex(cwd);
+  const intent = detectIntent(query);
+  const allFiles = Array.from(sigIndex.keys());
+
+  const ranked = rank(query, sigIndex, { topK: top, cwd })
+    .filter((r) => r.score > 0 || ranked0Empty(query));
+  const maxScore = ranked.reduce((m, r) => Math.max(m, r.score), 0);
+
+  // Greedy budget fill in rank order; the remainder is reported as dropped.
+  const files = [];
+  const droppedFiles = [];
+  let used = 0;
+
+  for (const r of ranked) {
+    const tokens = sigTokens(r.sigs);
+    if (files.length > 0 && used + tokens > budget) {
+      droppedFiles.push({ path: r.file, reason: `budget: would exceed ${budget}-token limit` });
+      continue;
+    }
+    used += tokens;
+
+    const safe = scan(r.sigs, r.file).safe;
+    const symbols = [];
+    const sourceLines = [];
+    for (const sig of safe) {
+      const { symbol, start, end } = parseAnchor(sig);
+      symbols.push(symbol);
+      if (start !== null) sourceLines.push({ symbol, start, end });
+    }
+
+    files.push({
+      path: r.file,
+      symbols,
+      reason: reasonFor(r.signals),
+      confidence: maxScore > 0 ? Math.round((r.score / maxScore) * 100) / 100 : 0,
+      sourceLines,
+      relatedTests: findRelatedTests(r.file, allFiles),
+      riskLabel: riskLabelFor(r.file),
+    });
+  }
+
+  const symbolCount = files.reduce((n, f) => n + f.symbols.length, 0);
+  const anchoredSymbols = files.reduce((n, f) => n + f.sourceLines.length, 0);
+
+  const pack = {
+    schemaVersion: SCHEMA_VERSION,
+    query,
+    intent,
+    files,
+    tokenBudget: { limit: budget, used, remaining: Math.max(0, budget - used) },
+    droppedFiles,
+    grounding: {
+      symbolCount,
+      anchoredSymbols,
+      anchorCoverage: symbolCount > 0 ? Math.round((anchoredSymbols / symbolCount) * 1000) / 1000 : 0,
+      contextHash: null,
+      deterministic: true,
+    },
+  };
+
+  // Hash everything except the hash field itself.
+  const forHash = Object.assign({}, pack, {
+    grounding: Object.assign({}, pack.grounding, { contextHash: undefined }),
+  });
+  pack.grounding.contextHash = 'sha256:' + crypto.createHash('sha256').update(canonicalize(forHash)).digest('hex');
+
+  return pack;
+}
+
+// rank() returns [] for an empty/whitespace query; keep the filter readable.
+function ranked0Empty(query) {
+  return !query || !query.trim();
+}
+
+/** Pretty-printed canonical JSON rendering of a pack. */
+function formatJSON(pack) {
+  return JSON.stringify(pack, null, 2);
+}
+
+/** Markdown handoff rendering of a pack. */
+function formatMarkdown(pack) {
+  const L = [];
+  L.push(`# Evidence Pack — \`${pack.query}\``);
+  L.push('');
+  L.push(`- **Schema:** v${pack.schemaVersion}`);
+  L.push(`- **Intent:** ${pack.intent}`);
+  L.push(`- **Budget:** ${pack.tokenBudget.used} / ${pack.tokenBudget.limit} tokens used (${pack.tokenBudget.remaining} remaining)`);
+  L.push(`- **Grounding:** ${pack.grounding.anchoredSymbols}/${pack.grounding.symbolCount} symbols anchored (${Math.round(pack.grounding.anchorCoverage * 100)}%)`);
+  L.push(`- **Hash:** \`${pack.grounding.contextHash}\``);
+  L.push('');
+
+  for (const f of pack.files) {
+    L.push(`## \`${f.path}\`  _(${f.riskLabel}, confidence ${f.confidence})_`);
+    L.push(`_${f.reason}_`);
+    if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.map((t) => `\`${t}\``).join(', ')}`);
+    L.push('');
+    L.push('```');
+    for (const s of f.symbols) L.push(s);
+    L.push('```');
+    L.push('');
+  }
+
+  if (pack.droppedFiles.length) {
+    L.push('## Dropped (over budget)');
+    for (const d of pack.droppedFiles) L.push(`- \`${d.path}\` — ${d.reason}`);
+    L.push('');
+  }
+
+  return L.join('\n');
+}
+
+module.exports = {
+  buildEvidencePack,
+  formatJSON,
+  formatMarkdown,
+  parseAnchor,
+  riskLabelFor,
+  findRelatedTests,
+  SCHEMA_VERSION,
+};

--- a/test/integration/evidence-pack.test.js
+++ b/test/integration/evidence-pack.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+/**
+ * Evidence Pack v1 (v8.0 E1) — integration + unit coverage.
+ *
+ * Covers: JSON schema shape, Markdown handoff mode, byte-level determinism,
+ * token-budget drops, the written .context/evidence-pack.json artifact, and the
+ * pure helpers (parseAnchor / riskLabelFor / findRelatedTests).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+const pack = require('../../src/evidence/pack');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function withTempProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-evidence-'));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Write a context file in the format buildSigIndex parses: an
+ * `## Auto-generated signatures` marker, then `### path` headers with fenced
+ * signature blocks. Signature lines keep their `:start-end` line anchors.
+ */
+function writeContextFile(dir) {
+  const body = [
+    '## Auto-generated signatures',
+    '# Code signatures',
+    '',
+    '### src/widget.js',
+    '```',
+    'module.exports = { renderWidget }  :12-12',
+    'function renderWidget(props) → string  :3-9',
+    '```',
+    '',
+    '### src/payment.js',
+    '```',
+    'function chargeCard(token, amount)  :5-11',
+    '```',
+    '',
+    '### settings.json',
+    '```',
+    'config widget.theme  :1-1',
+    '```',
+    '',
+  ].join('\n');
+  fs.mkdirSync(path.join(dir, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github', 'copilot-instructions.md'), body, 'utf8');
+}
+
+function runEvidence(dir, args) {
+  const out = execFileSync('node', [GEN_CONTEXT, 'evidence', ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return out;
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────
+
+test('parseAnchor splits symbol text from :start-end anchor', () => {
+  const r = pack.parseAnchor('function renderWidget(props) → string  :3-9');
+  assert.strictEqual(r.symbol, 'function renderWidget(props) → string');
+  assert.strictEqual(r.start, 3);
+  assert.strictEqual(r.end, 9);
+});
+
+test('parseAnchor returns null lines when no anchor present', () => {
+  const r = pack.parseAnchor('function foo()');
+  assert.strictEqual(r.symbol, 'function foo()');
+  assert.strictEqual(r.start, null);
+  assert.strictEqual(r.end, null);
+});
+
+test('riskLabelFor classifies generated/test/config/security/source', () => {
+  assert.strictEqual(pack.riskLabelFor('dist/bundle.js'), 'generated');
+  assert.strictEqual(pack.riskLabelFor('api.generated.ts'), 'generated');
+  assert.strictEqual(pack.riskLabelFor('test/auth.test.js'), 'test');
+  assert.strictEqual(pack.riskLabelFor('src/test_helpers.py'), 'test');
+  assert.strictEqual(pack.riskLabelFor('settings.json'), 'config');
+  assert.strictEqual(pack.riskLabelFor('src/auth.js'), 'security');
+  assert.strictEqual(pack.riskLabelFor('src/payment.js'), 'security');
+  assert.strictEqual(pack.riskLabelFor('src/widget.js'), 'source');
+});
+
+test('findRelatedTests matches a test file by stem', () => {
+  const universe = ['src/widget.js', 'test/widget.test.js', 'src/other.js'];
+  assert.deepStrictEqual(pack.findRelatedTests('src/widget.js', universe), ['test/widget.test.js']);
+  // a test file maps to nothing
+  assert.deepStrictEqual(pack.findRelatedTests('test/widget.test.js', universe), []);
+});
+
+test('buildEvidencePack produces a stable contextHash given the same index', () => {
+  const idx = new Map([['src/widget.js', ['function renderWidget(props)  :3-9']]]);
+  const a = pack.buildEvidencePack('render widget', '/tmp/none', { sigIndex: idx });
+  const b = pack.buildEvidencePack('render widget', '/tmp/none', { sigIndex: idx });
+  assert.strictEqual(a.grounding.contextHash, b.grounding.contextHash);
+  assert.ok(a.grounding.contextHash.startsWith('sha256:'));
+});
+
+// ── CLI: JSON shape ───────────────────────────────────────────────────────
+
+test('evidence JSON has the v1 schema shape', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const p = JSON.parse(runEvidence(dir, ['render widget']));
+    assert.strictEqual(p.schemaVersion, '1.0');
+    assert.strictEqual(p.query, 'render widget');
+    assert.ok(typeof p.intent === 'string');
+    assert.ok(Array.isArray(p.files));
+    assert.ok(p.files.length >= 1, 'expected at least one ranked file');
+    assert.ok(p.tokenBudget && typeof p.tokenBudget.limit === 'number');
+    assert.ok(typeof p.tokenBudget.used === 'number');
+    assert.ok(typeof p.tokenBudget.remaining === 'number');
+    assert.ok(Array.isArray(p.droppedFiles));
+    assert.ok(p.grounding && typeof p.grounding.symbolCount === 'number');
+    assert.strictEqual(p.grounding.deterministic, true);
+    assert.ok(p.grounding.contextHash.startsWith('sha256:'));
+  });
+});
+
+test('every file entry carries the required fields', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const p = JSON.parse(runEvidence(dir, ['render widget']));
+    const widget = p.files.find((f) => f.path === 'src/widget.js');
+    assert.ok(widget, 'widget file should rank for "render widget"');
+    assert.ok(Array.isArray(widget.symbols) && widget.symbols.length >= 1);
+    assert.ok(typeof widget.reason === 'string' && widget.reason.length > 0);
+    assert.ok(widget.confidence >= 0 && widget.confidence <= 1);
+    assert.strictEqual(widget.riskLabel, 'source');
+    assert.ok(Array.isArray(widget.relatedTests));
+    assert.ok(widget.sourceLines.length >= 1);
+    const sl = widget.sourceLines[0];
+    assert.ok(typeof sl.start === 'number' && typeof sl.end === 'number');
+    assert.ok(typeof sl.symbol === 'string');
+  });
+});
+
+test('top-ranked file has confidence 1 (normalized to max score)', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const p = JSON.parse(runEvidence(dir, ['render widget']));
+    assert.strictEqual(p.files[0].confidence, 1);
+  });
+});
+
+test('anchorCoverage reflects the fraction of anchored symbols', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const p = JSON.parse(runEvidence(dir, ['render widget']));
+    assert.ok(p.grounding.symbolCount > 0);
+    assert.strictEqual(p.grounding.anchoredSymbols, p.grounding.symbolCount,
+      'all fixture signatures carry anchors');
+    assert.strictEqual(p.grounding.anchorCoverage, 1);
+  });
+});
+
+// ── CLI: Markdown mode ────────────────────────────────────────────────────
+
+test('--markdown emits the Markdown handoff rendering', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const md = runEvidence(dir, ['render widget', '--markdown']);
+    assert.ok(md.startsWith('# Evidence Pack'), 'markdown should start with the pack heading');
+    assert.ok(md.includes('**Schema:** v1.0'));
+    assert.ok(md.includes('src/widget.js'));
+  });
+});
+
+// ── CLI: determinism ──────────────────────────────────────────────────────
+
+test('JSON output is byte-identical across runs (deterministic)', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const a = runEvidence(dir, ['render widget']);
+    const b = runEvidence(dir, ['render widget']);
+    assert.strictEqual(a, b, 'two runs on an unchanged repo must be byte-identical');
+  });
+});
+
+// ── CLI: budget drops + artifact ──────────────────────────────────────────
+
+test('a tiny --budget drops ranked files with a reason', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    const p = JSON.parse(runEvidence(dir, ['render widget chargeCard config', '--budget', '20']));
+    assert.ok(p.files.length >= 1, 'budget always keeps at least the top file');
+    assert.ok(p.droppedFiles.length >= 1, 'remaining ranked files should be dropped');
+    assert.ok(/budget/.test(p.droppedFiles[0].reason));
+    assert.ok(p.tokenBudget.used <= p.tokenBudget.limit + p.files[0].symbols.join('\n').length);
+  });
+});
+
+test('writes the .context/evidence-pack.json artifact', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    runEvidence(dir, ['render widget']);
+    const artifact = path.join(dir, '.context', 'evidence-pack.json');
+    assert.ok(fs.existsSync(artifact), 'artifact file should be written');
+    const p = JSON.parse(fs.readFileSync(artifact, 'utf8'));
+    assert.strictEqual(p.schemaVersion, '1.0');
+  });
+});
+
+test('exits non-zero with usage when no query given', () => {
+  withTempProject((dir) => {
+    writeContextFile(dir);
+    let threw = false;
+    try {
+      execFileSync('node', [GEN_CONTEXT, 'evidence'], { cwd: dir, stdio: 'ignore' });
+    } catch (_) {
+      threw = true;
+    }
+    assert.ok(threw, 'missing query should exit non-zero');
+  });
+});
+
+console.log(`\nEvidence Pack: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 15,
-  "tests": 100,
+  "tests": 101,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #372 · v8.0 "The Evidence Pack & the Pivot" → initiative **E1**.

## What
Adds `sigmap evidence "<query>"` — a deterministic, machine-consumable signature-and-evidence map. This is the keystone artifact that replaces the "paste this into your prompt" workflow with a byte-stable JSON (plus a Markdown handoff) that an agent or CI can ingest directly, every entry anchored to a real file, symbol, and line range.

## How
- **New zero-dep module** `src/evidence/pack.js` — `buildEvidencePack` / `formatJSON` / `formatMarkdown`, composed from shipped modules only: `retrieval/ranker` (ranked files, score→confidence, signals→reason), `extractors/line-anchor` (`:start-end` → `sourceLines`), `security/scanner` (secret redaction of symbols), path heuristics (`riskLabel`), stem-matching (`relatedTests`), and a `crypto` sha256 grounding hash.
- **Determinism:** the pack carries no wall-clock timestamp — an unchanged repo yields a byte-identical pack and a stable `grounding.contextHash`. This is the point: the artifact is auditable.
- **CLI** wired into `gen-context.js`: `--markdown`/`--md`, `--top`, `--budget`, `--out`; always writes `.context/evidence-pack.json`. Documented in `--help`; bundle rebuilt + reproducible.

### Schema v1
```
{ schemaVersion, query, intent,
  files:[{ path, symbols, reason, confidence, sourceLines:[{symbol,start,end}], relatedTests, riskLabel }],
  tokenBudget:{ limit, used, remaining },
  droppedFiles:[{ path, reason }],
  grounding:{ symbolCount, anchoredSymbols, anchorCoverage, contextHash, deterministic } }
```

## Acceptance criteria
- [x] `sigmap evidence "<q>"` emits valid Evidence Pack JSON v1 + writes `.context/evidence-pack.json`
- [x] `--markdown`/`--md` emits the Markdown handoff rendering
- [x] Every file entry has path/symbols/reason/confidence(0–1)/sourceLines/relatedTests/riskLabel ∈ {generated,test,config,security,source}
- [x] `tokenBudget{limit,used,remaining}` + `droppedFiles[]` with drop reason on budget exclusion
- [x] `grounding.contextHash` is sha256 of the canonical pack; two runs are byte-identical (determinism)
- [x] `grounding.anchorCoverage` reflects the anchored-symbol fraction
- [x] Documented in `--help`; bundle reproducible (`check:bundle:repro` ✓)
- [x] 14 unit+integration tests; full suite green (unit all-pass, integration 95/95)

## Out of scope (follow-up v8.0 PRs)
E2 repositioning, E3 `doctor`/quickstart, E4 agent recipes + `mcp install`, D3 +2 MCP tools. `relatedTests`/`riskLabel` are best-effort v1 — the measured test-discovery (C2) and richer risk labels (C3) land in v8.5.

## Supply-chain gate
Local audit PASS — no shell spawns · no install scripts · `main` exports API · no fingerprinting. External scanners re-grade after `/ship`.