### PR TITLE
feat(mcp): one-command per-client MCP install (sigmap mcp install <client>)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -116,6 +116,8 @@ sigmap note "<text>"                     Append a note to the cross-session deci
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
 sigmap doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
+sigmap mcp list                          List MCP clients and their config paths (--json)
+sigmap mcp install <client>              Wire MCP for one client (claude|cursor|windsurf|vscode|zed|codex|gemini|opencode|mcp); --global for user-level
 sigmap --init                            Write example config + .contextignore scaffold
 sigmap --help                            Show this message
 sigmap --version                         Show version

--- a/gen-context.js
+++ b/gen-context.js
@@ -12528,6 +12528,152 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
   
 };
 
+// ── ./src/mcp/install ──
+__factories["./src/mcp/install"] = function(module, exports) {
+  
+  /**
+   * Per-client MCP install (v8.0 E4).
+   *
+   * `sigmap --setup` wires *every* known editor at once and only touches config
+   * files that already exist (to avoid creating clutter for editors the user does
+   * not use). This module is the targeted counterpart: `sigmap mcp install <client>`
+   * picks one client, and — because the user explicitly asked for it — CREATES the
+   * config dir/file if it is missing. Idempotent: re-running never duplicates the
+   * entry. Zero dependencies; only `fs`/`path`/`os`.
+   */
+
+  const fs   = require('fs');
+  const path = require('path');
+  const os   = require('os');
+
+  // Config shapes the supported clients use.
+  //  - 'json'  → { mcpServers: { sigmap: { command, args } } }
+  //  - 'zed'   → { context_servers: { sigmap: { command: { path, args } } } }
+  //  - 'yaml'  → Codex CLI ~/.codex/config.yaml (mcpServers block, appended)
+  const CLIENTS = {
+    claude:   { label: 'Claude Code',  format: 'json', scope: 'project', project: ['.claude', 'settings.json'] },
+    cursor:   { label: 'Cursor',       format: 'json', scope: 'project', project: ['.cursor', 'mcp.json'] },
+    windsurf: { label: 'Windsurf',     format: 'json', scope: 'both',
+                project: ['.windsurf', 'mcp.json'],
+                global:  ['.codeium', 'windsurf', 'mcp_config.json'] },
+    vscode:   { label: 'VS Code',      format: 'json', scope: 'project', project: ['.vscode', 'mcp.json'] },
+    opencode: { label: 'OpenCode',     format: 'json', scope: 'both',
+                project: ['opencode.json'],
+                global:  ['.config', 'opencode', 'config.json'] },
+    gemini:   { label: 'Gemini CLI',   format: 'json', scope: 'global', global: ['.gemini', 'settings.json'] },
+    zed:      { label: 'Zed',          format: 'zed',  scope: 'global', global: ['.config', 'zed', 'settings.json'] },
+    codex:    { label: 'Codex CLI',    format: 'yaml', scope: 'global', global: ['.codex', 'config.yaml'] },
+    mcp:      { label: 'Portable (.mcp.json)', format: 'json', scope: 'project', project: ['.mcp.json'] },
+  };
+
+  /** Resolve the absolute config path for a client, honoring `global`. */
+  function resolveTarget(spec, cwd, home, useGlobal) {
+    const wantGlobal = useGlobal || spec.scope === 'global';
+    if (wantGlobal && spec.global) return path.join(home, ...spec.global);
+    if (spec.project) return path.join(cwd, ...spec.project);
+    if (spec.global)  return path.join(home, ...spec.global);
+    return null;
+  }
+
+  /** List supported clients with their resolved target paths. */
+  function listClients(opts = {}) {
+    const cwd  = opts.cwd  || process.cwd();
+    const home = opts.home || os.homedir();
+    return Object.keys(CLIENTS).map((key) => {
+      const spec = CLIENTS[key];
+      return {
+        client: key,
+        label:  spec.label,
+        scope:  spec.scope,
+        format: spec.format,
+        target: resolveTarget(spec, cwd, home, false),
+        globalTarget: spec.scope === 'both' ? resolveTarget(spec, cwd, home, true) : null,
+      };
+    });
+  }
+
+  function serverArgs(scriptPath) {
+    return [path.resolve(scriptPath), '--mcp'];
+  }
+
+  /** Install into a JSON `mcpServers` config (create file/dir if absent). */
+  function _installJson(filePath, scriptPath) {
+    let settings = {};
+    if (fs.existsSync(filePath)) {
+      try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+      catch (_) { settings = {}; }
+    }
+    if (!settings.mcpServers) settings.mcpServers = {};
+    if (settings.mcpServers.sigmap) return 'already';
+    settings.mcpServers.sigmap = { command: 'node', args: serverArgs(scriptPath) };
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+    return 'installed';
+  }
+
+  /** Install into Zed's `context_servers` config (create file/dir if absent). */
+  function _installZed(filePath, scriptPath) {
+    let settings = {};
+    if (fs.existsSync(filePath)) {
+      try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+      catch (_) { settings = {}; }
+    }
+    if (!settings.context_servers) settings.context_servers = {};
+    if (settings.context_servers.sigmap) return 'already';
+    settings.context_servers.sigmap = { command: { path: 'node', args: serverArgs(scriptPath) } };
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+    return 'installed';
+  }
+
+  /** Install into Codex CLI YAML (append block; create file if absent). */
+  function _installYaml(filePath, scriptPath) {
+    let raw = '';
+    if (fs.existsSync(filePath)) {
+      raw = fs.readFileSync(filePath, 'utf8');
+      if (raw.includes('sigmap')) return 'already';
+    }
+    const block = [
+      'mcpServers:',
+      '  sigmap:',
+      '    command: node',
+      '    args:',
+      `      - ${path.resolve(scriptPath)}`,
+      '      - --mcp',
+    ].join('\n');
+    const next = raw ? raw.trimEnd() + '\n\n' + block + '\n' : block + '\n';
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, next);
+    return 'installed';
+  }
+
+  /**
+   * Install the sigmap MCP server for a single client.
+   * @returns { client, label, path, status } where status is
+   *   'installed' | 'already' | 'unknown'.
+   */
+  function installClient(client, opts = {}) {
+    const spec = CLIENTS[client];
+    if (!spec) {
+      return { client, status: 'unknown', valid: Object.keys(CLIENTS) };
+    }
+    const cwd        = opts.cwd  || process.cwd();
+    const home       = opts.home || os.homedir();
+    const scriptPath = opts.scriptPath || path.join(cwd, 'gen-context.js');
+    const filePath   = resolveTarget(spec, cwd, home, opts.global);
+
+    let status;
+    if (spec.format === 'zed')       status = _installZed(filePath, scriptPath);
+    else if (spec.format === 'yaml') status = _installYaml(filePath, scriptPath);
+    else                             status = _installJson(filePath, scriptPath);
+
+    return { client, label: spec.label, path: filePath, status };
+  }
+
+  module.exports = { CLIENTS, listClients, installClient, resolveTarget };
+  
+};
+
 // ── ./src/mcp/server ──
 __factories["./src/mcp/server"] = function(module, exports) {
   
@@ -18192,6 +18338,8 @@ Usage:
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
   ${cmd} doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
+  ${cmd} mcp list                          List MCP clients and their config paths (--json)
+  ${cmd} mcp install <client>              Wire MCP for one client (claude|cursor|windsurf|vscode|zed|codex|gemini|opencode|mcp); --global for user-level
   ${cmd} --init                            Write example config + .contextignore scaffold
   ${cmd} --help                            Show this message
   ${cmd} --version                         Show version
@@ -19614,6 +19762,56 @@ function main() {
       console.log('  Notes:         none — add with: sigmap note "<text>"');
     }
     process.exit(0);
+  }
+
+  // `sigmap mcp install <client>` / `sigmap mcp list` — one-command per-client
+  // MCP wiring (v8.0 E4). Unlike `--setup` (wires every editor, only touches
+  // existing configs), this targets one client and creates the config if absent.
+  if (args[0] === 'mcp') {
+    const { listClients, installClient } = requireSourceOrBundled('./src/mcp/install');
+    const sub = args[1];
+
+    if (sub === 'list') {
+      const clients = listClients({ cwd });
+      if (args.includes('--json')) {
+        process.stdout.write(JSON.stringify(clients, null, 2) + '\n');
+        process.exit(0);
+      }
+      console.log('Supported MCP clients:\n');
+      for (const c of clients) {
+        const scope = c.scope === 'both' ? 'project (or --global)' : c.scope;
+        console.log(`  ${c.client.padEnd(10)} ${c.label}`);
+        console.log(`             ${_displayPath(c.target, cwd)}  [${scope}]`);
+      }
+      console.log('\nInstall with: sigmap mcp install <client>');
+      process.exit(0);
+    }
+
+    if (sub === 'install') {
+      const client = args[2];
+      if (!client || client.startsWith('--')) {
+        console.error('[sigmap] usage: sigmap mcp install <client>   (see: sigmap mcp list)');
+        process.exit(1);
+      }
+      const result = installClient(client, {
+        cwd,
+        scriptPath,
+        global: args.includes('--global'),
+      });
+      if (result.status === 'unknown') {
+        console.error(`[sigmap] unknown client "${client}". Valid: ${result.valid.join(', ')}`);
+        process.exit(1);
+      }
+      if (result.status === 'already') {
+        console.log(`[sigmap] ${result.label}: sigmap already registered in ${_displayPath(result.path, cwd)}`);
+      } else {
+        console.log(`[sigmap] ${result.label}: registered MCP server in ${_displayPath(result.path, cwd)}`);
+      }
+      process.exit(0);
+    }
+
+    console.error('[sigmap] usage: sigmap mcp install <client> | sigmap mcp list');
+    process.exit(1);
   }
 
   // `sigmap doctor` — diagnose config, index, freshness, coverage, and MCP

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -116,6 +116,8 @@ sigmap note "<text>"                     Append a note to the cross-session deci
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
 sigmap doctor                            Diagnose config, index, freshness, coverage, MCP wiring — with fixes (--json; exits 1 on hard failure)
