### PR TITLE
ci(sync): self-heal develop when auto-deleted by the release PR merge

### DIFF
--- a/.github/workflows/sync-develop-main.yml
+++ b/.github/workflows/sync-develop-main.yml
@@ -35,15 +35,23 @@ jobs:
 
       - name: Sync develop with main
         run: |
-          git fetch origin main develop
-          git checkout develop
-          git merge --no-edit origin/main
+          set -euo pipefail
+          git fetch origin main
 
-          # Check if there are changes to push
-          if ! git diff --exit-code origin/develop HEAD > /dev/null 2>&1; then
-            echo "Changes detected. Pushing develop..."
-            git push origin develop --force-with-lease
-            echo "✅ Successfully synced develop with main"
+          # `develop` may have been auto-deleted: it is the head branch of the
+          # develop→main release PR, and the repo has "delete branch on merge"
+          # enabled. The old `git fetch origin main develop` died here with
+          # "couldn't find remote ref develop". Recreate it from main when it is
+          # missing; otherwise merge main into it (preserving any divergence).
+          if git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
+            git fetch origin develop
+            git checkout -B develop origin/develop
+            git merge --no-edit origin/main
           else
-            echo "✓ develop is already up to date with main"
+            echo "develop is missing (auto-deleted as the release PR head) — recreating from main."
+            git checkout -B develop origin/main
           fi
+
+          # Idempotent: a no-op push prints "Everything up-to-date" and exits 0.
+          git push origin develop
+          echo "✅ develop synced with main"


### PR DESCRIPTION
## Problem
The `develop → main` release PR uses `develop` as its head branch, and the repo has **delete-branch-on-merge** enabled — so `develop` is deleted on every release. The **Sync develop with main** workflow then fails at `git fetch origin main develop` with `fatal: couldn't find remote ref develop`, and `develop` has to be recreated by hand (it has now needed manual restoration on v7.26.0 and v7.27.0).

## Fix
Make the sync job self-healing and idempotent:
- Fetch `main` only (always present).
- If `develop` exists → check it out and merge `main` in (preserves any divergence).
- If `develop` is missing → recreate it from `main`.
- Plain `git push origin develop` (no-op prints "Everything up-to-date").

Keeps `delete-branch-on-merge` on for feature branches; `develop` now repairs itself after each release instead of erroring.

## Test plan
- [ ] On next release, confirm the workflow run succeeds and `develop` exists at `main` HEAD without manual intervention.
- [x] `yaml.safe_load` parses the workflow.