### PR TITLE
feat(doctor): sigmap doctor diagnostic command (v8.0 E3)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -115,6 +115,7 @@ sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked file
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
+sigmap doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
 sigmap --init                            Write example config + .contextignore scaffold
 sigmap --help                            Show this message
 sigmap --version                         Show version

--- a/gen-context.js
+++ b/gen-context.js
@@ -3462,6 +3462,246 @@ __factories["./src/discovery/source-root-scorer"] = function(module, exports) {
   
 };
 
+// ── ./src/doctor/diagnose ──
+__factories["./src/doctor/diagnose"] = function(module, exports) {
+  
+  /**
+   * sigmap doctor (v8.0 E3).
+   *
+   * One-shot diagnostic for a SigMap setup: each check reports ok/warn/fail with
+   * an actionable fix, so a cold user can reach a useful answer in minutes. Pure,
+   * resilient (no check ever throws), zero new runtime deps. Composes the config
+   * loader, coverage scorer, signature index, and the known adapter-output /
+   * MCP-config paths.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+
+  // Generated context files a `read_context`/`ask` flow can consume.
+  const ADAPTER_OUTPUTS = [
+    ['.github', 'copilot-instructions.md'],
+    ['CLAUDE.md'],
+    ['AGENTS.md'],
+    ['.cursorrules'],
+    ['.windsurfrules'],
+    ['.github', 'openai-context.md'],
+    ['.github', 'gemini-context.md'],
+    ['llm-full.txt'],
+    ['llm.txt'],
+  ];
+
+  const EXCLUDE_DIRS = new Set([
+    'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+    '.next', 'coverage', 'target', 'vendor', '.context',
+  ]);
+
+  const ICON = { ok: '✓', warn: '⚠', fail: '✗' };
+
+  function _short(p, cwd) {
+    const rel = path.relative(cwd, p);
+    return rel && !rel.startsWith('..') ? rel : p.replace(os.homedir(), '~');
+  }
+
+  function _contextFiles(cwd) {
+    const out = [];
+    for (const parts of ADAPTER_OUTPUTS) {
+      const p = path.join(cwd, ...parts);
+      try { if (fs.existsSync(p)) out.push(p); } catch (_) {}
+    }
+    return out;
+  }
+
+  function _mcpTargets(cwd) {
+    return [
+      path.join(cwd, '.mcp.json'),
+      path.join(cwd, '.claude', 'settings.json'),
+      path.join(cwd, '.cursor', 'mcp.json'),
+      path.join(cwd, '.windsurf', 'mcp.json'),
+      path.join(cwd, '.vscode', 'mcp.json'),
+      path.join(cwd, 'opencode.json'),
+      path.join(os.homedir(), '.codeium', 'windsurf', 'mcp_config.json'),
+      path.join(os.homedir(), '.config', 'opencode', 'config.json'),
+      path.join(os.homedir(), '.gemini', 'settings.json'),
+      path.join(os.homedir(), '.codex', 'config.yaml'),
+      path.join(os.homedir(), '.config', 'zed', 'settings.json'),
+    ];
+  }
+
+  /** Count code files under srcDirs modified after the context was generated. */
+  function _countChangedSince(cwd, srcDirs, config, ctxMtime) {
+    const { CODE_EXTS } = __require('./src/analysis/coverage-score');
+    const exclude = new Set(EXCLUDE_DIRS);
+    if (config && Array.isArray(config.exclude)) for (const x of config.exclude) exclude.add(String(x));
+
+    let changed = 0;
+    let seen = 0;
+    const walk = (dir, depth) => {
+      if (depth > 8 || seen > 5000) return;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+      for (const e of entries) {
+        if (exclude.has(e.name)) continue;
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) walk(full, depth + 1);
+        else if (e.isFile() && CODE_EXTS.has(path.extname(e.name).toLowerCase())) {
+          seen++;
+          try { if (fs.statSync(full).mtimeMs > ctxMtime) changed++; } catch (_) {}
+        }
+      }
+    };
+    for (const d of srcDirs) {
+      const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+      if (fs.existsSync(abs)) walk(abs, 0);
+    }
+    return changed;
+  }
+
+  /**
+   * Run all diagnostic checks.
+   * @param {string} cwd
+   * @returns {{ checks: Array<{id,label,status,detail,fix}>, ok: boolean, errors: number, warnings: number }}
+   */
+  function diagnose(cwd, opts = {}) {
+    const checks = [];
+    const add = (id, label, status, detail, fix) => checks.push({ id, label, status, detail: detail || '', fix: fix || null });
+
+    // 1. Git repository
+    try {
+      const { tryGit } = __require('./src/util/git');
+      const inside = tryGit(['rev-parse', '--is-inside-work-tree'], { cwd });
+      if (inside === 'true') add('git', 'Git repository', 'ok', 'recency boost + impact analysis enabled');
+      else add('git', 'Git repository', 'warn', 'not a git repository', 'git init — enables recency boost and impact analysis');
+    } catch (_) {
+      add('git', 'Git repository', 'warn', 'git not available', 'install git for recency boost + impact analysis');
+    }
+
+    // 2. Config & source roots
+    let config = {};
+    try {
+      const cfgPath = path.join(cwd, 'gen-context.config.json');
+      let configBroken = false;
+      if (fs.existsSync(cfgPath)) {
+        try { JSON.parse(fs.readFileSync(cfgPath, 'utf8')); }
+        catch (e) {
+          configBroken = true;
+          add('config', 'Config & source roots', 'fail', `gen-context.config.json is invalid JSON: ${e.message}`, 'fix the JSON syntax, or delete the file to fall back to defaults');
+        }
+      }
+      const { loadConfig } = __require('./src/config/loader');
+      config = loadConfig(cwd) || {};
+      if (!configBroken) {
+        // Distinguish explicitly-configured srcDirs (validate each) from the
+        // default candidate list (just report which ones actually exist).
+        let explicitSrcDirs = null;
+        if (fs.existsSync(cfgPath)) {
+          try { const raw = JSON.parse(fs.readFileSync(cfgPath, 'utf8')); if (Array.isArray(raw.srcDirs)) explicitSrcDirs = raw.srcDirs; } catch (_) {}
+        }
+        const exists = (d) => { try { return fs.existsSync(path.isAbsolute(d) ? d : path.join(cwd, d)); } catch (_) { return false; } };
+        const srcDirs = Array.isArray(config.srcDirs) ? config.srcDirs : [];
+        const present = srcDirs.filter(exists);
+
+        if (explicitSrcDirs) {
+          const missing = explicitSrcDirs.filter((d) => !exists(d));
+          if (missing.length) add('config', 'Config & source roots', 'warn', `configured srcDirs not found: ${missing.join(', ')}`, 'fix "srcDirs" in gen-context.config.json');
+          else add('config', 'Config & source roots', 'ok', `srcDirs: ${explicitSrcDirs.join(', ')}`);
+        } else if (present.length === 0) {
+          add('config', 'Config & source roots', 'warn', 'no source directories found (looked for src/, app/, lib/, …)', 'create a src/ dir, set "srcDirs" in gen-context.config.json, or run: sigmap roots --fix');
+        } else {
+          add('config', 'Config & source roots', 'ok', `source roots: ${present.slice(0, 8).join(', ')}${present.length > 8 ? `, +${present.length - 8} more` : ''}`);
+        }
+      }
+    } catch (e) {
+      if (!checks.some((c) => c.id === 'config')) add('config', 'Config & source roots', 'warn', `could not load config: ${e.message}`);
+    }
+
+    // 3. Generated context file
+    const ctxFiles = _contextFiles(cwd);
+    if (ctxFiles.length === 0) {
+      add('context', 'Generated context', 'fail', 'no context file found', 'run: npx sigmap   (generates the signature map)');
+    } else {
+      add('context', 'Generated context', 'ok', `${ctxFiles.length} file(s): ${ctxFiles.map((f) => _short(f, cwd)).join(', ')}`);
+    }
+
+    // 4. Signature index
+    let indexSize = 0;
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      indexSize = buildSigIndex(cwd).size;
+    } catch (_) {}
+    if (indexSize === 0) {
+      add('index', 'Signature index', ctxFiles.length === 0 ? 'fail' : 'warn', 'no signatures indexed', 'run: npx sigmap   then: sigmap ask "<query>"');
+    } else {
+      add('index', 'Signature index', 'ok', `${indexSize} file(s) indexed`);
+    }
+
+    // 5. Index freshness
+    try {
+      if (ctxFiles.length) {
+        const ctxMtime = Math.max(...ctxFiles.map((f) => { try { return fs.statSync(f).mtimeMs; } catch (_) { return 0; } }));
+        const srcDirs = (config && Array.isArray(config.srcDirs) && config.srcDirs.length) ? config.srcDirs : ['src', 'app', 'lib'];
+        const changed = _countChangedSince(cwd, srcDirs, config, ctxMtime);
+        if (changed > 0) add('freshness', 'Index freshness', 'warn', `${changed} source file(s) changed since last generate`, 'run: sigmap   (or: sigmap --watch to auto-refresh)');
+        else add('freshness', 'Index freshness', 'ok', 'index is up to date with sources');
+      }
+    } catch (_) {}
+
+    // 6. Coverage
+    try {
+      if (indexSize > 0) {
+        const { coverageScore } = __require('./src/analysis/coverage-score');
+        const { buildSigIndex } = __require('./src/retrieval/ranker');
+        const entries = [...buildSigIndex(cwd).keys()].map((rel) => ({ filePath: path.resolve(cwd, rel) }));
+        const cov = coverageScore(cwd, entries, config);
+        if (cov.score < 70) add('coverage', 'Coverage', 'warn', `${cov.score}% of source files in context (grade ${cov.grade})`, 'increase maxTokens or expand srcDirs in gen-context.config.json');
+        else add('coverage', 'Coverage', 'ok', `${cov.score}% of source files in context (grade ${cov.grade})`);
+      }
+    } catch (_) {}
+
+    // 7. MCP wiring
+    try {
+      let wired = null;
+      for (const t of _mcpTargets(cwd)) {
+        try {
+          if (!fs.existsSync(t)) continue;
+          if (/sigmap/.test(fs.readFileSync(t, 'utf8'))) { wired = t; break; }
+        } catch (_) {}
+      }
+      if (wired) add('mcp', 'MCP wiring', 'ok', `registered in ${_short(wired, cwd)}`);
+      else add('mcp', 'MCP wiring', 'warn', 'MCP server not registered in any editor config', 'run: sigmap --setup   (auto-wires Claude, Cursor, Windsurf, VS Code, …)');
+    } catch (_) {}
+
+    const errors = checks.filter((c) => c.status === 'fail').length;
+    const warnings = checks.filter((c) => c.status === 'warn').length;
+    return { checks, ok: errors === 0, errors, warnings };
+  }
+
+  /** Human-readable checklist. */
+  function formatDoctor(result) {
+    const lines = ['sigmap doctor', ''];
+    for (const c of result.checks) {
+      lines.push(`${ICON[c.status] || '?'} ${c.label}${c.detail ? ' — ' + c.detail : ''}`);
+      if (c.status !== 'ok' && c.fix) lines.push(`    ↳ ${c.fix}`);
+    }
+    lines.push('');
+    lines.push(
+      result.errors === 0 && result.warnings === 0
+        ? '✓ All checks passed.'
+        : `${result.errors} error(s), ${result.warnings} warning(s).`
+    );
+    return lines.join('\n');
+  }
+
+  /** Machine-readable result. */
+  function formatDoctorJSON(result) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  module.exports = { diagnose, formatDoctor, formatDoctorJSON };
+  
+};
+
 // ── ./src/eval/analyzer ──
 __factories["./src/eval/analyzer"] = function(module, exports) {
   
@@ -17951,6 +18191,7 @@ Usage:
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
+  ${cmd} doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
   ${cmd} --init                            Write example config + .contextignore scaffold
   ${cmd} --help                            Show this message
   ${cmd} --version                         Show version
@@ -19373,6 +19614,20 @@ function main() {
       console.log('  Notes:         none — add with: sigmap note "<text>"');
     }
     process.exit(0);
+  }
+
+  // `sigmap doctor` — diagnose config, index, freshness, coverage, and MCP
+  // wiring; print an actionable fix for anything wrong. Exit 1 on a hard
+  // failure (no context file / invalid config) so it is usable in CI.
+  if (args[0] === 'doctor') {
+    const { diagnose, formatDoctor, formatDoctorJSON } = requireSourceOrBundled('./src/doctor/diagnose');
+    const result = diagnose(cwd);
+    if (args.includes('--json')) {
+      process.stdout.write(formatDoctorJSON(result) + '\n');
+    } else {
+      console.log(formatDoctor(result));
+    }
+    process.exit(result.ok ? 0 : 1);
   }
 
   // Layer 3: `sigmap conventions` — extract & report repo coding conventions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -115,6 +115,7 @@ sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked file
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
+sigmap doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
 sigmap --init                            Write example config + .contextignore scaffold
 sigmap --help                            Show this message
 sigmap --version                         Show version

