### PR TITLE
feat(mcp): get_diff_context & get_architecture_overview (v8.0 D3, 15→17 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,13 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 15 on-demand tools for Claude Code and Cursor:
+**MCP server** — 17 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp
 ```
 
-Tools: `read_context`, `search_signatures`, `get_map`, `create_checkpoint`, `get_routing`, `explain_file`, `list_modules`, `query_context`, `get_impact`, `get_lines`, `read_memory`, `get_callee_signatures`, plus the live-index notifications `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, and `sigmap_notify_file_deleted`. Full reference: [llms-full.txt](llms-full.txt).
+Tools: `read_context`, `search_signatures`, `get_map`, `create_checkpoint`, `get_routing`, `explain_file`, `list_modules`, `query_context`, `get_impact`, `get_lines`, `read_memory`, `get_callee_signatures`, `get_diff_context` (changed files + signatures + blast radius), `get_architecture_overview` (modules, hub files, cycles), plus the live-index notifications `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, and `sigmap_notify_file_deleted`. Full reference: [llms-full.txt](llms-full.txt).
 
 ---
 

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,13 +1,13 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 15 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 17 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
       content: "SigMap MCP Server — on-demand codebase context"
   - - meta
     - property: og:description
-      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 15 MCP tools over stdio."
+      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 17 MCP tools over stdio."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/mcp"
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 15 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 17 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 15 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 17 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.
@@ -117,6 +117,8 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `get_impact` | Returns the blast radius of a file — direct importers, transitive importers, affected tests and routes. | `file` (required string), `depth` (optional number, default 3) | `get_impact(file="src/auth/service.ts")` |
 | `get_lines` | **Surgical Context** demand-driven fetch: returns an exact line range from a file behind a `:start-end` anchor. Clamped to file bounds, secret-scanned, sandboxed to the project root. New in v6.12.0. | `file` (required string), `start` (required number), `end` (required number) | `get_lines(file="src/config/loader.js", start=42, end=58)` |
 | `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.15.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
+| `get_diff_context` | Returns every changed file (working tree, staged, or vs a base ref) with its current signatures + blast radius (importers, tests, routes) + risk label. Lists files shell-free. New in v8.0. | `base` (optional string), `staged` (optional bool), `depth` (optional number, default 2) | `get_diff_context(base="main")` |
+| `get_architecture_overview` | One-call codebase map: module breakdown (files/tokens), most-depended-on hub files, dependency-cycle count, route totals. Extends `get_map`. New in v8.0. | none | `get_architecture_overview()` |
 
 ## Token cost per tool call
 
@@ -147,7 +149,7 @@ Use `ask` to create `.context/query-context.md`, let the model answer, then run 
 
 ## Test the server
 
-Send a raw JSON-RPC request to confirm the server starts and returns all 11 tool definitions.
+Send a raw JSON-RPC request to confirm the server starts and returns all 17 tool definitions.
 
 ```bash
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node gen-context.js --mcp
@@ -171,7 +173,9 @@ Expected output:
       { "name": "query_context" },
       { "name": "get_impact" },
       { "name": "get_lines" },
-      { "name": "read_memory" }
+      { "name": "read_memory" },
+      { "name": "get_diff_context" },
+      { "name": "get_architecture_overview" }
     ]
   }
 }

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -24,7 +24,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 52.2% |
 | Prompts per task | 2.84 | 1.72 (39.4% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 15 |
+| MCP tools | — | 17 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -122,7 +122,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 15 tools
+## MCP server — 17 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -248,6 +248,22 @@ Tell SigMap a file was deleted so its symbols are dropped from the live index.
 
 ```
 Input:  { path: string }
+```
+
+### get_diff_context
+
+For every changed file in the working tree (or staged, or vs a base ref), return its current signatures plus blast radius — direct importers, transitive count, and affected tests/routes — with a risk label. One call gives an agent everything a code review or a safe edit needs. Lists changed files shell-free (git binary, never a shell).
+
+```
+Input:  { base?: string, staged?: boolean, depth?: number }
+```
+
+### get_architecture_overview
+
+A high-level map of the codebase in one call: module breakdown (files/tokens), the most depended-on "hub" files, the dependency-cycle count, and route totals. Extends get_map — use it to orient in an unfamiliar repo before drilling in with read_context / query_context.
+
+```
+Input:  { } (no arguments)
 ```
 
 ---

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -27,7 +27,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 52.2% vs 10% without SigMap
 - Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 33 supported · MCP tools: 15
+- Languages: 33 supported · MCP tools: 17
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/gen-context.js
+++ b/gen-context.js
@@ -12109,7 +12109,182 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     }
   }
 
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted };
+  /**
+   * List the files changed in the working tree, staged area, or vs a base ref.
+   * Shell-free (routes through src/util/git.js). Returns relative paths.
+   */
+  function _changedFiles(cwd, args) {
+    const { tryGit } = __require('./src/util/git');
+    let out = '';
+    if (args.base) {
+      if (!/^[A-Za-z0-9._/\-~^]+$/.test(args.base)) return [];
+      out = tryGit(['diff', `${args.base}..HEAD`, '--name-only'], { cwd });
+    } else if (args.staged) {
+      out = tryGit(['diff', '--cached', '--name-only'], { cwd });
+    } else {
+      out = tryGit(['diff', 'HEAD', '--name-only'], { cwd });
+    }
+    return out.split('\n').map((s) => s.trim()).filter(Boolean);
+  }
+
+  /**
+   * get_diff_context({ base?, staged?, depth? }) → string
+   *
+   * For each changed file: its extracted signatures + blast radius (direct
+   * importers, transitive count, affected tests/routes) + a risk label.
+   * Hands an agent everything a review or a safe edit needs in one call.
+   */
+  function getDiffContext(args, cwd) {
+    try {
+      const a = args || {};
+      const files = _changedFiles(cwd, a);
+      if (files.length === 0) {
+        return '_No changed files detected._ (Outside a git repo, or the working tree / selected range is clean.)';
+      }
+
+      const { extractFile, langFor } = __require('./src/extractors/dispatch');
+      const { analyzeImpact } = __require('./src/graph/impact');
+      let riskLabelFor;
+      try { ({ riskLabelFor } = __require('./src/evidence/pack')); } catch (_) { riskLabelFor = () => 'source'; }
+
+      const depth = Math.max(0, parseInt(a.depth, 10) || 2);
+      const srcFiles = files.filter((f) => langFor(f));
+      let impactByFile = new Map();
+      try {
+        const impacts = analyzeImpact(srcFiles, cwd, { depth });
+        impactByFile = new Map(impacts.map((r) => [r.file, r.impact]));
+      } catch (_) { /* graph optional */ }
+
+      const scope = a.base ? `vs ${a.base}` : (a.staged ? 'staged' : 'working tree');
+      const out = [
+        `# Diff context (${scope})`,
+        '',
+        `**${files.length} changed file${files.length === 1 ? '' : 's'}** · ${srcFiles.length} with extractable signatures`,
+        '',
+      ];
+
+      for (const rel of files) {
+        out.push(`## \`${rel}\``);
+        if (!langFor(rel)) { out.push('_non-source file (no signatures)_', ''); continue; }
+
+        out.push(`_risk: ${riskLabelFor(rel)}_`);
+        const impact = impactByFile.get(rel);
+        if (impact) {
+          out.push(
+            `**Blast radius:** ${impact.totalImpact} file(s) impacted — ` +
+            `${impact.direct.length} direct importer(s), ${impact.transitive.length} transitive` +
+            (impact.tests.length ? `, ${impact.tests.length} test(s)` : '') +
+            (impact.routes.length ? `, ${impact.routes.length} route(s)` : '')
+          );
+          if (impact.direct.length) {
+            out.push(`Direct importers: ${impact.direct.slice(0, 8).map((f) => '`' + f + '`').join(', ')}` + (impact.direct.length > 8 ? ' …' : ''));
+          }
+          if (impact.tests.length) {
+            out.push(`Tests to run: ${impact.tests.slice(0, 8).map((f) => '`' + f + '`').join(', ')}`);
+          }
+        } else {
+          out.push('**Blast radius:** (not in dependency graph — new or leaf file)');
+        }
+        out.push('');
+
+        let src = '';
+        try { src = fs.readFileSync(path.resolve(cwd, rel), 'utf8'); } catch (_) {}
+        const sigs = src ? extractFile(rel, src) : [];
+        if (sigs.length) {
+          out.push('```');
+          for (const s of sigs.slice(0, 40)) out.push(s);
+          if (sigs.length > 40) out.push(`… +${sigs.length - 40} more`);
+          out.push('```');
+        } else {
+          out.push('_(no signatures extracted — file may be deleted or empty)_');
+        }
+        out.push('');
+      }
+
+      return out.join('\n');
+    } catch (err) {
+      return `_get_diff_context failed: ${err.message}_`;
+    }
+  }
+
+  /**
+   * get_architecture_overview({}) → string
+   *
+   * A high-level map of the codebase: module breakdown (files/tokens), the most
+   * depended-on "hub" files, dependency-cycle count, and route totals. Extends
+   * get_map — one call to orient in an unfamiliar repo.
+   */
+  function getArchitectureOverview(args, cwd) {
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      const index = buildSigIndex(cwd);
+      const out = ['# Architecture overview', ''];
+
+      if (index.size === 0) {
+        out.push('_No context file found. Run: node gen-context.js_', '');
+      } else {
+        const groups = {};
+        let totalTokens = 0;
+        let totalFiles = 0;
+        for (const [rel, sigs] of index.entries()) {
+          const parts = rel.replace(/\\/g, '/').split('/');
+          const mod = parts.length > 1 ? parts[0] : '.';
+          const tok = Math.ceil(sigs.join('\n').length / 4);
+          if (!groups[mod]) groups[mod] = { files: 0, tokens: 0 };
+          groups[mod].files++;
+          groups[mod].tokens += tok;
+          totalTokens += tok;
+          totalFiles++;
+        }
+        const sorted = Object.entries(groups)
+          .map(([mod, d]) => ({ mod, files: d.files, tokens: d.tokens }))
+          .sort((a, b) => b.tokens - a.tokens);
+
+        out.push(`**${totalFiles} indexed files · ${sorted.length} modules · ~${totalTokens} tokens**`, '');
+        out.push('## Modules', '| Module | Files | Tokens |', '|--------|-------|--------|');
+        for (const m of sorted.slice(0, 20)) out.push(`| ${m.mod} | ${m.files} | ~${m.tokens} |`);
+        out.push('');
+      }
+
+      // Hub files + cycle count from the dependency graph (optional).
+      try {
+        const { buildFromCwd } = __require('./src/graph/builder');
+        const { detectCycles } = __require('./src/map/import-graph');
+        const graph = buildFromCwd(cwd);
+        if (graph && graph.reverse && graph.reverse.size) {
+          const hubs = [...graph.reverse.entries()]
+            .map(([f, importers]) => ({ file: path.relative(cwd, f).replace(/\\/g, '/'), in: importers.length }))
+            .filter((h) => h.in > 0)
+            .sort((a, b) => b.in - a.in)
+            .slice(0, 10);
+          if (hubs.length) {
+            out.push('## Hub files (most depended-on)', '| File | Importers |', '|------|-----------|');
+            for (const h of hubs) out.push(`| \`${h.file}\` | ${h.in} |`);
+            out.push('');
+          }
+          let cycleCount = 0;
+          try { cycleCount = detectCycles(graph.forward).length; } catch (_) {}
+          out.push(`**Dependency cycles:** ${cycleCount}` + (cycleCount ? ' _(see import graph)_' : ' — none detected'), '');
+        }
+      } catch (_) { /* graph optional */ }
+
+      // Routes from PROJECT_MAP.md if present.
+      const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+      if (fs.existsSync(mapPath)) {
+        const mc = fs.readFileSync(mapPath, 'utf8');
+        const routeCount = mc.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---')).length;
+        out.push('## Project map', `Routes detected: ${routeCount} _(use get_map for imports/classes/routes detail)_`, '');
+      } else {
+        out.push('_Run `node gen-project-map.js` for routes / class-hierarchy detail (get_map)._');
+      }
+
+      return out.join('\n');
+    } catch (err) {
+      return `_get_architecture_overview failed: ${err.message}_`;
+    }
+  }
+
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview };
   
 };
 
