### PR TITLE
docs: sync live site to v7.30.0 (banner + benchmark labels)

### DIFF
--- a/docs-vp/guide/benchmark.md
+++ b/docs-vp/guide/benchmark.md
@@ -1,13 +1,13 @@
 ---
 title: Benchmark overview
-description: Official v7.29.0 benchmark snapshot. 97.0% average token reduction across 21 repos, 76% retrieval hit@5, 39.4% fewer prompts, and R language support verified.
+description: Official v7.30.0 benchmark snapshot. 97.0% average token reduction across 21 repos, 76% retrieval hit@5, 39.4% fewer prompts, and R language support verified.
 head:
   - - meta
     - property: og:title
-      content: "SigMap benchmark overview — v7.29.0 snapshot with R language"
+      content: "SigMap benchmark overview — v7.30.0 snapshot with R language"
   - - meta
     - property: og:description
-      content: "Token, retrieval, quality, and task metrics from latest v7.29.0 benchmark run (2026-06-23) with 21 repositories including R language support."
+      content: "Token, retrieval, quality, and task metrics from latest v7.30.0 benchmark run (2026-06-23) with 21 repositories including R language support."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/benchmark"
@@ -15,7 +15,7 @@ head:
 
 # Benchmark overview
 
-::: info Official v7.29.0 benchmark snapshot (21 repos, including R language)
+::: info Official v7.30.0 benchmark snapshot (21 repos, including R language)
 **Benchmark ID:** sigmap-v7.30-main &nbsp;·&nbsp; **Date:** 2026-06-23
 
 | Metric | Value |
@@ -37,9 +37,9 @@ This is the landing page for the public benchmark story. It answers four differe
 | SigMap reduces retries and wrong-context answers | [Task benchmark](/guide/task-benchmark) |
 | SigMap keeps large repos inside model limits | [Quality benchmark](/guide/quality-benchmark) |
 
-## Official v7.29.0 snapshot (with R language support)
+## Official v7.30.0 snapshot (with R language support)
 
-Latest saved benchmark run: **2026-06-23 (v7.29.0)**
+Latest saved benchmark run: **2026-06-23 (v7.30.0)**
 
 | Metric | Result |
 |---|---:|

--- a/docs-vp/guide/generalization.md
+++ b/docs-vp/guide/generalization.md
@@ -1,6 +1,6 @@
 ---
 title: Generalization — SigMap across languages, domains & repo sizes
-description: SigMap generalizes across 21 repos, 33 languages, and multiple domains with 75.6% hit@5 in the latest saved v7.29.0 retrieval run.
+description: SigMap generalizes across 21 repos, 33 languages, and multiple domains with 75.6% hit@5 in the latest saved v7.30.0 retrieval run.
 head:
   - - meta
     - property: og:title
@@ -19,8 +19,8 @@ head:
 SigMap was not tuned for one repo. This benchmark matters because it shows the same workflow transfers across different languages, repo sizes, and architectures without manual tuning.
 :::
 
-::: info Official v7.29.0 benchmark snapshot
-**Benchmark ID:** sigmap-v7.29-main &nbsp;·&nbsp; **Date:** 2026-06-23 (with R language)
+::: info Official v7.30.0 benchmark snapshot
+**Benchmark ID:** sigmap-v7.30-main &nbsp;·&nbsp; **Date:** 2026-06-23 (with R language)
 
 | Metric | Value |
 |---|---:|
@@ -37,7 +37,7 @@ The important part of SigMap's benchmark story is not just the topline score. It
 ::: info What "generalization" means here
 SigMap's signature extractors are hand-written regex patterns, not ML models. Generalization
 means: *do the patterns hold up on codebases the authors never inspected?* The answer across
-these 90 tasks is yes — 76% hit@5 with no per-repo tuning in the latest saved v7.29.0 run.
+these 90 tasks is yes — 76% hit@5 with no per-repo tuning in the latest saved v7.30.0 run.
 :::
 
 - **21 repos** (including 3 R language repos)

--- a/docs-vp/guide/quality-benchmark.md
+++ b/docs-vp/guide/quality-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Quality benchmark
-description: What token reduction means operationally in v7.29.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
+description: What token reduction means operationally in v7.30.0. 16/21 repos overflow GPT-4o without SigMap, 5,200+ files would be hidden, and GPT-4o input savings reach $10,500+/month at 10 calls/day.
 head:
   - - meta
     - property: og:title
@@ -15,7 +15,7 @@ head:
 
 # Quality benchmark
 
-::: info Official v7.29.0 benchmark snapshot
+::: info Official v7.30.0 benchmark snapshot
 **Benchmark ID:** sigmap-v7.30-main &nbsp;·&nbsp; **Date:** 2026-06-23 (with R language)
 
 | Metric | Value |
@@ -34,7 +34,7 @@ Token reduction is the mechanism. This benchmark shows the operational consequen
 - how much code would be hidden without SigMap?
 - what does that mean for API cost?
 