--- a/src/doctor/diagnose.js
+++ b/src/doctor/diagnose.js
@@ -1,0 +1,236 @@
+'use strict';
+
+/**
+ * sigmap doctor (v8.0 E3).
+ *
+ * One-shot diagnostic for a SigMap setup: each check reports ok/warn/fail with
+ * an actionable fix, so a cold user can reach a useful answer in minutes. Pure,
+ * resilient (no check ever throws), zero new runtime deps. Composes the config
+ * loader, coverage scorer, signature index, and the known adapter-output /
+ * MCP-config paths.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Generated context files a `read_context`/`ask` flow can consume.
+const ADAPTER_OUTPUTS = [
+  ['.github', 'copilot-instructions.md'],
+  ['CLAUDE.md'],
+  ['AGENTS.md'],
+  ['.cursorrules'],
+  ['.windsurfrules'],
+  ['.github', 'openai-context.md'],
+  ['.github', 'gemini-context.md'],
+  ['llm-full.txt'],
+  ['llm.txt'],
+];
+
+const EXCLUDE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', '__pycache__',
+  '.next', 'coverage', 'target', 'vendor', '.context',
+]);
+
+const ICON = { ok: '✓', warn: '⚠', fail: '✗' };
+
+function _short(p, cwd) {
+  const rel = path.relative(cwd, p);
+  return rel && !rel.startsWith('..') ? rel : p.replace(os.homedir(), '~');
+}
+
+function _contextFiles(cwd) {
+  const out = [];
+  for (const parts of ADAPTER_OUTPUTS) {
+    const p = path.join(cwd, ...parts);
+    try { if (fs.existsSync(p)) out.push(p); } catch (_) {}
+  }
+  return out;
+}
+
+function _mcpTargets(cwd) {
+  return [
+    path.join(cwd, '.mcp.json'),
+    path.join(cwd, '.claude', 'settings.json'),
+    path.join(cwd, '.cursor', 'mcp.json'),
+    path.join(cwd, '.windsurf', 'mcp.json'),
+    path.join(cwd, '.vscode', 'mcp.json'),
+    path.join(cwd, 'opencode.json'),
+    path.join(os.homedir(), '.codeium', 'windsurf', 'mcp_config.json'),
+    path.join(os.homedir(), '.config', 'opencode', 'config.json'),
+    path.join(os.homedir(), '.gemini', 'settings.json'),
+    path.join(os.homedir(), '.codex', 'config.yaml'),
+    path.join(os.homedir(), '.config', 'zed', 'settings.json'),
+  ];
+}
+
+/** Count code files under srcDirs modified after the context was generated. */
+function _countChangedSince(cwd, srcDirs, config, ctxMtime) {
+  const { CODE_EXTS } = require('../analysis/coverage-score');
+  const exclude = new Set(EXCLUDE_DIRS);
+  if (config && Array.isArray(config.exclude)) for (const x of config.exclude) exclude.add(String(x));
+
+  let changed = 0;
+  let seen = 0;
+  const walk = (dir, depth) => {
+    if (depth > 8 || seen > 5000) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    for (const e of entries) {
+      if (exclude.has(e.name)) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full, depth + 1);
+      else if (e.isFile() && CODE_EXTS.has(path.extname(e.name).toLowerCase())) {
+        seen++;
+        try { if (fs.statSync(full).mtimeMs > ctxMtime) changed++; } catch (_) {}
+      }
+    }
+  };
+  for (const d of srcDirs) {
+    const abs = path.isAbsolute(d) ? d : path.join(cwd, d);
+    if (fs.existsSync(abs)) walk(abs, 0);
+  }
+  return changed;
+}
+
+/**
+ * Run all diagnostic checks.
+ * @param {string} cwd
+ * @returns {{ checks: Array<{id,label,status,detail,fix}>, ok: boolean, errors: number, warnings: number }}
+ */
+function diagnose(cwd, opts = {}) {
+  const checks = [];
+  const add = (id, label, status, detail, fix) => checks.push({ id, label, status, detail: detail || '', fix: fix || null });
+
+  // 1. Git repository
+  try {
+    const { tryGit } = require('../util/git');
+    const inside = tryGit(['rev-parse', '--is-inside-work-tree'], { cwd });
+    if (inside === 'true') add('git', 'Git repository', 'ok', 'recency boost + impact analysis enabled');
+    else add('git', 'Git repository', 'warn', 'not a git repository', 'git init — enables recency boost and impact analysis');
+  } catch (_) {
+    add('git', 'Git repository', 'warn', 'git not available', 'install git for recency boost + impact analysis');
+  }
+
+  // 2. Config & source roots
+  let config = {};
+  try {
+    const cfgPath = path.join(cwd, 'gen-context.config.json');
+    let configBroken = false;
+    if (fs.existsSync(cfgPath)) {
+      try { JSON.parse(fs.readFileSync(cfgPath, 'utf8')); }
+      catch (e) {
+        configBroken = true;
+        add('config', 'Config & source roots', 'fail', `gen-context.config.json is invalid JSON: ${e.message}`, 'fix the JSON syntax, or delete the file to fall back to defaults');
+      }
+    }
+    const { loadConfig } = require('../config/loader');
+    config = loadConfig(cwd) || {};
+    if (!configBroken) {
+      // Distinguish explicitly-configured srcDirs (validate each) from the
+      // default candidate list (just report which ones actually exist).
+      let explicitSrcDirs = null;
+      if (fs.existsSync(cfgPath)) {
+        try { const raw = JSON.parse(fs.readFileSync(cfgPath, 'utf8')); if (Array.isArray(raw.srcDirs)) explicitSrcDirs = raw.srcDirs; } catch (_) {}
+      }
+      const exists = (d) => { try { return fs.existsSync(path.isAbsolute(d) ? d : path.join(cwd, d)); } catch (_) { return false; } };
+      const srcDirs = Array.isArray(config.srcDirs) ? config.srcDirs : [];
+      const present = srcDirs.filter(exists);
+
+      if (explicitSrcDirs) {
+        const missing = explicitSrcDirs.filter((d) => !exists(d));
+        if (missing.length) add('config', 'Config & source roots', 'warn', `configured srcDirs not found: ${missing.join(', ')}`, 'fix "srcDirs" in gen-context.config.json');
+        else add('config', 'Config & source roots', 'ok', `srcDirs: ${explicitSrcDirs.join(', ')}`);
+      } else if (present.length === 0) {
+        add('config', 'Config & source roots', 'warn', 'no source directories found (looked for src/, app/, lib/, …)', 'create a src/ dir, set "srcDirs" in gen-context.config.json, or run: sigmap roots --fix');
+      } else {
+        add('config', 'Config & source roots', 'ok', `source roots: ${present.slice(0, 8).join(', ')}${present.length > 8 ? `, +${present.length - 8} more` : ''}`);
+      }
+    }
+  } catch (e) {
+    if (!checks.some((c) => c.id === 'config')) add('config', 'Config & source roots', 'warn', `could not load config: ${e.message}`);
+  }
+
+  // 3. Generated context file
+  const ctxFiles = _contextFiles(cwd);
+  if (ctxFiles.length === 0) {
+    add('context', 'Generated context', 'fail', 'no context file found', 'run: npx sigmap   (generates the signature map)');
+  } else {
+    add('context', 'Generated context', 'ok', `${ctxFiles.length} file(s): ${ctxFiles.map((f) => _short(f, cwd)).join(', ')}`);
+  }
+
+  // 4. Signature index
+  let indexSize = 0;
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    indexSize = buildSigIndex(cwd).size;
+  } catch (_) {}
+  if (indexSize === 0) {
+    add('index', 'Signature index', ctxFiles.length === 0 ? 'fail' : 'warn', 'no signatures indexed', 'run: npx sigmap   then: sigmap ask "<query>"');
+  } else {
+    add('index', 'Signature index', 'ok', `${indexSize} file(s) indexed`);
+  }
+
+  // 5. Index freshness
+  try {
+    if (ctxFiles.length) {
+      const ctxMtime = Math.max(...ctxFiles.map((f) => { try { return fs.statSync(f).mtimeMs; } catch (_) { return 0; } }));
+      const srcDirs = (config && Array.isArray(config.srcDirs) && config.srcDirs.length) ? config.srcDirs : ['src', 'app', 'lib'];
+      const changed = _countChangedSince(cwd, srcDirs, config, ctxMtime);
+      if (changed > 0) add('freshness', 'Index freshness', 'warn', `${changed} source file(s) changed since last generate`, 'run: sigmap   (or: sigmap --watch to auto-refresh)');
+      else add('freshness', 'Index freshness', 'ok', 'index is up to date with sources');
+    }
+  } catch (_) {}
+
+  // 6. Coverage
+  try {
+    if (indexSize > 0) {
+      const { coverageScore } = require('../analysis/coverage-score');
+      const { buildSigIndex } = require('../retrieval/ranker');
+      const entries = [...buildSigIndex(cwd).keys()].map((rel) => ({ filePath: path.resolve(cwd, rel) }));
+      const cov = coverageScore(cwd, entries, config);
+      if (cov.score < 70) add('coverage', 'Coverage', 'warn', `${cov.score}% of source files in context (grade ${cov.grade})`, 'increase maxTokens or expand srcDirs in gen-context.config.json');
+      else add('coverage', 'Coverage', 'ok', `${cov.score}% of source files in context (grade ${cov.grade})`);
+    }
+  } catch (_) {}
+
+  // 7. MCP wiring
+  try {
+    let wired = null;
+    for (const t of _mcpTargets(cwd)) {
+      try {
+        if (!fs.existsSync(t)) continue;
+        if (/sigmap/.test(fs.readFileSync(t, 'utf8'))) { wired = t; break; }
+      } catch (_) {}
+    }
+    if (wired) add('mcp', 'MCP wiring', 'ok', `registered in ${_short(wired, cwd)}`);
+    else add('mcp', 'MCP wiring', 'warn', 'MCP server not registered in any editor config', 'run: sigmap --setup   (auto-wires Claude, Cursor, Windsurf, VS Code, …)');
+  } catch (_) {}
+
+  const errors = checks.filter((c) => c.status === 'fail').length;
+  const warnings = checks.filter((c) => c.status === 'warn').length;
+  return { checks, ok: errors === 0, errors, warnings };
+}
+
+/** Human-readable checklist. */
+function formatDoctor(result) {
+  const lines = ['sigmap doctor', ''];
+  for (const c of result.checks) {
+    lines.push(`${ICON[c.status] || '?'} ${c.label}${c.detail ? ' — ' + c.detail : ''}`);
+    if (c.status !== 'ok' && c.fix) lines.push(`    ↳ ${c.fix}`);
+  }
+  lines.push('');
+  lines.push(
+    result.errors === 0 && result.warnings === 0
+      ? '✓ All checks passed.'
+      : `${result.errors} error(s), ${result.warnings} warning(s).`
+  );
+  return lines.join('\n');
+}
+
+/** Machine-readable result. */
+function formatDoctorJSON(result) {
+  return JSON.stringify(result, null, 2);
+}
+
+module.exports = { diagnose, formatDoctor, formatDoctorJSON };