@@ -12124,13 +12299,13 @@ __factories["./src/mcp/server"] = function(module, exports) {
    *
    * Supported methods:
    *   initialize        → serverInfo + capabilities
-   *   tools/list        → 11 tool definitions
+   *   tools/list        → 17 tool definitions
    *   tools/call        → dispatch to handler, return result
    */
 
   const readline = require('readline');
   const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted } = __require('./src/mcp/handlers');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview } = __require('./src/mcp/handlers');
 
   const SERVER_INFO = {
     name: 'sigmap',
@@ -12197,6 +12372,8 @@ __factories["./src/mcp/server"] = function(module, exports) {
         else if (name === 'sigmap_notify_file_created') text = notifyFileCreated(args, cwd);
         else if (name === 'sigmap_notify_symbol_added') text = notifySymbolAdded(args, cwd);
         else if (name === 'sigmap_notify_file_deleted') text = notifyFileDeleted(args, cwd);
+        else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
+        else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
         else {
           respondError(id, -32601, `Unknown tool: ${name}`);
           return;
@@ -12257,11 +12434,11 @@ __factories["./src/mcp/server"] = function(module, exports) {
 __factories["./src/mcp/tools"] = function(module, exports) {
   
   /**
-   * MCP tool definitions for SigMap (15 tools).
+   * MCP tool definitions for SigMap (17 tools).
    * read_context, search_signatures, get_map, create_checkpoint, get_routing,
    * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
    * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
-   * sigmap_notify_file_deleted.
+   * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview.
    */
 
   const TOOLS = [
@@ -12532,6 +12709,44 @@ __factories["./src/mcp/tools"] = function(module, exports) {
           path: { type: 'string', description: 'Deleted file path relative to the project root.' },
         },
         required: ['path'],
+      },
+    },
+    {
+      name: 'get_diff_context',
+      description:
+        'For every changed file in the working tree (or staged, or vs a base ref), return its ' +
+        'current signatures plus blast radius — direct importers, transitive count, and affected ' +
+        'tests/routes — with a risk label. One call gives an agent everything a code review or a ' +
+        'safe edit needs. Lists changed files shell-free (git binary, never a shell).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          base: {
+            type: 'string',
+            description: 'Optional git ref to diff against (e.g. "main"). Returns files changed in `base..HEAD`. Omit for working-tree changes.',
+          },
+          staged: {
+            type: 'boolean',
+            description: 'When true (and no base), report only staged changes (`git diff --cached`).',
+          },
+          depth: {
+            type: 'number',
+            description: 'Blast-radius BFS depth limit (default: 2). Use 0 for unlimited.',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'get_architecture_overview',
+      description:
+        'A high-level map of the codebase in one call: module breakdown (files/tokens), the most ' +
+        'depended-on "hub" files, the dependency-cycle count, and route totals. Extends get_map — ' +
+        'use it to orient in an unfamiliar repo before drilling in with read_context / query_context.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
       },
     },
   ];

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,7 +24,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 52.2% |
 | Prompts per task | 2.84 | 1.72 (39.4% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 15 |
+| MCP tools | — | 17 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -122,7 +122,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 15 tools
+## MCP server — 17 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -248,6 +248,22 @@ Tell SigMap a file was deleted so its symbols are dropped from the live index.
 
 ```
 Input:  { path: string }
+```
+
+### get_diff_context
+
+For every changed file in the working tree (or staged, or vs a base ref), return its current signatures plus blast radius — direct importers, transitive count, and affected tests/routes — with a risk label. One call gives an agent everything a code review or a safe edit needs. Lists changed files shell-free (git binary, never a shell).
+
+```
+Input:  { base?: string, staged?: boolean, depth?: number }
+```
+
+### get_architecture_overview
+
+A high-level map of the codebase in one call: module breakdown (files/tokens), the most depended-on "hub" files, the dependency-cycle count, and route totals. Extends get_map — use it to orient in an unfamiliar repo before drilling in with read_context / query_context.
+
+```
+Input:  { } (no arguments)
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ Claude, Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 52.2% vs 10% without SigMap
 - Prompts per task: 1.72 vs 2.84 baseline (39.4% fewer)
-- Languages: 33 supported · MCP tools: 15
+- Languages: 33 supported · MCP tools: 17
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -674,4 +674,179 @@ function notifyFileDeleted(args, cwd) {
   }
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted };
+/**
+ * List the files changed in the working tree, staged area, or vs a base ref.
+ * Shell-free (routes through src/util/git.js). Returns relative paths.
+ */
+function _changedFiles(cwd, args) {
+  const { tryGit } = require('../util/git');
+  let out = '';
+  if (args.base) {
+    if (!/^[A-Za-z0-9._/\-~^]+$/.test(args.base)) return [];
+    out = tryGit(['diff', `${args.base}..HEAD`, '--name-only'], { cwd });
+  } else if (args.staged) {
+    out = tryGit(['diff', '--cached', '--name-only'], { cwd });
+  } else {
+    out = tryGit(['diff', 'HEAD', '--name-only'], { cwd });
+  }
+  return out.split('\n').map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * get_diff_context({ base?, staged?, depth? }) → string
+ *
+ * For each changed file: its extracted signatures + blast radius (direct
+ * importers, transitive count, affected tests/routes) + a risk label.
+ * Hands an agent everything a review or a safe edit needs in one call.
+ */
+function getDiffContext(args, cwd) {
+  try {
+    const a = args || {};
+    const files = _changedFiles(cwd, a);
+    if (files.length === 0) {
+      return '_No changed files detected._ (Outside a git repo, or the working tree / selected range is clean.)';
+    }
+
+    const { extractFile, langFor } = require('../extractors/dispatch');
+    const { analyzeImpact } = require('../graph/impact');
+    let riskLabelFor;
+    try { ({ riskLabelFor } = require('../evidence/pack')); } catch (_) { riskLabelFor = () => 'source'; }
+
+    const depth = Math.max(0, parseInt(a.depth, 10) || 2);
+    const srcFiles = files.filter((f) => langFor(f));
+    let impactByFile = new Map();
+    try {
+      const impacts = analyzeImpact(srcFiles, cwd, { depth });
+      impactByFile = new Map(impacts.map((r) => [r.file, r.impact]));
+    } catch (_) { /* graph optional */ }
+
+    const scope = a.base ? `vs ${a.base}` : (a.staged ? 'staged' : 'working tree');
+    const out = [
+      `# Diff context (${scope})`,
+      '',
+      `**${files.length} changed file${files.length === 1 ? '' : 's'}** · ${srcFiles.length} with extractable signatures`,
+      '',
+    ];
+
+    for (const rel of files) {
+      out.push(`## \`${rel}\``);
+      if (!langFor(rel)) { out.push('_non-source file (no signatures)_', ''); continue; }
+
+      out.push(`_risk: ${riskLabelFor(rel)}_`);
+      const impact = impactByFile.get(rel);
+      if (impact) {
+        out.push(
+          `**Blast radius:** ${impact.totalImpact} file(s) impacted — ` +
+          `${impact.direct.length} direct importer(s), ${impact.transitive.length} transitive` +
+          (impact.tests.length ? `, ${impact.tests.length} test(s)` : '') +
+          (impact.routes.length ? `, ${impact.routes.length} route(s)` : '')
+        );
+        if (impact.direct.length) {
+          out.push(`Direct importers: ${impact.direct.slice(0, 8).map((f) => '`' + f + '`').join(', ')}` + (impact.direct.length > 8 ? ' …' : ''));
+        }
+        if (impact.tests.length) {
+          out.push(`Tests to run: ${impact.tests.slice(0, 8).map((f) => '`' + f + '`').join(', ')}`);
+        }
+      } else {
+        out.push('**Blast radius:** (not in dependency graph — new or leaf file)');
+      }
+      out.push('');
+
+      let src = '';
+      try { src = fs.readFileSync(path.resolve(cwd, rel), 'utf8'); } catch (_) {}
+      const sigs = src ? extractFile(rel, src) : [];
+      if (sigs.length) {
+        out.push('```');
+        for (const s of sigs.slice(0, 40)) out.push(s);
+        if (sigs.length > 40) out.push(`… +${sigs.length - 40} more`);
+        out.push('```');
+      } else {
+        out.push('_(no signatures extracted — file may be deleted or empty)_');
+      }
+      out.push('');
+    }
+
+    return out.join('\n');
+  } catch (err) {
+    return `_get_diff_context failed: ${err.message}_`;
+  }
+}
+
+/**
+ * get_architecture_overview({}) → string
+ *
+ * A high-level map of the codebase: module breakdown (files/tokens), the most
+ * depended-on "hub" files, dependency-cycle count, and route totals. Extends
+ * get_map — one call to orient in an unfamiliar repo.
+ */
+function getArchitectureOverview(args, cwd) {
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    const index = buildSigIndex(cwd);
+    const out = ['# Architecture overview', ''];
+
+    if (index.size === 0) {
+      out.push('_No context file found. Run: node gen-context.js_', '');
+    } else {
+      const groups = {};
+      let totalTokens = 0;
+      let totalFiles = 0;
+      for (const [rel, sigs] of index.entries()) {
+        const parts = rel.replace(/\\/g, '/').split('/');
+        const mod = parts.length > 1 ? parts[0] : '.';
+        const tok = Math.ceil(sigs.join('\n').length / 4);
+        if (!groups[mod]) groups[mod] = { files: 0, tokens: 0 };
+        groups[mod].files++;
+        groups[mod].tokens += tok;
+        totalTokens += tok;
+        totalFiles++;
+      }
+      const sorted = Object.entries(groups)
+        .map(([mod, d]) => ({ mod, files: d.files, tokens: d.tokens }))
+        .sort((a, b) => b.tokens - a.tokens);
+
+      out.push(`**${totalFiles} indexed files · ${sorted.length} modules · ~${totalTokens} tokens**`, '');
+      out.push('## Modules', '| Module | Files | Tokens |', '|--------|-------|--------|');
+      for (const m of sorted.slice(0, 20)) out.push(`| ${m.mod} | ${m.files} | ~${m.tokens} |`);
+      out.push('');
+    }
+
+    // Hub files + cycle count from the dependency graph (optional).
+    try {
+      const { buildFromCwd } = require('../graph/builder');
+      const { detectCycles } = require('../map/import-graph');
+      const graph = buildFromCwd(cwd);
+      if (graph && graph.reverse && graph.reverse.size) {
+        const hubs = [...graph.reverse.entries()]
+          .map(([f, importers]) => ({ file: path.relative(cwd, f).replace(/\\/g, '/'), in: importers.length }))
+          .filter((h) => h.in > 0)
+          .sort((a, b) => b.in - a.in)
+          .slice(0, 10);
+        if (hubs.length) {
+          out.push('## Hub files (most depended-on)', '| File | Importers |', '|------|-----------|');
+          for (const h of hubs) out.push(`| \`${h.file}\` | ${h.in} |`);
+          out.push('');
+        }
+        let cycleCount = 0;
+        try { cycleCount = detectCycles(graph.forward).length; } catch (_) {}
+        out.push(`**Dependency cycles:** ${cycleCount}` + (cycleCount ? ' _(see import graph)_' : ' — none detected'), '');
+      }
+    } catch (_) { /* graph optional */ }
+
+    // Routes from PROJECT_MAP.md if present.
+    const mapPath = path.join(cwd, 'PROJECT_MAP.md');
+    if (fs.existsSync(mapPath)) {
+      const mc = fs.readFileSync(mapPath, 'utf8');
+      const routeCount = mc.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Method') && !l.startsWith('|---')).length;
+      out.push('## Project map', `Routes detected: ${routeCount} _(use get_map for imports/classes/routes detail)_`, '');
+    } else {
+      out.push('_Run `node gen-project-map.js` for routes / class-hierarchy detail (get_map)._');
+    }
+
+    return out.join('\n');
+  } catch (err) {
+    return `_get_architecture_overview failed: ${err.message}_`;
+  }
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -8,13 +8,13 @@
  *
  * Supported methods:
  *   initialize        → serverInfo + capabilities
