### PR TITLE
docs: fix correctness multiplier badge (×5.2 → ×6.8) on main

### DIFF
--- a/docs/comparison-chart.svg
+++ b/docs/comparison-chart.svg
@@ -60,7 +60,7 @@
 
   <!-- Badge -->
   <rect x="588" y="165" width="94" height="32" fill="#22c55e" rx="6"/>
-  <text x="635" y="178" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">×5.2 better</text>
+  <text x="635" y="178" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">×6.8 better</text>
   <text x="635" y="191" text-anchor="middle" font-size="9" fill="#bbf7d0">correctness</text>
 
   <!-- ═══════════════════════════════════════════ -->

--- a/docs/impact-banner.svg
+++ b/docs/impact-banner.svg
@@ -34,7 +34,7 @@
 
   <!-- STAT CARDS -->
 
-  <!-- Card 1: 5.2x -->
+  <!-- Card 1: 6.8x -->
   <rect x="22" y="56" width="228" height="116" rx="10" fill="#0f0a24" stroke="#3a2b88" stroke-width="1.5"/>
   <rect x="22" y="56" width="228" height="116" rx="10" fill="url(#cardglow)"/>
   <text x="136" y="122" text-anchor="middle" font-size="64" font-weight="900" fill="#7c6af7">6.8x</text>
@@ -48,7 +48,7 @@
   <text x="380" y="142" text-anchor="middle" font-size="13" font-weight="700" fill="#7de8a4">fewer tokens</text>
   <text x="380" y="161" text-anchor="middle" font-size="11" fill="#236b3a">80,000 to 2,000 / session</text>
 
-  <!-- Card 3: 39.4% -->
+  <!-- Card 3: 48.8% -->
   <rect x="510" y="56" width="228" height="116" rx="10" fill="#1a1100" stroke="#5a3b00" stroke-width="1.5"/>
   <rect x="510" y="56" width="228" height="116" rx="10" fill="url(#cardglow)"/>
   <text x="624" y="122" text-anchor="middle" font-size="52" font-weight="900" fill="#f59e0b">48.8%</text>


### PR DESCRIPTION
## Summary
Promote the comparison-chart badge fix (#399) to `main` so the corrected multiplier shows on the public GitHub README.

- `docs/comparison-chart.svg`: ANSWER CORRECTNESS badge `×5.2 better` → **`×6.8 better`** (67.8% task success ÷ 10% baseline).
- `docs/impact-banner.svg`: refreshed two stale code comments.

No version bump — docs-artifact correction only. README benchmark block already in sync.

## Test plan
- [x] version-json + docs-sync guard tests pass
- [x] sync-metrics --check green