--- a/test/integration/doctor.test.js
+++ b/test/integration/doctor.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/**
+ * v8.0 E3 — `sigmap doctor` diagnostic command.
+ * Covers the diagnose() module directly and the CLI (exit codes + --json).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+const { diagnose, formatDoctor, formatDoctorJSON } = require('../../src/doctor/diagnose');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.log(`  FAIL  ${name}: ${err.message}`); failed++; }
+}
+
+function withTempProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-doctor-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+/** Seed a healthy project: a src file, a matching context file, a config. */
+function seedHealthy(dir) {
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'widget.js'), 'function renderWidget(props){return props;}\nmodule.exports={renderWidget};\n');
+  fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({ srcDirs: ['src'] }) + '\n');
+  fs.mkdirSync(path.join(dir, '.github'), { recursive: true });
+  // Written last so the context mtime is newest → freshness ok.
+  fs.writeFileSync(path.join(dir, '.github', 'copilot-instructions.md'), [
+    '## Auto-generated signatures', '# Code signatures', '',
+    '### src/widget.js', '```', 'function renderWidget(props)  :1-1', '```', '',
+  ].join('\n'));
+}
+
+function runDoctor(dir, args) {
+  return execFileSync('node', [GEN_CONTEXT, 'doctor', ...(args || [])], { cwd: dir, encoding: 'utf8' });
+}
+
+function runDoctorExit(dir, args) {
+  try {
+    execFileSync('node', [GEN_CONTEXT, 'doctor', ...(args || [])], { cwd: dir, encoding: 'utf8', stdio: 'ignore' });
+    return 0;
+  } catch (e) {
+    return e.status == null ? -1 : e.status;
+  }
+}
+
+// ── diagnose() module ──────────────────────────────────────────────────────
+
+test('diagnose returns the result shape with a checks array', () => {
+  withTempProject((dir) => {
+    const r = diagnose(dir);
+    assert.ok(Array.isArray(r.checks) && r.checks.length >= 5, 'has checks');
+    assert.ok(typeof r.ok === 'boolean');
+    assert.ok(typeof r.errors === 'number' && typeof r.warnings === 'number');
+    for (const c of r.checks) {
+      assert.ok(c.id && c.label && c.status, 'each check has id/label/status');
+      assert.ok(['ok', 'warn', 'fail'].includes(c.status));
+    }
+  });
+});
+
+test('diagnose flags a missing context file as a hard failure', () => {
+  withTempProject((dir) => {
+    const r = diagnose(dir);
+    const ctx = r.checks.find((c) => c.id === 'context');
+    assert.strictEqual(ctx.status, 'fail');
+    assert.ok(/npx sigmap/.test(ctx.fix), 'fix points at generating context');
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors >= 1);
+  });
+});
+
+test('diagnose passes context + index on a seeded project', () => {
+  withTempProject((dir) => {
+    seedHealthy(dir);
+    const r = diagnose(dir);
+    assert.strictEqual(r.checks.find((c) => c.id === 'context').status, 'ok');
+    assert.strictEqual(r.checks.find((c) => c.id === 'index').status, 'ok');
+    assert.strictEqual(r.checks.find((c) => c.id === 'coverage').status, 'ok');
+    assert.strictEqual(r.ok, true, 'no hard failures on a healthy project');
+  });
+});
+
+test('diagnose flags invalid gen-context.config.json', () => {
+  withTempProject((dir) => {
+    fs.writeFileSync(path.join(dir, 'gen-context.config.json'), '{ not valid json ');
+    const cfg = diagnose(dir).checks.find((c) => c.id === 'config');
+    assert.strictEqual(cfg.status, 'fail');
+    assert.ok(/invalid JSON/i.test(cfg.detail));
+  });
+});
+
+test('every non-ok check carries an actionable fix', () => {
+  withTempProject((dir) => {
+    const r = diagnose(dir);
+    for (const c of r.checks) {
+      if (c.status !== 'ok') assert.ok(c.fix && c.fix.length > 0, `${c.id} has a fix`);
+    }
+  });
+});
+
+test('diagnose does not throw on an empty directory', () => {
+  withTempProject((dir) => {
+    assert.doesNotThrow(() => diagnose(dir));
+  });
+});
+
+test('formatDoctor renders a checklist; formatDoctorJSON round-trips', () => {
+  withTempProject((dir) => {
+    const r = diagnose(dir);
+    const text = formatDoctor(r);
+    assert.ok(/sigmap doctor/.test(text));
+    assert.ok(/[✓⚠✗]/.test(text), 'has status icons');
+    assert.deepStrictEqual(JSON.parse(formatDoctorJSON(r)).errors, r.errors);
+  });
+});
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+test('CLI doctor exits 1 when context is missing (hard failure)', () => {
+  withTempProject((dir) => {
+    assert.strictEqual(runDoctorExit(dir), 1);
+  });
+});
+
+test('CLI doctor exits 0 on a healthy seeded project', () => {
+  withTempProject((dir) => {
+    seedHealthy(dir);
+    assert.strictEqual(runDoctorExit(dir), 0);
+  });
+});
+
+test('CLI doctor --json emits { checks, ok, errors, warnings }', () => {
+  withTempProject((dir) => {
+    seedHealthy(dir);
+    const out = runDoctor(dir, ['--json']);
+    const r = JSON.parse(out);
+    assert.ok(Array.isArray(r.checks));
+    assert.ok(typeof r.ok === 'boolean');
+    assert.ok('errors' in r && 'warnings' in r);
+  });
+});
+
+test('CLI doctor prints fix hints for failures (exit 1, stdout captured)', () => {
+  withTempProject((dir) => {
+    let out = '';
+    try {
+      out = execFileSync('node', [GEN_CONTEXT, 'doctor'], { cwd: dir, encoding: 'utf8' });
+      assert.fail('expected non-zero exit on missing context');
+    } catch (e) {
+      assert.strictEqual(e.status, 1);
+      out = e.stdout || '';
+    }
+    assert.ok(/Generated context/.test(out), 'lists the context check');
+    assert.ok(/npx sigmap/.test(out), 'prints the fix hint');
+  });
+});
+
+console.log(`\nDoctor: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 17,
-  "tests": 102,
+  "tests": 103,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #381 · v8.0 "The Evidence Pack & the Pivot" → initiative **E3**.

## What
Adds `sigmap doctor` — a one-shot setup diagnostic so a cold user can reach a useful answer in minutes. It runs seven resilient checks and prints an actionable fix for anything wrong.

```
sigmap doctor

✓ Git repository — recency boost + impact analysis enabled
✓ Config & source roots — srcDirs: src, packages
✓ Generated context — 1 file(s): .github/copilot-instructions.md
✓ Signature index — 130 file(s) indexed
⚠ Index freshness — 1 source file(s) changed since last generate
    ↳ run: sigmap   (or: sigmap --watch to auto-refresh)
✓ Coverage — 99% of source files in context (grade A)
✓ MCP wiring — registered in .claude/settings.json
```

## How
- New zero-dep module `src/doctor/diagnose.js`: `diagnose(cwd)` → `{ checks:[{id,label,status,detail,fix}], ok, errors, warnings }`, plus `formatDoctor` (checklist) and `formatDoctorJSON`.
- Checks: **git** repo · **config & source roots** (validates explicit `srcDirs`, cleanly reports defaults) · **context** file present · **index** symbol count · **freshness** (files changed since generate) · **coverage** ≥ 70% · **mcp** wiring across known editor configs.
- CLI `sigmap doctor [--json]` in `gen-context.js`; documented in `--help`; bundle reproducible. Exit **1** on a hard failure (no context / invalid config), else **0** — usable in CI.
- Composed from `loadConfig`, `coverageScore`, `buildSigIndex`, and the adapter-output / MCP-config path lists. Git via `src/util/git.js` (no shell spawns).

## Acceptance criteria
- [x] Checklist with ✓/⚠/✗ per check, each non-ok line carrying a concrete fix
- [x] Covers config validity, context presence, index count, freshness, coverage, MCP wiring
- [x] `--json` emits `{ checks, ok, errors, warnings }`
- [x] Exit 1 on hard failure (missing context / invalid config), 0 otherwise
- [x] Degrades gracefully on empty / non-git projects (no throw)
- [x] Documented in `--help`; bundle reproducible; Phase 4B audit green
- [x] Tests: diagnose() module + CLI exit codes + `--json` (11 tests); full suite green (unit 23/0 · integration 97/0)

## Supply-chain gate
Local audit PASS — no shell spawns (git via `src/util/git.js`; `os.homedir()` used only to locate config files) · no install scripts · `main` exports API · no fingerprinting.

## Out of scope (remaining v8.0)
E2 repositioning, E4 agent recipes + `mcp install`. The 5-minute quickstart doc (E3's docs half) can follow in `/update-docs` or a small docs PR.