- *   tools/list        → 11 tool definitions
+ *   tools/list        → 17 tool definitions
  *   tools/call        → dispatch to handler, return result
  */
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -81,6 +81,8 @@ function dispatch(msg, cwd) {
       else if (name === 'sigmap_notify_file_created') text = notifyFileCreated(args, cwd);
       else if (name === 'sigmap_notify_symbol_added') text = notifySymbolAdded(args, cwd);
       else if (name === 'sigmap_notify_file_deleted') text = notifyFileDeleted(args, cwd);
+      else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
+      else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,11 +1,11 @@
 'use strict';
 
 /**
- * MCP tool definitions for SigMap (15 tools).
+ * MCP tool definitions for SigMap (17 tools).
  * read_context, search_signatures, get_map, create_checkpoint, get_routing,
  * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
  * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
- * sigmap_notify_file_deleted.
+ * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview.
  */
 
 const TOOLS = [
@@ -276,6 +276,44 @@ const TOOLS = [
         path: { type: 'string', description: 'Deleted file path relative to the project root.' },
       },
       required: ['path'],
+    },
+  },
+  {
+    name: 'get_diff_context',
+    description:
+      'For every changed file in the working tree (or staged, or vs a base ref), return its ' +
+      'current signatures plus blast radius — direct importers, transitive count, and affected ' +
+      'tests/routes — with a risk label. One call gives an agent everything a code review or a ' +
+      'safe edit needs. Lists changed files shell-free (git binary, never a shell).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        base: {
+          type: 'string',
+          description: 'Optional git ref to diff against (e.g. "main"). Returns files changed in `base..HEAD`. Omit for working-tree changes.',
+        },
+        staged: {
+          type: 'boolean',
+          description: 'When true (and no base), report only staged changes (`git diff --cached`).',
+        },
+        depth: {
+          type: 'number',
+          description: 'Blast-radius BFS depth limit (default: 2). Use 0 for unlimited.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_architecture_overview',
+    description:
+      'A high-level map of the codebase in one call: module breakdown (files/tokens), the most ' +
+      'depended-on "hub" files, the dependency-cycle count, and route totals. Extends get_map — ' +
+      'use it to orient in an unfamiliar repo before drilling in with read_context / query_context.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
     },
   },
 ];

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 15 tools (not 12)', () => {
+test('mcp.md: description mentions 17 tools (not 12)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('15 tools'), 'missing "15 tools" in mcp.md');
+  assert.ok(src.includes('17 tools'), 'missing "17 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -77,9 +77,9 @@ test('version.json: extractors field is derived (>= languages)', () => {
   assert.ok(Number.isInteger(v.extractors) && v.extractors >= v.languages, `extractors=${v.extractors}`);
 });
 