+sigmap mcp list                          List MCP clients and their config paths (--json)
+sigmap mcp install <client>              Wire MCP for one client (claude|cursor|windsurf|vscode|zed|codex|gemini|opencode|mcp); --global for user-level
 sigmap --init                            Write example config + .contextignore scaffold
 sigmap --help                            Show this message
 sigmap --version                         Show version

--- a/src/mcp/install.js
+++ b/src/mcp/install.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * Per-client MCP install (v8.0 E4).
+ *
+ * `sigmap --setup` wires *every* known editor at once and only touches config
+ * files that already exist (to avoid creating clutter for editors the user does
+ * not use). This module is the targeted counterpart: `sigmap mcp install <client>`
+ * picks one client, and — because the user explicitly asked for it — CREATES the
+ * config dir/file if it is missing. Idempotent: re-running never duplicates the
+ * entry. Zero dependencies; only `fs`/`path`/`os`.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+// Config shapes the supported clients use.
+//  - 'json'  → { mcpServers: { sigmap: { command, args } } }
+//  - 'zed'   → { context_servers: { sigmap: { command: { path, args } } } }
+//  - 'yaml'  → Codex CLI ~/.codex/config.yaml (mcpServers block, appended)
+const CLIENTS = {
+  claude:   { label: 'Claude Code',  format: 'json', scope: 'project', project: ['.claude', 'settings.json'] },
+  cursor:   { label: 'Cursor',       format: 'json', scope: 'project', project: ['.cursor', 'mcp.json'] },
+  windsurf: { label: 'Windsurf',     format: 'json', scope: 'both',
+              project: ['.windsurf', 'mcp.json'],
+              global:  ['.codeium', 'windsurf', 'mcp_config.json'] },
+  vscode:   { label: 'VS Code',      format: 'json', scope: 'project', project: ['.vscode', 'mcp.json'] },
+  opencode: { label: 'OpenCode',     format: 'json', scope: 'both',
+              project: ['opencode.json'],
+              global:  ['.config', 'opencode', 'config.json'] },
+  gemini:   { label: 'Gemini CLI',   format: 'json', scope: 'global', global: ['.gemini', 'settings.json'] },
+  zed:      { label: 'Zed',          format: 'zed',  scope: 'global', global: ['.config', 'zed', 'settings.json'] },
+  codex:    { label: 'Codex CLI',    format: 'yaml', scope: 'global', global: ['.codex', 'config.yaml'] },
+  mcp:      { label: 'Portable (.mcp.json)', format: 'json', scope: 'project', project: ['.mcp.json'] },
+};
+
+/** Resolve the absolute config path for a client, honoring `global`. */
+function resolveTarget(spec, cwd, home, useGlobal) {
+  const wantGlobal = useGlobal || spec.scope === 'global';
+  if (wantGlobal && spec.global) return path.join(home, ...spec.global);
+  if (spec.project) return path.join(cwd, ...spec.project);
+  if (spec.global)  return path.join(home, ...spec.global);
+  return null;
+}
+
+/** List supported clients with their resolved target paths. */
+function listClients(opts = {}) {
+  const cwd  = opts.cwd  || process.cwd();
+  const home = opts.home || os.homedir();
+  return Object.keys(CLIENTS).map((key) => {
+    const spec = CLIENTS[key];
+    return {
+      client: key,
+      label:  spec.label,
+      scope:  spec.scope,
+      format: spec.format,
+      target: resolveTarget(spec, cwd, home, false),
+      globalTarget: spec.scope === 'both' ? resolveTarget(spec, cwd, home, true) : null,
+    };
+  });
+}
+
+function serverArgs(scriptPath) {
+  return [path.resolve(scriptPath), '--mcp'];
+}
+
+/** Install into a JSON `mcpServers` config (create file/dir if absent). */
+function _installJson(filePath, scriptPath) {
+  let settings = {};
+  if (fs.existsSync(filePath)) {
+    try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+    catch (_) { settings = {}; }
+  }
+  if (!settings.mcpServers) settings.mcpServers = {};
+  if (settings.mcpServers.sigmap) return 'already';
+  settings.mcpServers.sigmap = { command: 'node', args: serverArgs(scriptPath) };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+  return 'installed';
+}
+
+/** Install into Zed's `context_servers` config (create file/dir if absent). */
+function _installZed(filePath, scriptPath) {
+  let settings = {};
+  if (fs.existsSync(filePath)) {
+    try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+    catch (_) { settings = {}; }
+  }
+  if (!settings.context_servers) settings.context_servers = {};
+  if (settings.context_servers.sigmap) return 'already';
+  settings.context_servers.sigmap = { command: { path: 'node', args: serverArgs(scriptPath) } };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+  return 'installed';
+}
+
+/** Install into Codex CLI YAML (append block; create file if absent). */
+function _installYaml(filePath, scriptPath) {
+  let raw = '';
+  if (fs.existsSync(filePath)) {
+    raw = fs.readFileSync(filePath, 'utf8');
+    if (raw.includes('sigmap')) return 'already';
+  }
+  const block = [
+    'mcpServers:',
+    '  sigmap:',
+    '    command: node',
+    '    args:',
+    `      - ${path.resolve(scriptPath)}`,
+    '      - --mcp',
+  ].join('\n');
+  const next = raw ? raw.trimEnd() + '\n\n' + block + '\n' : block + '\n';
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, next);
+  return 'installed';
+}
+
+/**
+ * Install the sigmap MCP server for a single client.
+ * @returns { client, label, path, status } where status is
+ *   'installed' | 'already' | 'unknown'.
+ */
+function installClient(client, opts = {}) {
+  const spec = CLIENTS[client];
+  if (!spec) {
+    return { client, status: 'unknown', valid: Object.keys(CLIENTS) };
+  }
+  const cwd        = opts.cwd  || process.cwd();
+  const home       = opts.home || os.homedir();
+  const scriptPath = opts.scriptPath || path.join(cwd, 'gen-context.js');
+  const filePath   = resolveTarget(spec, cwd, home, opts.global);
+
+  let status;
+  if (spec.format === 'zed')       status = _installZed(filePath, scriptPath);
+  else if (spec.format === 'yaml') status = _installYaml(filePath, scriptPath);
+  else                             status = _installJson(filePath, scriptPath);
+
+  return { client, label: spec.label, path: filePath, status };
+}
+
+module.exports = { CLIENTS, listClients, installClient, resolveTarget };