-Latest saved run: **2026-06-23 (v7.29.0)**
+Latest saved run: **2026-06-23 (v7.30.0)**
 
 ## Headline numbers
 

--- a/docs-vp/guide/retrieval-benchmark.md
+++ b/docs-vp/guide/retrieval-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Retrieval benchmark
-description: Latest saved retrieval benchmark for SigMap v7.29.0. 76% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
+description: Latest saved retrieval benchmark for SigMap v7.30.0. 76% hit@5 vs 13.6% random baseline across 90 tasks on 18 repos, with R language support.
 head:
   - - meta
     - property: og:title
@@ -15,7 +15,7 @@ head:
 
 # Retrieval benchmark
 
-::: info Official v7.29.0 benchmark snapshot
+::: info Official v7.30.0 benchmark snapshot
 **Benchmark ID:** sigmap-v7.30-main &nbsp;·&nbsp; **Date:** 2026-06-23 (with R language)
 
 | Metric | Value |
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-23 (v7.29.0)**
+Latest saved run: **2026-06-23 (v7.30.0)**
 
 **Result:** SigMap finds the right file in the top 5 far more often than chance — **76% hit@5** vs **13.6%** random baseline across 90 tasks on 18 real repos.
 

--- a/docs-vp/guide/task-benchmark.md
+++ b/docs-vp/guide/task-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: Task benchmark
-description: Latest saved task benchmark for SigMap v7.29.0. 52.2% correct, 39.4% fewer prompts, 76% hit@5 across 90 tasks, with R language support.
+description: Latest saved task benchmark for SigMap v7.30.0. 52.2% correct, 39.4% fewer prompts, 76% hit@5 across 90 tasks, with R language support.
 head:
   - - meta
     - property: og:title
@@ -15,7 +15,7 @@ head:
 
 # Task benchmark
 
-::: info Official v7.29.0 benchmark snapshot
+::: info Official v7.30.0 benchmark snapshot
 **Benchmark ID:** sigmap-v7.30-main &nbsp;·&nbsp; **Date:** 2026-06-23 (with R language)
 
 | Metric | Value |
@@ -29,7 +29,7 @@ head:
 | GPT-4o overflow (without → with) | **16/21 → 0/21** |
 :::
 
-Latest saved run: **2026-06-23 (v7.29.0)** — Now includes R language support (ggplot2, dplyr, shiny)
+Latest saved run: **2026-06-23 (v7.30.0)** — Now includes R language support (ggplot2, dplyr, shiny)
 
 This page answers the question people care about most:
 

--- a/docs-vp/index.md
+++ b/docs-vp/index.md
@@ -78,12 +78,12 @@ features:
 
 <div style="max-width:840px;margin:0 auto;padding:18px 24px 0;text-align:center">
 <div style="display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-brand-soft,#ede9fe);border:1px solid rgba(124,106,247,.25);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-1)">
-  <span><strong>Release:</strong> v7.29.0</span>
+  <span><strong>Release:</strong> v7.30.0</span>
   <span>·</span>
-  <span>New <code>sigmap doctor</code> (v8.0 E3): a one-shot setup diagnostic — config, context, index freshness, coverage, and MCP wiring — that prints an actionable fix for anything wrong, so a cold user reaches a useful answer fast (<code>--json</code>; CI-usable exit codes)</span>
+  <span><strong>v8.0 complete — the Pivot:</strong> SigMap is now positioned as the deterministic, verifiable grounding layer for AI code work (token reduction demoted to proof), with copy-paste <strong>agent recipes</strong> framing Claude Code, Cursor, Cline, Continue, Aider, OpenHands, and Codex CLI as consumers — plus documented <code>evidence</code> and <code>doctor</code> commands</span>
 </div>
 <div style="margin-top:.4rem;display:inline-flex;flex-wrap:wrap;gap:.5rem;justify-content:center;background:var(--vp-c-default-soft,#f3f4f6);border:1px solid rgba(0,0,0,.08);border-radius:999px;padding:.55rem .9rem;font-size:.9rem;color:var(--vp-c-text-2)">
-  <span><strong>Benchmark:</strong> sigmap-v7.29-main</span>
+  <span><strong>Benchmark:</strong> sigmap-v7.30-main</span>
   <span>·</span>
   <span>76% hit@5 · 97.0% token reduction · 2026-06-23</span>
 </div>
@@ -176,7 +176,7 @@ See the full [end-to-end walkthrough](/guide/walkthrough) to watch this in actio
 | Overall token reduction | — | **97.0%** |
 | GPT-4o overflow repos | 16/21 | **0/21** |
 
-Latest saved benchmark run: **2026-06-23 (v7.29.0)**.
+Latest saved benchmark run: **2026-06-23 (v7.30.0)**.
 
 </div>
 


### PR DESCRIPTION
Promotes the docs-vp v7.30.0 sync (#393) to main so GitHub Pages redeploys the live site. Docs-only; no version/tag change — npm is unaffected (publish is tag-triggered).