-test('version.json: mcp_tools is 15', () => {
+test('version.json: mcp_tools is 17', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 15);
+  assert.strictEqual(v.mcp_tools, 17);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 15 tools including get_impact', () => {
+test('MCP tools/list: returns 17 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 15, `expected 15 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 17, `expected 17 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/diff-architecture-tools.test.js
+++ b/test/integration/mcp/diff-architecture-tools.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * v8.0 D3 — get_diff_context & get_architecture_overview MCP tools.
+ * Drives the live stdio MCP server against controlled temp git repos.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../../gen-context.js');
+const { TOOLS } = require('../../../src/mcp/tools.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.log(`  FAIL  ${name}: ${err.message}`); failed++; }
+}
+
+function mcp(messages, cwd) {
+  const input = (Array.isArray(messages) ? messages : [messages])
+    .map((m) => JSON.stringify(m)).join('\n') + '\n';
+  const stdout = execFileSync('node', [GEN_CONTEXT, '--mcp'], { input, cwd, encoding: 'utf8', timeout: 20000 });
+  return stdout.split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+}
+
+function callText(name, args, cwd) {
+  const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args || {} } }, cwd);
+  return res.find((r) => r.id === 1).result.content[0].text;
+}
+
+function git(args, cwd) { execFileSync('git', args, { cwd, stdio: 'ignore' }); }
+
+function withGitProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-mcpd3-'));
+  try {
+    git(['init', '-q'], dir);
+    git(['config', 'user.email', 't@t.t'], dir);
+    git(['config', 'user.name', 'tester'], dir);
+    git(['config', 'commit.gpgsign', 'false'], dir);
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function seedContext(dir) {
+  const gh = path.join(dir, '.github');
+  fs.mkdirSync(gh, { recursive: true });
+  fs.writeFileSync(path.join(gh, 'copilot-instructions.md'), [
+    '## Auto-generated signatures', '# Code signatures', '',
+    '### src/widget.js', '```', 'function renderWidget(props)  :3-9', '```', '',
+    '### src/store.js', '```', 'function loadStore()  :1-5', '```', '',
+  ].join('\n'));
+}
+
+// ── tools/list registration ────────────────────────────────────────────────
+
+test('tools/list registers 17 tools including both new ones', () => {
+  withGitProject((dir) => {
+    const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, dir);
+    const tools = res.find((r) => r.id === 1).result.tools;
+    assert.strictEqual(tools.length, TOOLS.length, 'server list matches TOOLS');
+    assert.strictEqual(tools.length, 17, 'exactly 17 tools');
+    assert.ok(tools.some((t) => t.name === 'get_diff_context'), 'get_diff_context registered');
+    assert.ok(tools.some((t) => t.name === 'get_architecture_overview'), 'get_architecture_overview registered');
+  });
+});
+
+// ── get_diff_context ───────────────────────────────────────────────────────
+
+test('get_diff_context reports changed files with signatures and blast radius', () => {
+  withGitProject((dir) => {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src/widget.js'), 'function renderWidget(props){return props;}\nmodule.exports={renderWidget};\n');
+    fs.writeFileSync(path.join(dir, 'src/page.js'), "const {renderWidget}=require('./widget');\nfunction page(){return renderWidget(1);}\n");
+    git(['add', '-A'], dir); git(['commit', '-qm', 'init'], dir);
+    // Working-tree change to widget.js (page.js imports it → direct importer)
+    fs.writeFileSync(path.join(dir, 'src/widget.js'), 'function renderWidget(props, theme){return props;}\nmodule.exports={renderWidget};\n');
+
+    const text = callText('get_diff_context', {}, dir);
+    assert.ok(/src\/widget\.js/.test(text), 'lists the changed file');
+    assert.ok(/renderWidget/.test(text), 'includes current signatures');
+    assert.ok(/Blast radius/i.test(text), 'includes a blast-radius line');
+    assert.ok(/page\.js/.test(text), 'blast radius names the importer');
+  });
+});
+
+test('get_diff_context --staged reports only staged changes', () => {
+  withGitProject((dir) => {
+    fs.writeFileSync(path.join(dir, 'a.js'), 'function a(){}\n');
+    git(['add', '-A'], dir); git(['commit', '-qm', 'init'], dir);
+    fs.writeFileSync(path.join(dir, 'a.js'), 'function a(){return 1;}\n');
+    fs.writeFileSync(path.join(dir, 'b.js'), 'function b(){}\n'); // unstaged
+    git(['add', 'a.js'], dir); // stage a.js only
+
+    const text = callText('get_diff_context', { staged: true }, dir);
+    assert.ok(/a\.js/.test(text), 'staged file appears');
+    assert.ok(!/b\.js/.test(text), 'unstaged file must not appear');
+  });
+});
+
+test('get_diff_context degrades gracefully on a clean tree', () => {
+  withGitProject((dir) => {
+    fs.writeFileSync(path.join(dir, 'a.js'), 'function a(){}\n');
+    git(['add', '-A'], dir); git(['commit', '-qm', 'init'], dir);
+    const text = callText('get_diff_context', {}, dir);
+    assert.ok(/No changed files/i.test(text), 'reports no changes without throwing');
+  });
+});
+
+// ── get_architecture_overview ──────────────────────────────────────────────
+
+test('get_architecture_overview returns modules, hub files, and totals', () => {
+  withGitProject((dir) => {
+    seedContext(dir);
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src/widget.js'), 'module.exports={};\n');
+    fs.writeFileSync(path.join(dir, 'src/store.js'), "const w=require('./widget');\nmodule.exports={};\n");
+
+    const text = callText('get_architecture_overview', {}, dir);
+    assert.ok(/Architecture overview/.test(text));
+    assert.ok(/## Modules/.test(text), 'has a module breakdown');
+    assert.ok(/indexed files/.test(text), 'reports totals');
+    assert.ok(/Hub files|Dependency cycles/.test(text), 'includes the dependency-graph section');
+  });
+});
+
+test('get_architecture_overview degrades gracefully without a context file', () => {
+  withGitProject((dir) => {
+    const text = callText('get_architecture_overview', {}, dir);
+    assert.ok(/No context file found|Architecture overview/.test(text), 'does not throw without context');
+  });
+});
+
+console.log(`\nD3 MCP tools: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (15 tools total)', () => {
+test('get_lines is registered (17 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 15, `expected 15 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 17, `expected 17 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -101,12 +101,12 @@ test('initialize returns serverInfo', () => {
 // ─────────────────────────────────────────────────────────────
 // Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 15 tools', () => {
+test('tools/list returns exactly 17 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 15);
+    assert.strictEqual(res.result.tools.length, 17);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -83,12 +83,12 @@ function seedContextFile(dir) {
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 15 tools', () => {
+test('tools/list returns exactly 17 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 15, `Expected 15 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 17, `Expected 17 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 15);
+  assert.strictEqual(tools.length, 17);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 15 tools including query_context', () => {
+test('MCP tools/list: returns 17 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 15, `expected 15 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 17, `expected 17 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "benchmark_id": "sigmap-v7.26-main",
   "languages": 33,
   "extractors": 42,
-  "mcp_tools": 15,
-  "tests": 101,
+  "mcp_tools": 17,
+  "tests": 102,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #376 · v8.0 "The Evidence Pack & the Pivot" → initiative **D3**.

## What
Adds two MCP tools, both composed from data SigMap already computes — bringing the surface from **15 to 17 tools**. Zero new deps, no system-shell spawns.

- **`get_diff_context`** `{ base?, staged?, depth? }` → for every changed file (working tree, staged, or vs a base ref): current **signatures** + **blast radius** (direct importers, transitive count, affected tests/routes) + a risk label. One call gives an agent everything a review or safe edit needs. Lists changed files **shell-free** via `src/util/git.js`.
- **`get_architecture_overview`** `{}` → one-call codebase map: module breakdown (files/tokens), most depended-on **hub files**, dependency-**cycle** count, route totals. Extends `get_map`.

## How
- `src/mcp/tools.js` (schemas + header), `src/mcp/handlers.js` (handlers + shell-free `_changedFiles`), `src/mcp/server.js` (dispatch). Bundle rebuilt + reproducible.
- Composed from `src/util/git.js` (`tryGit`), `src/extractors/dispatch.js` (`extractFile`), `src/graph/impact.js` (`analyzeImpact`), `src/graph/builder.js` (`buildFromCwd`), `src/map/import-graph.js` (`detectCycles`).
- Documented surface synced: README + `docs-vp/guide/mcp.md` 15→17 + both tools; `version.json.mcp_tools=17`; llms regenerated (auto-documents both tools). Hardcoded `15`-tool count assertions across existing tests bumped to 17.

## Acceptance criteria
- [x] `tools/list` returns **17** tools incl. `get_diff_context` + `get_architecture_overview`
- [x] `get_diff_context`: per-file signatures + blast radius; honors `base`/`staged`/`depth`; shell-free; degrades gracefully (clean tree / no git)
- [x] `get_architecture_overview`: modules + hub files + cycle count + totals; degrades gracefully without context/graph
- [x] README says "17 on-demand tools" + lists both; `version.json.mcp_tools == TOOLS.length`
- [x] `surface-docs` + `version-meta` gates pass; live MCP integration tests for both tools
- [x] Full suite green (unit 23/0 · integration 96/0 · bundle reproducible)

## Supply-chain gate
Local audit PASS — no shell spawns (git via `src/util/git.js`) · no install scripts · `main` exports API · no fingerprinting.

## Out of scope (remaining v8.0)
E2 repositioning, E3 `doctor`/quickstart, E4 agent recipes + `mcp install`.