--- a/test/integration/features/query-validate.test.js
+++ b/test/integration/features/query-validate.test.js
@@ -149,22 +149,39 @@ test('sigmap --ci --json → valid JSON with pass/coverage/threshold', () => {
   assert.strictEqual(typeof parsed.coverage, 'number', 'coverage not a number');
 });
 
-// 11. sigmap --ci --min-coverage 99 → exits 1
-test('sigmap --ci --min-coverage 99 → exits 1', () => {
-  const r = spawnSync(process.execPath, [SCRIPT, '--ci', '--min-coverage', '99'], {
+// Measure the repo's actual coverage once — the absolute value is
+// environment-dependent (it shifts with auto-detected srcDirs, the auto-budget,
+// and whatever context other tests have generated in ROOT), so tests 11/12 pin
+// their threshold relative to it rather than to a hard-coded "impossible" number.
+function measuredCoverage() {
+  const r = spawnSync(process.execPath, [SCRIPT, '--ci', '--json'], {
     encoding: 'utf8', cwd: ROOT, timeout: 20000,
   });
-  assert.strictEqual(r.status, 1, `expected exit 1, got ${r.status}`);
+  return JSON.parse(r.stdout.trim()).coverage;
+}
+
+// 11. --ci gate fails when the threshold exceeds achievable coverage → exits 1
+test('sigmap --ci with a threshold above measured coverage → exits 1', () => {
+  const cov = measuredCoverage();
+  if (cov >= 100) { console.log('  SKIP  coverage is 100% — no higher threshold to test'); return; }
+  const threshold = Math.min(100, cov + 1);
+  const r = spawnSync(process.execPath, [SCRIPT, '--ci', '--min-coverage', String(threshold)], {
+    encoding: 'utf8', cwd: ROOT, timeout: 20000,
+  });
+  assert.strictEqual(r.status, 1, `expected exit 1 at threshold ${threshold} (coverage ${cov}), got ${r.status}`);
 });
 
-// 12. sigmap --ci --min-coverage 99 --json → pass:false
-test('sigmap --ci --min-coverage 99 --json → pass:false', () => {
-  const r = spawnSync(process.execPath, [SCRIPT, '--ci', '--min-coverage', '99', '--json'], {
+// 12. same, --json → pass:false with the requested threshold echoed back
+test('sigmap --ci --json with a threshold above measured coverage → pass:false', () => {
+  const cov = measuredCoverage();
+  if (cov >= 100) { console.log('  SKIP  coverage is 100% — no higher threshold to test'); return; }
+  const threshold = Math.min(100, cov + 1);
+  const r = spawnSync(process.execPath, [SCRIPT, '--ci', '--min-coverage', String(threshold), '--json'], {
     encoding: 'utf8', cwd: ROOT, timeout: 20000,
   });
   const parsed = JSON.parse(r.stdout.trim());
-  assert.strictEqual(parsed.pass,      false, `expected pass:false, got ${parsed.pass}`);
-  assert.strictEqual(parsed.threshold, 99,    `expected threshold 99, got ${parsed.threshold}`);
+  assert.strictEqual(parsed.pass,      false,     `expected pass:false at threshold ${threshold} (coverage ${cov})`);
+  assert.strictEqual(parsed.threshold, threshold, `expected threshold ${threshold}, got ${parsed.threshold}`);
 });
 
 // 13. sigmap ask --json → JSON does not crash regardless of coverage

--- a/test/integration/mcp/install.test.js
+++ b/test/integration/mcp/install.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../../gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-mcp-install-'));
+  fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({ srcDirs: [] }));
+  return dir;
+}
+
+function cleanup(dirs) {
+  for (const d of dirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+/** Run gen-context.js; returns { stdout, status }. Never throws on non-zero. */
+function run(dir, argv, extraEnv) {
+  try {
+    const stdout = execFileSync('node', [GEN_CONTEXT, ...argv], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 15000,
+      env: { ...process.env, ...(extraEnv || {}) },
+    });
+    return { stdout, status: 0 };
+  } catch (err) {
+    return { stdout: (err.stdout || '') + (err.stderr || ''), status: err.status || 1 };
+  }
+}
+
+console.log('\nmcp-install: sigmap mcp install/list tests\n');
+
+// ── mcp list ────────────────────────────────────────────────────────────────
+test('mcp list prints supported clients with config paths', () => {
+  const dir = makeTmpDir();
+  try {
+    const { stdout, status } = run(dir, ['mcp', 'list']);
+    assert.strictEqual(status, 0, 'mcp list should exit 0');
+    assert.ok(/claude/.test(stdout), 'should list claude');
+    assert.ok(/cursor/.test(stdout), 'should list cursor');
+    assert.ok(/\.claude[\/\\]settings\.json/.test(stdout), 'should show claude config path');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('mcp list --json emits parseable client array with target paths', () => {
+  const dir = makeTmpDir();
+  try {
+    const { stdout, status } = run(dir, ['mcp', 'list', '--json']);
+    assert.strictEqual(status, 0);
+    const clients = JSON.parse(stdout);
+    assert.ok(Array.isArray(clients) && clients.length >= 5, 'should be an array of clients');
+    const claude = clients.find((c) => c.client === 'claude');
+    assert.ok(claude && claude.target, 'claude entry should carry a target path');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+// ── install creates config when absent ───────────────────────────────────────
+test('mcp install claude writes a valid sigmap entry, creating the dir', () => {
+  const dir = makeTmpDir();
+  try {
+    assert.ok(!fs.existsSync(path.join(dir, '.claude')), '.claude must not pre-exist');
+    const { status } = run(dir, ['mcp', 'install', 'claude']);
+    assert.strictEqual(status, 0);
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, '.claude', 'settings.json'), 'utf8'));
+    assert.ok(cfg.mcpServers?.sigmap, 'mcpServers.sigmap should be set');
+    assert.strictEqual(cfg.mcpServers.sigmap.command, 'node');
+    assert.ok(Array.isArray(cfg.mcpServers.sigmap.args));
+    assert.ok(cfg.mcpServers.sigmap.args.includes('--mcp'), 'args should include --mcp');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+// ── idempotency ───────────────────────────────────────────────────────────────
+test('mcp install is idempotent — re-run reports already-installed, no duplicate', () => {
+  const dir = makeTmpDir();
+  try {
+    run(dir, ['mcp', 'install', 'cursor']);
+    const { stdout, status } = run(dir, ['mcp', 'install', 'cursor']);
+    assert.strictEqual(status, 0);
+    assert.ok(/already/.test(stdout), 'second run should report already registered');
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, '.cursor', 'mcp.json'), 'utf8'));
+    assert.strictEqual(Object.keys(cfg.mcpServers).length, 1, 'exactly one server entry');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('mcp install preserves an existing different sigmap entry', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.cursor'));
+    fs.writeFileSync(
+      path.join(dir, '.cursor', 'mcp.json'),
+      JSON.stringify({ mcpServers: { sigmap: { command: 'node', args: ['existing'] } } })
+    );
+    run(dir, ['mcp', 'install', 'cursor']);
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, '.cursor', 'mcp.json'), 'utf8'));
+    assert.deepStrictEqual(cfg.mcpServers.sigmap.args, ['existing'], 'existing entry must not be overwritten');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('mcp install merges alongside another mcp server', () => {
+  const dir = makeTmpDir();
+  try {
+    fs.writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({ mcpServers: { other: { command: 'foo', args: [] } } })
+    );
+    run(dir, ['mcp', 'install', 'mcp']);
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.ok(cfg.mcpServers.other, 'pre-existing server must be preserved');
+    assert.ok(cfg.mcpServers.sigmap, 'sigmap must be added');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+// ── Zed shape (context_servers) ───────────────────────────────────────────────
+test('mcp install zed produces context_servers shape (not mcpServers)', () => {
+  const dir      = makeTmpDir();
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-home-'));
+  try {
+    const { status } = run(dir, ['mcp', 'install', 'zed'], { HOME: fakeHome, USERPROFILE: fakeHome });
+    assert.strictEqual(status, 0);
+    const cfg = JSON.parse(fs.readFileSync(path.join(fakeHome, '.config', 'zed', 'settings.json'), 'utf8'));
+    assert.ok(cfg.context_servers?.sigmap, 'context_servers.sigmap should be set');
+    assert.strictEqual(cfg.context_servers.sigmap.command.path, 'node');
+    assert.ok(Array.isArray(cfg.context_servers.sigmap.command.args));
+  } finally {
+    cleanup([dir, fakeHome]);
+  }
+});
+
+// ── Codex YAML shape ──────────────────────────────────────────────────────────
+test('mcp install codex produces a YAML mcpServers block', () => {
+  const dir      = makeTmpDir();
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-home-'));
+  try {
+    const { status } = run(dir, ['mcp', 'install', 'codex'], { HOME: fakeHome, USERPROFILE: fakeHome });
+    assert.strictEqual(status, 0);
+    const raw = fs.readFileSync(path.join(fakeHome, '.codex', 'config.yaml'), 'utf8');
+    assert.ok(/mcpServers:/.test(raw), 'should contain mcpServers: block');
+    assert.ok(/sigmap:/.test(raw), 'should register sigmap');
+    assert.ok(/- --mcp/.test(raw), 'should pass --mcp arg');
+  } finally {
+    cleanup([dir, fakeHome]);
+  }
+});
+
+// ── --global scope ────────────────────────────────────────────────────────────
+test('mcp install windsurf --global targets the user-level config', () => {
+  const dir      = makeTmpDir();
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-home-'));
+  try {
+    const { status } = run(dir, ['mcp', 'install', 'windsurf', '--global'], { HOME: fakeHome, USERPROFILE: fakeHome });
+    assert.strictEqual(status, 0);
+    const globalPath = path.join(fakeHome, '.codeium', 'windsurf', 'mcp_config.json');
+    assert.ok(fs.existsSync(globalPath), 'global windsurf config should be created');
+    assert.ok(!fs.existsSync(path.join(dir, '.windsurf')), 'project config should not be created with --global');
+    const cfg = JSON.parse(fs.readFileSync(globalPath, 'utf8'));
+    assert.ok(cfg.mcpServers?.sigmap);
+  } finally {
+    cleanup([dir, fakeHome]);
+  }
+});
+
+// ── error handling ────────────────────────────────────────────────────────────
+test('mcp install <unknown> exits non-zero and lists valid clients', () => {
+  const dir = makeTmpDir();
+  try {
+    const { stdout, status } = run(dir, ['mcp', 'install', 'bogus']);
+    assert.notStrictEqual(status, 0, 'unknown client should exit non-zero');
+    assert.ok(/claude/.test(stdout) && /cursor/.test(stdout), 'should list valid clients');
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+test('mcp install with no client name exits non-zero with usage', () => {
+  const dir = makeTmpDir();
+  try {
+    const { status } = run(dir, ['mcp', 'install']);
+    assert.notStrictEqual(status, 0);
+  } finally {
+    cleanup([dir]);
+  }
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 17,
-  "tests": 103,
+  "tests": 104,
   "metrics": {
     "hit_at_5": 0.756,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #385 · v8.0 initiative **E4**.

## What
Adds targeted, per-client MCP wiring:
- `sigmap mcp list` — list supported clients + their config paths (`--json`)
- `sigmap mcp install <client>` — wire one client (`claude|cursor|windsurf|vscode|zed|codex|gemini|opencode|mcp`); `--global` for user-level config

Unlike `sigmap --setup` (wires *every* editor at once, only updates configs that already exist), this targets one client and **creates** the config dir/file when absent — supporting the v8.0 <5-min quickstart exit gate.

## How
- New zero-dep module `src/mcp/install.js` (client registry + `listClients`/`installClient`); handles the three config shapes already in use: `mcpServers` JSON, Zed `context_servers`, Codex YAML. Idempotent.
- CLI dispatch + `--help` entries in `gen-context.js`; bundle regenerated (reproducible — 128 modules).
- `version.json` test count synced; `llms-full.txt` regenerated with the new commands.

## Commits
1. `feat(mcp)` — the install/list command + module + tests + bundle + version.json
2. `docs(llms)` — regenerate llms-full.txt with the new command surface
3. `test(ci-gate)` — harden two pre-existing `--ci --min-coverage` tests that were order/environment-dependent (they assumed 99% coverage is unreachable; once the suite generates a full `src/` context, coverage hits 99-100% and the hard-coded threshold no longer fails the gate). Now measured relative to actual coverage.

## Acceptance criteria
- [x] `mcp list` prints clients + config paths
- [x] `mcp install <client>` writes a valid entry, creating dir/file if absent
- [x] Idempotent — re-run reports already-installed, no duplicate
- [x] Zed (`context_servers`) and Codex (YAML) shapes correct
- [x] Unknown client exits non-zero with valid-client list
- [x] `--setup` unchanged; full suite green
- [x] Phase 4B supply-chain audit clean (no shell spawns · no install scripts · main exports API · no fingerprinting)

## Tests
`test/integration/mcp/install.test.js` — 11 tests, all passing. Full integration + unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)