### PR TITLE
v8.x: repo-context coverage, measured test discovery, richer risk labels

### DIFF
--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -14,5 +14,11 @@
     "baseline_prompts_per_task": 2.84,
     "prompt_reduction_pct": 48.8,
     "graph_boosted_hit_at_5": 0.867
+  },
+  "test_discovery": {
+    "repos": 28,
+    "pairs": 3701,
+    "f1": 0.98,
+    "hit_at_1": 0.974
   }
 }

--- a/benchmarks/reports/test-discovery.json
+++ b/benchmarks/reports/test-discovery.json
@@ -1,0 +1,267 @@
+{
+  "generated": "2026-07-04T13:39:46.346Z",
+  "source": "benchmarks/repos/* (canonical impl↔test name oracle)",
+  "repos": 28,
+  "impls": 2377,
+  "pairs": 3701,
+  "metrics": {
+    "precision": 0.971,
+    "recall": 0.988,
+    "f1": 0.98,
+    "hitAt1": 0.974
+  },
+  "perRepo": [
+    {
+      "repo": "akka",
+      "impls": 335,
+      "pairs": 429,
+      "precision": 0.996,
+      "recall": 1,
+      "f1": 0.998,
+      "hitAt1": 1
+    },
+    {
+      "repo": "axios",
+      "impls": 27,
+      "pairs": 27,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "click",
+      "impls": 8,
+      "pairs": 8,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "cobra",
+      "impls": 15,
+      "pairs": 15,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "echo",
+      "impls": 42,
+      "pairs": 44,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "fastapi",
+      "impls": 14,
+      "pairs": 103,
+      "precision": 0.857,
+      "recall": 1,
+      "f1": 0.923,
+      "hitAt1": 1
+    },
+    {
+      "repo": "fastify",
+      "impls": 21,
+      "pairs": 26,
+      "precision": 0.976,
+      "recall": 1,
+      "f1": 0.988,
+      "hitAt1": 0.952
+    },
+    {
+      "repo": "flask",
+      "impls": 15,
+      "pairs": 15,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "gin",
+      "impls": 35,
+      "pairs": 37,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "gorm",
+      "impls": 46,
+      "pairs": 59,
+      "precision": 0.986,
+      "recall": 1,
+      "f1": 0.993,
+      "hitAt1": 1
+    },
+    {
+      "repo": "gson",
+      "impls": 39,
+      "pairs": 40,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "guzzle",
+      "impls": 33,
+      "pairs": 34,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "httpx",
+      "impls": 2,
+      "pairs": 2,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "kotlinx-coroutines",
+      "impls": 90,
+      "pairs": 109,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "laravel",
+      "impls": 312,
+      "pairs": 342,
+      "precision": 0.986,
+      "recall": 1,
+      "f1": 0.993,
+      "hitAt1": 0.984
+    },
+    {
+      "repo": "okhttp",
+      "impls": 26,
+      "pairs": 28,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "rails",
+      "impls": 871,
+      "pairs": 1702,
+      "precision": 0.937,
+      "recall": 0.968,
+      "f1": 0.952,
+      "hitAt1": 0.939
+    },
+    {
+      "repo": "redux",
+      "impls": 76,
+      "pairs": 192,
+      "precision": 0.987,
+      "recall": 1,
+      "f1": 0.993,
+      "hitAt1": 0.987
+    },
+    {
+      "repo": "retrofit",
+      "impls": 42,
+      "pairs": 50,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "rich",
+      "impls": 56,
+      "pairs": 56,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "rust-analyzer",
+      "impls": 2,
+      "pairs": 2,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "shiny",
+      "impls": 2,
+      "pairs": 2,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "sidekiq",
+      "impls": 38,
+      "pairs": 38,
+      "precision": 0.974,
+      "recall": 1,
+      "f1": 0.987,
+      "hitAt1": 0.947
+    },
+    {
+      "repo": "spdlog",
+      "impls": 11,
+      "pairs": 11,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "svelte",
+      "impls": 9,
+      "pairs": 9,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "vue-core",
+      "impls": 150,
+      "pairs": 204,
+      "precision": 0.985,
+      "recall": 1,
+      "f1": 0.992,
+      "hitAt1": 1
+    },
+    {
+      "repo": "zod",
+      "impls": 55,
+      "pairs": 109,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    },
+    {
+      "repo": "zustand",
+      "impls": 5,
+      "pairs": 8,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "hitAt1": 1
+    }
+  ]
+}

--- a/gen-context.js
+++ b/gen-context.js
@@ -4609,7 +4609,14 @@ __factories["./src/evidence/pack"] = function(module, exports) {
   const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
   const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
   const CONFIG_RE = /\.(json|ya?ml|toml|ini|conf|config|properties|env)$|(^|\/)(\.?[a-z]+rc)$|\.config\.[a-z]+$/i;
-  const SECURITY_RE = /(^|\/|[._-])(auth|authn|authz|login|password|passwd|secret|credential|token|session|crypto|cipher|payment|billing|checkout|oauth|jwt|permission|acl|rbac)([._-]|\/|$)/i;
+  // DB migrations: framework dirs (Rails/Alembic/Prisma), Flyway `V1__x.sql`,
+  // timestamped migration files, and `*_migration.*` naming.
+  const MIGRATION_RE = /(^|\/)(migrations?|alembic\/versions|prisma\/migrations)(\/|$)|(^|\/)db\/migrate\/|(^|\/)V\d+(_\d+)*__[^/]+\.(sql|java)$|(^|\/)\d{8,}[_-][^/]+\.(sql|rb|py|js|ts)$|[._-]migration[s]?[._-]/i;
+  const PAYMENT_RE = /(^|\/|[._-])(payment|payments|billing|checkout|invoice|invoicing|subscription|stripe|paypal|braintree|charge|refund|payout)([._-]|\/|$)/i;
+  const AUTH_RE = /(^|\/|[._-])(auth|authn|authz|login|logout|signin|signup|password|passwd|session|oauth|jwt|permission|permissions|acl|rbac|credential|credentials)([._-]|\/|$)/i;
+  const SECURITY_RE = /(^|\/|[._-])(secret|secrets|crypto|cipher|encrypt|decrypt|token|signing|keystore|vault)([._-]|\/|$)/i;
+  // Public API surface: `api/` dirs, `public-api`, and module barrel entrypoints.
+  const PUBLIC_API_RE = /(^|\/)api(\/|$)|(^|\/)public[-_]?api(\/|$)|(^|\/)index\.(js|ts|mjs|cjs)$/i;
 
   /**
    * Split a signature's `  :start-end` line anchor from its symbol text.
@@ -4627,17 +4634,25 @@ __factories["./src/evidence/pack"] = function(module, exports) {
   }
 
   /**
-   * Classify a file into a coarse risk label. Path-based heuristic (v1) — the
-   * richer label set (C3) lands in v8.5.
+   * Classify a file into a risk label (C3, v8.5). Path-based, deterministic.
+   * Precedence is strict, most-specific-risk first: a migration touching payments
+   * is labeled `migration` (a schema change is the dominant risk), payment/auth
+   * outrank the generic `security` bucket, and `config`/`public-api` resolve
+   * before the `source` fallback. `test`/`generated` semantics are preserved so
+   * existing consumers (findRelatedTests, verifier) keep working.
    * @param {string} relPath
-   * @returns {'generated'|'test'|'config'|'security'|'source'}
+   * @returns {'generated'|'test'|'migration'|'payment'|'auth'|'security'|'config'|'public-api'|'source'}
    */
   function riskLabelFor(relPath) {
     const p = relPath.replace(/\\/g, '/');
     if (GENERATED_RE.test(p)) return 'generated';
     if (TEST_RE.test(p)) return 'test';
+    if (MIGRATION_RE.test(p)) return 'migration';
+    if (PAYMENT_RE.test(p)) return 'payment';
+    if (AUTH_RE.test(p)) return 'auth';
     if (SECURITY_RE.test(p)) return 'security';
     if (CONFIG_RE.test(p)) return 'config';
+    if (PUBLIC_API_RE.test(p)) return 'public-api';
     return 'source';
   }
 
@@ -4648,9 +4663,28 @@ __factories["./src/evidence/pack"] = function(module, exports) {
   }
 
   /**
-   * Best-effort impl→test discovery (v1). Matches test files whose stem equals
-   * the implementation file's stem, by common convention. Deterministic. The
-   * accuracy-measured discovery (C2) lands in v8.5.
+   * Infer the implementation stem a test file targets, by stripping the
+   * conventional test affixes across languages (measured in the C2 benchmark):
+   *   foo.test.js / foo.spec.ts    → foo   (JS/TS)
+   *   test_foo.py                  → foo   (Python / pytest)
+   *   foo_test.go / foo_test.py    → foo   (Go, unittest)
+   *   FooTest.java / BarSpec.scala → Foo   (JVM, PascalCase)
+   * @param {string} relPath
+   * @returns {string}
+   */
+  function testTargetStem(relPath) {
+    let s = stemOf(relPath);               // strips ext + trailing .test/.spec
+    s = s.replace(/^test[_-]/i, '');       // Python: test_foo
+    s = s.replace(/[_-]test$/i, '');       // Go / unittest: foo_test
+    s = s.replace(/(Tests?|Specs?)$/, ''); // JVM PascalCase: FooTest, BarSpec
+    return s;
+  }
+
+  /**
+   * Impl→test discovery (C2, v8.5). Matches test files back to their
+   * implementation by normalizing conventional test affixes, so JS/TS, Python,
+   * Go, and JVM naming conventions all resolve. Deterministic; accuracy is
+   * measured by `scripts/run-test-discovery-benchmark.mjs`.
    * @param {string} relPath
    * @param {string[]} allFiles  - universe of indexed files (relative paths)
    * @returns {string[]}
@@ -4663,7 +4697,7 @@ __factories["./src/evidence/pack"] = function(module, exports) {
     for (const f of allFiles) {
       if (f === relPath) continue;
       if (riskLabelFor(f) !== 'test') continue;
-      if (stemOf(f).toLowerCase() === stem) out.push(f);
+      if (testTargetStem(f).toLowerCase() === stem) out.push(f);
     }
     return out.sort();
   }
@@ -11179,6 +11213,101 @@ __factories["./src/learning/weights"] = function(module, exports) {
   
 };
 
+// ── ./src/map/build-ci ──
+__factories["./src/map/build-ci"] = function(module, exports) {
+  
+  /**
+   * Build & CI extractor (v8.5 C1).
+   *
+   * Surfaces how the project is built and validated: npm/pnpm/yarn scripts
+   * (package.json), GitHub Actions workflows (.github/workflows/*.yml), and
+   * Makefile targets. Pure, zero-dependency, deterministic.
+   *
+   * @param {string[]} files — absolute file paths (unused; roots are read directly)
+   * @param {string}   cwd   — project root
+   * @returns {string} formatted markdown table (empty string if none found)
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const MAX_ROWS = 120;
+
+  function readJson(p) {
+    try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; }
+  }
+
+  function npmScripts(cwd, rows) {
+    const pkg = readJson(path.join(cwd, 'package.json'));
+    if (!pkg || !pkg.scripts || typeof pkg.scripts !== 'object') return;
+    for (const name of Object.keys(pkg.scripts).sort()) {
+      rows.push({ kind: 'script', name, detail: 'npm run ' + name });
+    }
+  }
+
+  function ciWorkflows(cwd, rows) {
+    const dir = path.join(cwd, '.github', 'workflows');
+    let entries;
+    try { entries = fs.readdirSync(dir); } catch (_) { return; }
+    for (const file of entries.sort()) {
+      if (!/\.ya?ml$/i.test(file)) continue;
+      let content;
+      try { content = fs.readFileSync(path.join(dir, file), 'utf8'); } catch (_) { continue; }
+      const nameMatch = content.match(/^name:\s*(.+)$/m);
+      const name = nameMatch ? nameMatch[1].trim().replace(/^['"]|['"]$/g, '') : file;
+      // Trigger events from an `on:` mapping or inline form.
+      const onMatch = content.match(/^on:\s*(.*)$/m);
+      let triggers = '';
+      if (onMatch) {
+        if (onMatch[1].trim()) {
+          triggers = onMatch[1].replace(/[[\]{}'"]/g, '').trim();
+        } else {
+          const block = content.slice(onMatch.index);
+          const events = [...block.matchAll(/^\s{2,}([a-z_]+):/gm)].map((m) => m[1]);
+          triggers = [...new Set(events)].slice(0, 6).join(', ');
+        }
+      }
+      rows.push({ kind: 'ci', name, detail: `${file}${triggers ? ' — ' + triggers : ''}` });
+    }
+  }
+
+  function makeTargets(cwd, rows) {
+    let content;
+    try { content = fs.readFileSync(path.join(cwd, 'Makefile'), 'utf8'); } catch (_) { return; }
+    const targets = [];
+    for (const line of content.split('\n')) {
+      const m = line.match(/^([a-zA-Z0-9_][a-zA-Z0-9_.-]*)\s*:(?!=)/);
+      if (m && m[1] !== '.PHONY') targets.push(m[1]);
+    }
+    for (const t of [...new Set(targets)].sort()) {
+      rows.push({ kind: 'make', name: t, detail: 'make ' + t });
+    }
+  }
+
+  function analyze(files, cwd) {
+    const rows = [];
+    npmScripts(cwd, rows);
+    ciWorkflows(cwd, rows);
+    makeTargets(cwd, rows);
+    if (rows.length === 0) return '';
+
+    const lines = [
+      '| Kind | Name | Detail |',
+      '|------|------|--------|',
+    ];
+    for (const r of rows.slice(0, MAX_ROWS)) {
+      lines.push(`| ${r.kind} | ${r.name} | ${r.detail} |`);
+    }
+    if (rows.length > MAX_ROWS) {
+      lines.push(`| … | | +${rows.length - MAX_ROWS} more |`);
+    }
+    return lines.join('\n');
+  }
+
+  module.exports = { analyze };
+  
+};
+
 // ── ./src/map/class-hierarchy ──
 __factories["./src/map/class-hierarchy"] = function(module, exports) {
   
@@ -11294,6 +11423,205 @@ __factories["./src/map/class-hierarchy"] = function(module, exports) {
         return line;
       })
       .join('\n');
+  }
+
+  module.exports = { analyze };
+  
+};
+
+// ── ./src/map/config-manifest ──
+__factories["./src/map/config-manifest"] = function(module, exports) {
+  
+  /**
+   * Config & package-manifest extractor (v8.5 C1).
+   *
+   * Surfaces the project's package manifests (name / version / dependency counts)
+   * across ecosystems and the notable root config files present. Pure,
+   * zero-dependency, deterministic.
+   *
+   * @param {string[]} files — absolute file paths (unused; roots are read directly)
+   * @param {string}   cwd   — project root
+   * @returns {string} formatted markdown table (empty string if none found)
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const CONFIG_FILES = [
+    'tsconfig.json', 'jsconfig.json', '.eslintrc', '.eslintrc.json', '.eslintrc.js',
+    '.prettierrc', 'babel.config.js', 'jest.config.js', 'vitest.config.ts',
+    'webpack.config.js', 'vite.config.ts', 'rollup.config.js', 'tailwind.config.js',
+    'docker-compose.yml', 'docker-compose.yaml', 'Dockerfile', '.editorconfig',
+  ];
+
+  function readText(p) { try { return fs.readFileSync(p, 'utf8'); } catch (_) { return null; } }
+  function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
+  function count(obj) { return obj && typeof obj === 'object' ? Object.keys(obj).length : 0; }
+
+  function manifests(cwd, rows) {
+    const pkg = readJson(path.join(cwd, 'package.json'));
+    if (pkg) {
+      const deps = count(pkg.dependencies);
+      const dev = count(pkg.devDependencies);
+      const id = [pkg.name, pkg.version].filter(Boolean).join('@') || 'package.json';
+      rows.push({ manifest: 'package.json (npm)', detail: `${id} · ${deps} deps, ${dev} devDeps` });
+    }
+
+    const pyproject = readText(path.join(cwd, 'pyproject.toml'));
+    if (pyproject) {
+      const name = (pyproject.match(/^\s*name\s*=\s*["']([^"']+)["']/m) || [])[1];
+      const ver = (pyproject.match(/^\s*version\s*=\s*["']([^"']+)["']/m) || [])[1];
+      rows.push({ manifest: 'pyproject.toml (python)', detail: [name, ver].filter(Boolean).join('@') || 'present' });
+    } else if (readText(path.join(cwd, 'setup.py'))) {
+      rows.push({ manifest: 'setup.py (python)', detail: 'present' });
+    }
+    if (readText(path.join(cwd, 'requirements.txt'))) {
+      rows.push({ manifest: 'requirements.txt (python)', detail: 'present' });
+    }
+
+    const cargo = readText(path.join(cwd, 'Cargo.toml'));
+    if (cargo) {
+      const name = (cargo.match(/^\s*name\s*=\s*["']([^"']+)["']/m) || [])[1];
+      const ver = (cargo.match(/^\s*version\s*=\s*["']([^"']+)["']/m) || [])[1];
+      rows.push({ manifest: 'Cargo.toml (rust)', detail: [name, ver].filter(Boolean).join('@') || 'present' });
+    }
+
+    const gomod = readText(path.join(cwd, 'go.mod'));
+    if (gomod) {
+      const mod = (gomod.match(/^module\s+(\S+)/m) || [])[1];
+      const go = (gomod.match(/^go\s+(\S+)/m) || [])[1];
+      rows.push({ manifest: 'go.mod (go)', detail: [mod, go && 'go ' + go].filter(Boolean).join(' · ') || 'present' });
+    }
+
+    if (readText(path.join(cwd, 'pom.xml'))) rows.push({ manifest: 'pom.xml (maven)', detail: 'present' });
+    if (readText(path.join(cwd, 'build.gradle')) || readText(path.join(cwd, 'build.gradle.kts'))) {
+      rows.push({ manifest: 'build.gradle (gradle)', detail: 'present' });
+    }
+    if (readText(path.join(cwd, 'Gemfile'))) rows.push({ manifest: 'Gemfile (ruby)', detail: 'present' });
+    const composer = readJson(path.join(cwd, 'composer.json'));
+    if (composer) {
+      rows.push({ manifest: 'composer.json (php)', detail: `${composer.name || 'present'} · ${count(composer.require)} deps` });
+    }
+  }
+
+  function configFiles(cwd) {
+    const present = [];
+    for (const f of CONFIG_FILES) {
+      if (fs.existsSync(path.join(cwd, f))) present.push(f);
+    }
+    return present;
+  }
+
+  function analyze(files, cwd) {
+    const rows = [];
+    manifests(cwd, rows);
+    const configs = configFiles(cwd);
+    if (rows.length === 0 && configs.length === 0) return '';
+
+    const lines = [];
+    if (rows.length) {
+      lines.push('| Manifest | Detail |', '|----------|--------|');
+      for (const r of rows) lines.push(`| ${r.manifest} | ${r.detail} |`);
+    }
+    if (configs.length) {
+      if (lines.length) lines.push('');
+      lines.push(`**Config files:** ${configs.map((c) => '`' + c + '`').join(', ')}`);
+    }
+    return lines.join('\n');
+  }
+
+  module.exports = { analyze };
+  
+};
+
+// ── ./src/map/env-schema ──
+__factories["./src/map/env-schema"] = function(module, exports) {
+  
+  /**
+   * Environment-variable schema extractor (v8.5 C1).
+   *
+   * Surfaces the environment the project actually reads — from source across
+   * JS/TS, Python, Ruby, and Go, plus keys declared in a committed `.env.example`
+   * / `.env.sample` / `.env.template`. Pure, zero-dependency, deterministic.
+   *
+   * @param {string[]} files — absolute file paths to analyze (srcDirs-scoped)
+   * @param {string}   cwd   — project root
+   * @returns {string} formatted markdown table (empty string if none found)
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const SCAN_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.py', '.rb', '.go']);
+  const EXAMPLE_FILES = ['.env.example', '.env.sample', '.env.template', '.env.dist'];
+
+  // process.env.X / process.env['X'] / import.meta.env.X / Deno.env.get('X')
+  const JS_RE = /(?:process\.env|import\.meta\.env)(?:\.([A-Z_][A-Z0-9_]*)|\[\s*['"]([A-Z_][A-Z0-9_]*)['"]\s*\])|Deno\.env\.get\(\s*['"]([A-Z_][A-Z0-9_]*)['"]/g;
+  // os.environ['X'] / os.environ.get('X') / os.getenv('X') / getenv('X')
+  const PY_RE = /(?:os\.)?(?:environ(?:\.get)?\[?\s*['"]([A-Z_][A-Z0-9_]*)['"]|getenv\(\s*['"]([A-Z_][A-Z0-9_]*)['"])/g;
+  const RB_RE = /ENV\[\s*['"]([A-Z_][A-Z0-9_]*)['"]\s*\]/g;
+  const GO_RE = /os\.(?:Getenv|LookupEnv)\(\s*["`']([A-Z_][A-Z0-9_]*)["`']/g;
+
+  const MAX_ROWS = 200;
+
+  function collectMatches(re, content, into) {
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(content)) !== null) {
+      const name = m[1] || m[2] || m[3];
+      if (name) into.add(name);
+    }
+  }
+
+  function readExampleKeys(cwd) {
+    const keys = new Set();
+    for (const name of EXAMPLE_FILES) {
+      let content;
+      try { content = fs.readFileSync(path.join(cwd, name), 'utf8'); } catch (_) { continue; }
+      for (const line of content.split('\n')) {
+        const t = line.trim();
+        if (!t || t.startsWith('#')) continue;
+        const eq = t.match(/^(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=/);
+        if (eq) keys.add(eq[1]);
+      }
+    }
+    return keys;
+  }
+
+  function analyze(files, cwd) {
+    const fromCode = new Set();
+
+    for (const filePath of files) {
+      const ext = path.extname(filePath).toLowerCase();
+      if (!SCAN_EXTS.has(ext)) continue;
+      let content;
+      try { content = fs.readFileSync(filePath, 'utf8'); } catch (_) { continue; }
+
+      if (ext === '.py') collectMatches(PY_RE, content, fromCode);
+      else if (ext === '.rb') collectMatches(RB_RE, content, fromCode);
+      else if (ext === '.go') collectMatches(GO_RE, content, fromCode);
+      else collectMatches(JS_RE, content, fromCode);
+    }
+
+    const fromExample = readExampleKeys(cwd);
+    const all = new Set([...fromCode, ...fromExample]);
+    if (all.size === 0) return '';
+
+    const names = [...all].sort();
+    const lines = [
+      '| Variable | Source |',
+      '|----------|--------|',
+    ];
+    for (const name of names.slice(0, MAX_ROWS)) {
+      const src = [];
+      if (fromCode.has(name)) src.push('code');
+      if (fromExample.has(name)) src.push('.env.example');
+      lines.push(`| ${name} | ${src.join(', ')} |`);
+    }
+    if (names.length > MAX_ROWS) {
+      lines.push(`| … | +${names.length - MAX_ROWS} more |`);
+    }
+    return lines.join('\n');
   }
 
   module.exports = { analyze };
@@ -11489,6 +11817,94 @@ __factories["./src/map/import-graph"] = function(module, exports) {
   
 };
 
+// ── ./src/map/migrations ──
+__factories["./src/map/migrations"] = function(module, exports) {
+  
+  /**
+   * Database-migration extractor (v8.5 C1).
+   *
+   * Detects schema-migration files across the common frameworks — Rails
+   * (db/migrate), Django/Alembic, Prisma, Flyway (`V1__name.sql`), knex/Sequelize,
+   * and timestamped SQL — and surfaces them with a parsed version + name. Pure,
+   * zero-dependency, deterministic.
+   *
+   * @param {string[]} files — absolute file paths (unused; the tree is walked)
+   * @param {string}   cwd   — project root
+   * @returns {string} formatted markdown table (empty string if none found)
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const MAX_DEPTH = 6;
+  const MAX_ROWS = 200;
+  const SKIP_DIR = new Set(['.git', 'node_modules', 'vendor', 'dist', 'build', 'target', '.venv', 'venv', '__pycache__']);
+  const MIG_EXT = new Set(['.sql', '.rb', '.py', '.js', '.ts']);
+
+  // A directory whose path marks its children as migrations.
+  const MIG_DIR_RE = /(^|\/)(db\/migrate|migrations?|alembic\/versions|prisma\/migrations)$/i;
+  // A filename that is itself a migration regardless of directory.
+  const FLYWAY_RE = /^V\d+(?:[._]\d+)*__(.+)\.(sql|java)$/;
+  const TIMESTAMP_RE = /^(\d{8,})[_-](.+)\.(sql|rb|py|js|ts)$/;
+  const NAMED_RE = /[._-]migrations?[._-]/i;
+
+  function walk(dir, cwd, depth, out) {
+    if (depth > MAX_DEPTH) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    const relDir = path.relative(cwd, dir).replace(/\\/g, '/');
+    const dirIsMigration = MIG_DIR_RE.test(relDir);
+
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (SKIP_DIR.has(e.name)) continue;
+        walk(path.join(dir, e.name), cwd, depth + 1, out);
+        continue;
+      }
+      const ext = path.extname(e.name).toLowerCase();
+      if (!MIG_EXT.has(ext)) continue;
+
+      const rel = path.relative(cwd, path.join(dir, e.name)).replace(/\\/g, '/');
+      let version = null;
+      let name = null;
+
+      let m;
+      if ((m = e.name.match(FLYWAY_RE))) { version = e.name.split('__')[0]; name = m[1].replace(/_/g, ' '); }
+      else if ((m = e.name.match(TIMESTAMP_RE))) { version = m[1]; name = m[2].replace(/[_-]/g, ' '); }
+      else if (dirIsMigration) { version = '—'; name = e.name.replace(ext, ''); }
+      else if (NAMED_RE.test(e.name)) { version = '—'; name = e.name.replace(ext, ''); }
+      else continue;
+
+      out.push({ version, name, file: rel });
+    }
+  }
+
+  function analyze(files, cwd) {
+    const found = [];
+    walk(cwd, cwd, 0, found);
+    if (found.length === 0) return '';
+
+    found.sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+
+    const lines = [
+      '| Version | Migration | File |',
+      '|---------|-----------|------|',
+    ];
+    for (const r of found.slice(0, MAX_ROWS)) {
+      lines.push(`| ${r.version} | ${r.name} | ${r.file} |`);
+    }
+    if (found.length > MAX_ROWS) {
+      lines.push(`| … | +${found.length - MAX_ROWS} more | |`);
+    }
+    return lines.join('\n');
+  }
+
+  module.exports = { analyze };
+  
+};
+
 // ── ./src/map/route-table ──
 __factories["./src/map/route-table"] = function(module, exports) {
   
@@ -11644,6 +12060,10 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     imports: '### Import graph',
     classes: '### Class hierarchy',
     routes: '### Route table',
+    env: '### Environment variables',
+    buildci: '### Build & CI',
+    manifests: '### Config & manifests',
+    migrations: '### Database migrations',
   };
 
   /**
@@ -11729,7 +12149,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
 
     const header = MAP_SECTIONS[args.type];
     if (!header) {
-      return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
+      return `Unknown map type: "${args.type}". Use: ${Object.keys(MAP_SECTIONS).join(', ')}`;
     }
 
     const mapPath = path.join(cwd, 'PROJECT_MAP.md');

--- a/gen-project-map.js
+++ b/gen-project-map.js
@@ -127,9 +127,13 @@ function formatOutput(sections) {
   ];
 
   const parts = [
-    { key: 'imports',   header: '### Import graph',      content: sections.imports },
-    { key: 'classes',   header: '### Class hierarchy',   content: sections.classes },
-    { key: 'routes',    header: '### Route table',       content: sections.routes  },
+    { key: 'imports',    header: '### Import graph',         content: sections.imports },
+    { key: 'classes',    header: '### Class hierarchy',      content: sections.classes },
+    { key: 'routes',     header: '### Route table',          content: sections.routes  },
+    { key: 'env',        header: '### Environment variables', content: sections.env },
+    { key: 'buildci',    header: '### Build & CI',           content: sections.buildci },
+    { key: 'manifests',  header: '### Config & manifests',   content: sections.manifests },
+    { key: 'migrations', header: '### Database migrations',  content: sections.migrations },
   ];
 
   for (const { header, content } of parts) {
@@ -165,9 +169,13 @@ function main() {
   }
 
   const sections = {
-    imports: runAnalyzer('import-graph',     files, cwd),
-    classes: runAnalyzer('class-hierarchy',  files, cwd),
-    routes:  runAnalyzer('route-table',      files, cwd),
+    imports:    runAnalyzer('import-graph',    files, cwd),
+    classes:    runAnalyzer('class-hierarchy', files, cwd),
+    routes:     runAnalyzer('route-table',     files, cwd),
+    env:        runAnalyzer('env-schema',      files, cwd),
+    buildci:    runAnalyzer('build-ci',        files, cwd),
+    manifests:  runAnalyzer('config-manifest', files, cwd),
+    migrations: runAnalyzer('migrations',      files, cwd),
   };
 
   const output = formatOutput(sections);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "benchmark:matrix": "node scripts/run-benchmark-matrix.mjs --save --skip-clone",
     "benchmark:verify": "node scripts/run-verify-benchmark.mjs",
     "benchmark:squeeze": "node scripts/run-squeeze-benchmark.mjs --save",
+    "benchmark:test-discovery": "node scripts/run-test-discovery-benchmark.mjs --save",
     "validate:squeeze": "node scripts/run-squeeze-benchmark.mjs --gate",
     "health": "node gen-context.js --health",
     "map": "node gen-project-map.js",

--- a/scripts/gen-benchmark-latest.mjs
+++ b/scripts/gen-benchmark-latest.mjs
@@ -27,6 +27,11 @@ function readReport(root, name) {
   return JSON.parse(readFileSync(join(root, 'benchmarks', 'reports', name), 'utf8'));
 }
 
+/** Read a report that may not exist yet (returns null instead of throwing). */
+function readReportOptional(root, name) {
+  try { return readReport(root, name); } catch { return null; }
+}
+
 /** Round to `d` decimal places (deterministic). */
 function round(n, d = 1) {
   const f = 10 ** d;
@@ -50,7 +55,7 @@ export function computeLatest(root = ROOT) {
   const generated = matrixReport.generated || tokenReport.timestamp || '';
   const benchmark_date = String(generated).slice(0, 10);
 
-  return {
+  const out = {
     benchmark_id: `sigmap-v${maj}.${min}-main`,
     benchmark_date,
     source: 'benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction}.json',
@@ -68,6 +73,21 @@ export function computeLatest(root = ROOT) {
       graph_boosted_hit_at_5: round(matrix.avgHitAt5Pct / 100, 3),
     },
   };
+
+  // Test-discovery (v8.5 C2) — optional, present once the benchmark has run.
+  // Kept top-level (not under `metrics`) so version.json's metrics mirror is
+  // unaffected and the hermetic gen-benchmark-latest fixture still resolves.
+  const td = readReportOptional(root, 'test-discovery.json');
+  if (td && td.metrics) {
+    out.test_discovery = {
+      repos: td.repos,
+      pairs: td.pairs,
+      f1: round(td.metrics.f1, 3),
+      hit_at_1: round(td.metrics.hitAt1, 3),
+    };
+  }
+
+  return out;
 }
 
 const LATEST = join(ROOT, 'benchmarks', 'latest.json');

--- a/scripts/run-test-discovery-benchmark.mjs
+++ b/scripts/run-test-discovery-benchmark.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Test-discovery benchmark (v8.5 C2) — measures `findRelatedTests`.
+ *
+ * The CHANGELOG deferred a *measured* impl→test discovery number to v8.5. This
+ * harness produces it, reproducibly and with zero LLM calls:
+ *
+ *   1. Walk every repo under benchmarks/repos/.
+ *   2. Build an INDEPENDENT gold standard: a test file is a gold match for an
+ *      implementation file iff its basename equals an EXACT canonical form of
+ *      the impl stem — `X.test.js`, `X.spec.ts`, `test_X.py`, `X_test.go`,
+ *      `XTest.java`, `XSpec.scala`. This oracle is deliberately stricter and
+ *      case-sensitive, so it does NOT reuse findRelatedTests' fuzzy affix
+ *      normalization — the measurement is honest, not circular.
+ *   3. Run `findRelatedTests` (repo-wide, lowercased, cross-language) against
+ *      each impl and score precision / recall / F1 / hit@1 vs the gold set.
+ *
+ * All metrics are string-matching math over a fixed file tree → deterministic.
+ *
+ * Usage:
+ *   node scripts/run-test-discovery-benchmark.mjs           # print summary
+ *   node scripts/run-test-discovery-benchmark.mjs --save     # write report JSON
+ *   node scripts/run-test-discovery-benchmark.mjs --json     # machine-readable
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const REPOS_DIR = path.join(ROOT, 'benchmarks', 'repos');
+const REPORTS_DIR = path.join(ROOT, 'benchmarks', 'reports');
+
+const SAVE = process.argv.includes('--save');
+const JSON_OUT = process.argv.includes('--json');
+
+const { findRelatedTests, riskLabelFor } = require('../src/evidence/pack.js');
+
+const CODE_EXT = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.py', '.go', '.rb', '.rs',
+  '.java', '.kt', '.scala', '.swift', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp',
+]);
+const SKIP_DIR = new Set(['.git', 'node_modules', 'vendor', 'dist', 'build', 'target', '.venv', 'venv', '__pycache__']);
+
+/** Recursively collect code files under `dir`, returned as repo-relative POSIX paths. */
+function walk(dir, repoRoot, out) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIR.has(e.name)) continue;
+      walk(full, repoRoot, out);
+    } else if (CODE_EXT.has(path.extname(e.name).toLowerCase())) {
+      out.push(path.relative(repoRoot, full).replace(/\\/g, '/'));
+    }
+  }
+  return out;
+}
+
+/** Plain stem: basename minus its final extension. */
+function baseStem(rel) {
+  return path.basename(rel).replace(/\.[^.]+$/, '');
+}
+
+/**
+ * Independent gold oracle: does `testRel`'s basename exactly match a canonical
+ * test filename for implementation stem `stem`? Case-sensitive, exact — no
+ * lowercasing, no whole-repo stem collisions.
+ */
+function isCanonicalTestFor(testRel, stem) {
+  const b = path.basename(testRel);
+  const ext = path.extname(b);
+  const tstem = b.slice(0, b.length - ext.length);
+  return (
+    tstem === `${stem}.test` ||
+    tstem === `${stem}.spec` ||
+    tstem === `test_${stem}` ||
+    tstem === `${stem}_test` ||
+    tstem === `${stem}Test` ||
+    tstem === `${stem}Spec`
+  );
+}
+
+function scoreRepo(repo) {
+  const repoRoot = path.join(REPOS_DIR, repo);
+  const files = walk(repoRoot, repoRoot, []);
+  if (!files.length) return null;
+
+  const testFiles = files.filter((f) => riskLabelFor(f) === 'test');
+  const implFiles = files.filter((f) => riskLabelFor(f) !== 'test');
+  if (!testFiles.length || !implFiles.length) return null;
+
+  let pairs = 0;
+  let sumPrecision = 0;
+  let sumRecall = 0;
+  let scored = 0;
+  let hits = 0;
+
+  for (const impl of implFiles) {
+    const stem = baseStem(impl);
+    if (!stem) continue;
+    const gold = testFiles.filter((t) => isCanonicalTestFor(t, stem));
+    if (!gold.length) continue;
+
+    const goldSet = new Set(gold);
+    const predicted = findRelatedTests(impl, files);
+    const tp = predicted.filter((p) => goldSet.has(p)).length;
+
+    const precision = predicted.length ? tp / predicted.length : 0;
+    const recall = tp / gold.length;
+    sumPrecision += precision;
+    sumRecall += recall;
+    hits += predicted.length && goldSet.has(predicted[0]) ? 1 : 0;
+    pairs += gold.length;
+    scored++;
+  }
+
+  if (!scored) return null;
+  const precision = sumPrecision / scored;
+  const recall = sumRecall / scored;
+  const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0;
+  return { repo, impls: scored, pairs, precision, recall, f1, hitAt1: hits / scored };
+}
+
+function round(n, d = 3) {
+  const f = 10 ** d;
+  return Math.round(Number(n) * f) / f;
+}
+
+function main() {
+  let repos;
+  try {
+    repos = fs.readdirSync(REPOS_DIR, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    console.error(`No benchmark repos at ${REPOS_DIR}. Nothing to measure.`);
+    return 1;
+  }
+
+  const perRepo = [];
+  for (const repo of repos) {
+    const r = scoreRepo(repo);
+    if (r) perRepo.push(r);
+  }
+
+  if (!perRepo.length) {
+    console.error('No repos yielded canonical impl↔test pairs.');
+    return 1;
+  }
+
+  const impls = perRepo.reduce((n, r) => n + r.impls, 0);
+  const pairs = perRepo.reduce((n, r) => n + r.pairs, 0);
+  // Micro-average across all scored implementation files.
+  const precision = perRepo.reduce((s, r) => s + r.precision * r.impls, 0) / impls;
+  const recall = perRepo.reduce((s, r) => s + r.recall * r.impls, 0) / impls;
+  const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0;
+  const hitAt1 = perRepo.reduce((s, r) => s + r.hitAt1 * r.impls, 0) / impls;
+
+  const report = {
+    generated: new Date().toISOString(),
+    source: 'benchmarks/repos/* (canonical impl↔test name oracle)',
+    repos: perRepo.length,
+    impls,
+    pairs,
+    metrics: {
+      precision: round(precision),
+      recall: round(recall),
+      f1: round(f1),
+      hitAt1: round(hitAt1),
+    },
+    perRepo: perRepo.map((r) => ({
+      repo: r.repo,
+      impls: r.impls,
+      pairs: r.pairs,
+      precision: round(r.precision),
+      recall: round(r.recall),
+      f1: round(r.f1),
+      hitAt1: round(r.hitAt1),
+    })),
+  };
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log('Test-discovery benchmark (findRelatedTests vs canonical gold)');
+    console.log(`  repos: ${report.repos}   impls scored: ${impls}   gold pairs: ${pairs}`);
+    console.log(`  precision: ${(precision * 100).toFixed(1)}%   recall: ${(recall * 100).toFixed(1)}%`);
+    console.log(`  F1: ${(f1 * 100).toFixed(1)}%   hit@1: ${(hitAt1 * 100).toFixed(1)}%`);
+  }
+
+  if (SAVE) {
+    fs.mkdirSync(REPORTS_DIR, { recursive: true });
+    fs.writeFileSync(path.join(REPORTS_DIR, 'test-discovery.json'), JSON.stringify(report, null, 2) + '\n');
+    console.error(`✓ wrote benchmarks/reports/test-discovery.json`);
+  }
+
+  return 0;
+}
+
+process.exit(main());

--- a/src/evidence/pack.js
+++ b/src/evidence/pack.js
@@ -33,7 +33,14 @@ const DEFAULT_TOP = 12;
 const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
 const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
 const CONFIG_RE = /\.(json|ya?ml|toml|ini|conf|config|properties|env)$|(^|\/)(\.?[a-z]+rc)$|\.config\.[a-z]+$/i;
-const SECURITY_RE = /(^|\/|[._-])(auth|authn|authz|login|password|passwd|secret|credential|token|session|crypto|cipher|payment|billing|checkout|oauth|jwt|permission|acl|rbac)([._-]|\/|$)/i;
+// DB migrations: framework dirs (Rails/Alembic/Prisma), Flyway `V1__x.sql`,
+// timestamped migration files, and `*_migration.*` naming.
+const MIGRATION_RE = /(^|\/)(migrations?|alembic\/versions|prisma\/migrations)(\/|$)|(^|\/)db\/migrate\/|(^|\/)V\d+(_\d+)*__[^/]+\.(sql|java)$|(^|\/)\d{8,}[_-][^/]+\.(sql|rb|py|js|ts)$|[._-]migration[s]?[._-]/i;
+const PAYMENT_RE = /(^|\/|[._-])(payment|payments|billing|checkout|invoice|invoicing|subscription|stripe|paypal|braintree|charge|refund|payout)([._-]|\/|$)/i;
+const AUTH_RE = /(^|\/|[._-])(auth|authn|authz|login|logout|signin|signup|password|passwd|session|oauth|jwt|permission|permissions|acl|rbac|credential|credentials)([._-]|\/|$)/i;
+const SECURITY_RE = /(^|\/|[._-])(secret|secrets|crypto|cipher|encrypt|decrypt|token|signing|keystore|vault)([._-]|\/|$)/i;
+// Public API surface: `api/` dirs, `public-api`, and module barrel entrypoints.
+const PUBLIC_API_RE = /(^|\/)api(\/|$)|(^|\/)public[-_]?api(\/|$)|(^|\/)index\.(js|ts|mjs|cjs)$/i;
 
 /**
  * Split a signature's `  :start-end` line anchor from its symbol text.
@@ -51,17 +58,25 @@ function parseAnchor(sig) {
 }
 
 /**
- * Classify a file into a coarse risk label. Path-based heuristic (v1) — the
- * richer label set (C3) lands in v8.5.
+ * Classify a file into a risk label (C3, v8.5). Path-based, deterministic.
+ * Precedence is strict, most-specific-risk first: a migration touching payments
+ * is labeled `migration` (a schema change is the dominant risk), payment/auth
+ * outrank the generic `security` bucket, and `config`/`public-api` resolve
+ * before the `source` fallback. `test`/`generated` semantics are preserved so
+ * existing consumers (findRelatedTests, verifier) keep working.
  * @param {string} relPath
- * @returns {'generated'|'test'|'config'|'security'|'source'}
+ * @returns {'generated'|'test'|'migration'|'payment'|'auth'|'security'|'config'|'public-api'|'source'}
  */
 function riskLabelFor(relPath) {
   const p = relPath.replace(/\\/g, '/');
   if (GENERATED_RE.test(p)) return 'generated';
   if (TEST_RE.test(p)) return 'test';
+  if (MIGRATION_RE.test(p)) return 'migration';
+  if (PAYMENT_RE.test(p)) return 'payment';
+  if (AUTH_RE.test(p)) return 'auth';
   if (SECURITY_RE.test(p)) return 'security';
   if (CONFIG_RE.test(p)) return 'config';
+  if (PUBLIC_API_RE.test(p)) return 'public-api';
   return 'source';
 }
 
@@ -72,9 +87,28 @@ function stemOf(relPath) {
 }
 
 /**
- * Best-effort impl→test discovery (v1). Matches test files whose stem equals
- * the implementation file's stem, by common convention. Deterministic. The
- * accuracy-measured discovery (C2) lands in v8.5.
+ * Infer the implementation stem a test file targets, by stripping the
+ * conventional test affixes across languages (measured in the C2 benchmark):
+ *   foo.test.js / foo.spec.ts    → foo   (JS/TS)
+ *   test_foo.py                  → foo   (Python / pytest)
+ *   foo_test.go / foo_test.py    → foo   (Go, unittest)
+ *   FooTest.java / BarSpec.scala → Foo   (JVM, PascalCase)
+ * @param {string} relPath
+ * @returns {string}
+ */
+function testTargetStem(relPath) {
+  let s = stemOf(relPath);               // strips ext + trailing .test/.spec
+  s = s.replace(/^test[_-]/i, '');       // Python: test_foo
+  s = s.replace(/[_-]test$/i, '');       // Go / unittest: foo_test
+  s = s.replace(/(Tests?|Specs?)$/, ''); // JVM PascalCase: FooTest, BarSpec
+  return s;
+}
+
+/**
+ * Impl→test discovery (C2, v8.5). Matches test files back to their
+ * implementation by normalizing conventional test affixes, so JS/TS, Python,
+ * Go, and JVM naming conventions all resolve. Deterministic; accuracy is
+ * measured by `scripts/run-test-discovery-benchmark.mjs`.
  * @param {string} relPath
  * @param {string[]} allFiles  - universe of indexed files (relative paths)
  * @returns {string[]}
@@ -87,7 +121,7 @@ function findRelatedTests(relPath, allFiles) {
   for (const f of allFiles) {
     if (f === relPath) continue;
     if (riskLabelFor(f) !== 'test') continue;
-    if (stemOf(f).toLowerCase() === stem) out.push(f);
+    if (testTargetStem(f).toLowerCase() === stem) out.push(f);
   }
   return out.sort();
 }

--- a/src/map/build-ci.js
+++ b/src/map/build-ci.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * Build & CI extractor (v8.5 C1).
+ *
+ * Surfaces how the project is built and validated: npm/pnpm/yarn scripts
+ * (package.json), GitHub Actions workflows (.github/workflows/*.yml), and
+ * Makefile targets. Pure, zero-dependency, deterministic.
+ *
+ * @param {string[]} files — absolute file paths (unused; roots are read directly)
+ * @param {string}   cwd   — project root
+ * @returns {string} formatted markdown table (empty string if none found)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_ROWS = 120;
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; }
+}
+
+function npmScripts(cwd, rows) {
+  const pkg = readJson(path.join(cwd, 'package.json'));
+  if (!pkg || !pkg.scripts || typeof pkg.scripts !== 'object') return;
+  for (const name of Object.keys(pkg.scripts).sort()) {
+    rows.push({ kind: 'script', name, detail: 'npm run ' + name });
+  }
+}
+
+function ciWorkflows(cwd, rows) {
+  const dir = path.join(cwd, '.github', 'workflows');
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch (_) { return; }
+  for (const file of entries.sort()) {
+    if (!/\.ya?ml$/i.test(file)) continue;
+    let content;
+    try { content = fs.readFileSync(path.join(dir, file), 'utf8'); } catch (_) { continue; }
+    const nameMatch = content.match(/^name:\s*(.+)$/m);
+    const name = nameMatch ? nameMatch[1].trim().replace(/^['"]|['"]$/g, '') : file;
+    // Trigger events from an `on:` mapping or inline form.
+    const onMatch = content.match(/^on:\s*(.*)$/m);
+    let triggers = '';
+    if (onMatch) {
+      if (onMatch[1].trim()) {
+        triggers = onMatch[1].replace(/[[\]{}'"]/g, '').trim();
+      } else {
+        const block = content.slice(onMatch.index);
+        const events = [...block.matchAll(/^\s{2,}([a-z_]+):/gm)].map((m) => m[1]);
+        triggers = [...new Set(events)].slice(0, 6).join(', ');
+      }
+    }
+    rows.push({ kind: 'ci', name, detail: `${file}${triggers ? ' — ' + triggers : ''}` });
+  }
+}
+
+function makeTargets(cwd, rows) {
+  let content;
+  try { content = fs.readFileSync(path.join(cwd, 'Makefile'), 'utf8'); } catch (_) { return; }
+  const targets = [];
+  for (const line of content.split('\n')) {
+    const m = line.match(/^([a-zA-Z0-9_][a-zA-Z0-9_.-]*)\s*:(?!=)/);
+    if (m && m[1] !== '.PHONY') targets.push(m[1]);
+  }
+  for (const t of [...new Set(targets)].sort()) {
+    rows.push({ kind: 'make', name: t, detail: 'make ' + t });
+  }
+}
+
+function analyze(files, cwd) {
+  const rows = [];
+  npmScripts(cwd, rows);
+  ciWorkflows(cwd, rows);
+  makeTargets(cwd, rows);
+  if (rows.length === 0) return '';
+
+  const lines = [
+    '| Kind | Name | Detail |',
+    '|------|------|--------|',
+  ];
+  for (const r of rows.slice(0, MAX_ROWS)) {
+    lines.push(`| ${r.kind} | ${r.name} | ${r.detail} |`);
+  }
+  if (rows.length > MAX_ROWS) {
+    lines.push(`| … | | +${rows.length - MAX_ROWS} more |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { analyze };

--- a/src/map/config-manifest.js
+++ b/src/map/config-manifest.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Config & package-manifest extractor (v8.5 C1).
+ *
+ * Surfaces the project's package manifests (name / version / dependency counts)
+ * across ecosystems and the notable root config files present. Pure,
+ * zero-dependency, deterministic.
+ *
+ * @param {string[]} files — absolute file paths (unused; roots are read directly)
+ * @param {string}   cwd   — project root
+ * @returns {string} formatted markdown table (empty string if none found)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILES = [
+  'tsconfig.json', 'jsconfig.json', '.eslintrc', '.eslintrc.json', '.eslintrc.js',
+  '.prettierrc', 'babel.config.js', 'jest.config.js', 'vitest.config.ts',
+  'webpack.config.js', 'vite.config.ts', 'rollup.config.js', 'tailwind.config.js',
+  'docker-compose.yml', 'docker-compose.yaml', 'Dockerfile', '.editorconfig',
+];
+
+function readText(p) { try { return fs.readFileSync(p, 'utf8'); } catch (_) { return null; } }
+function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
+function count(obj) { return obj && typeof obj === 'object' ? Object.keys(obj).length : 0; }
+
+function manifests(cwd, rows) {
+  const pkg = readJson(path.join(cwd, 'package.json'));
+  if (pkg) {
+    const deps = count(pkg.dependencies);
+    const dev = count(pkg.devDependencies);
+    const id = [pkg.name, pkg.version].filter(Boolean).join('@') || 'package.json';
+    rows.push({ manifest: 'package.json (npm)', detail: `${id} · ${deps} deps, ${dev} devDeps` });
+  }
+
+  const pyproject = readText(path.join(cwd, 'pyproject.toml'));
+  if (pyproject) {
+    const name = (pyproject.match(/^\s*name\s*=\s*["']([^"']+)["']/m) || [])[1];
+    const ver = (pyproject.match(/^\s*version\s*=\s*["']([^"']+)["']/m) || [])[1];
+    rows.push({ manifest: 'pyproject.toml (python)', detail: [name, ver].filter(Boolean).join('@') || 'present' });
+  } else if (readText(path.join(cwd, 'setup.py'))) {
+    rows.push({ manifest: 'setup.py (python)', detail: 'present' });
+  }
+  if (readText(path.join(cwd, 'requirements.txt'))) {
+    rows.push({ manifest: 'requirements.txt (python)', detail: 'present' });
+  }
+
+  const cargo = readText(path.join(cwd, 'Cargo.toml'));
+  if (cargo) {
+    const name = (cargo.match(/^\s*name\s*=\s*["']([^"']+)["']/m) || [])[1];
+    const ver = (cargo.match(/^\s*version\s*=\s*["']([^"']+)["']/m) || [])[1];
+    rows.push({ manifest: 'Cargo.toml (rust)', detail: [name, ver].filter(Boolean).join('@') || 'present' });
+  }
+
+  const gomod = readText(path.join(cwd, 'go.mod'));
+  if (gomod) {
+    const mod = (gomod.match(/^module\s+(\S+)/m) || [])[1];
+    const go = (gomod.match(/^go\s+(\S+)/m) || [])[1];
+    rows.push({ manifest: 'go.mod (go)', detail: [mod, go && 'go ' + go].filter(Boolean).join(' · ') || 'present' });
+  }
+
+  if (readText(path.join(cwd, 'pom.xml'))) rows.push({ manifest: 'pom.xml (maven)', detail: 'present' });
+  if (readText(path.join(cwd, 'build.gradle')) || readText(path.join(cwd, 'build.gradle.kts'))) {
+    rows.push({ manifest: 'build.gradle (gradle)', detail: 'present' });
+  }
+  if (readText(path.join(cwd, 'Gemfile'))) rows.push({ manifest: 'Gemfile (ruby)', detail: 'present' });
+  const composer = readJson(path.join(cwd, 'composer.json'));
+  if (composer) {
+    rows.push({ manifest: 'composer.json (php)', detail: `${composer.name || 'present'} · ${count(composer.require)} deps` });
+  }
+}
+
+function configFiles(cwd) {
+  const present = [];
+  for (const f of CONFIG_FILES) {
+    if (fs.existsSync(path.join(cwd, f))) present.push(f);
+  }
+  return present;
+}
+
+function analyze(files, cwd) {
+  const rows = [];
+  manifests(cwd, rows);
+  const configs = configFiles(cwd);
+  if (rows.length === 0 && configs.length === 0) return '';
+
+  const lines = [];
+  if (rows.length) {
+    lines.push('| Manifest | Detail |', '|----------|--------|');
+    for (const r of rows) lines.push(`| ${r.manifest} | ${r.detail} |`);
+  }
+  if (configs.length) {
+    if (lines.length) lines.push('');
+    lines.push(`**Config files:** ${configs.map((c) => '`' + c + '`').join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { analyze };

--- a/src/map/env-schema.js
+++ b/src/map/env-schema.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Environment-variable schema extractor (v8.5 C1).
+ *
+ * Surfaces the environment the project actually reads — from source across
+ * JS/TS, Python, Ruby, and Go, plus keys declared in a committed `.env.example`
+ * / `.env.sample` / `.env.template`. Pure, zero-dependency, deterministic.
+ *
+ * @param {string[]} files — absolute file paths to analyze (srcDirs-scoped)
+ * @param {string}   cwd   — project root
+ * @returns {string} formatted markdown table (empty string if none found)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SCAN_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.py', '.rb', '.go']);
+const EXAMPLE_FILES = ['.env.example', '.env.sample', '.env.template', '.env.dist'];
+
+// process.env.X / process.env['X'] / import.meta.env.X / Deno.env.get('X')
+const JS_RE = /(?:process\.env|import\.meta\.env)(?:\.([A-Z_][A-Z0-9_]*)|\[\s*['"]([A-Z_][A-Z0-9_]*)['"]\s*\])|Deno\.env\.get\(\s*['"]([A-Z_][A-Z0-9_]*)['"]/g;
+// os.environ['X'] / os.environ.get('X') / os.getenv('X') / getenv('X')
+const PY_RE = /(?:os\.)?(?:environ(?:\.get)?\[?\s*['"]([A-Z_][A-Z0-9_]*)['"]|getenv\(\s*['"]([A-Z_][A-Z0-9_]*)['"])/g;
+const RB_RE = /ENV\[\s*['"]([A-Z_][A-Z0-9_]*)['"]\s*\]/g;
+const GO_RE = /os\.(?:Getenv|LookupEnv)\(\s*["`']([A-Z_][A-Z0-9_]*)["`']/g;
+
+const MAX_ROWS = 200;
+
+function collectMatches(re, content, into) {
+  let m;
+  re.lastIndex = 0;
+  while ((m = re.exec(content)) !== null) {
+    const name = m[1] || m[2] || m[3];
+    if (name) into.add(name);
+  }
+}
+
+function readExampleKeys(cwd) {
+  const keys = new Set();
+  for (const name of EXAMPLE_FILES) {
+    let content;
+    try { content = fs.readFileSync(path.join(cwd, name), 'utf8'); } catch (_) { continue; }
+    for (const line of content.split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) continue;
+      const eq = t.match(/^(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=/);
+      if (eq) keys.add(eq[1]);
+    }
+  }
+  return keys;
+}
+
+function analyze(files, cwd) {
+  const fromCode = new Set();
+
+  for (const filePath of files) {
+    const ext = path.extname(filePath).toLowerCase();
+    if (!SCAN_EXTS.has(ext)) continue;
+    let content;
+    try { content = fs.readFileSync(filePath, 'utf8'); } catch (_) { continue; }
+
+    if (ext === '.py') collectMatches(PY_RE, content, fromCode);
+    else if (ext === '.rb') collectMatches(RB_RE, content, fromCode);
+    else if (ext === '.go') collectMatches(GO_RE, content, fromCode);
+    else collectMatches(JS_RE, content, fromCode);
+  }
+
+  const fromExample = readExampleKeys(cwd);
+  const all = new Set([...fromCode, ...fromExample]);
+  if (all.size === 0) return '';
+
+  const names = [...all].sort();
+  const lines = [
+    '| Variable | Source |',
+    '|----------|--------|',
+  ];
+  for (const name of names.slice(0, MAX_ROWS)) {
+    const src = [];
+    if (fromCode.has(name)) src.push('code');
+    if (fromExample.has(name)) src.push('.env.example');
+    lines.push(`| ${name} | ${src.join(', ')} |`);
+  }
+  if (names.length > MAX_ROWS) {
+    lines.push(`| … | +${names.length - MAX_ROWS} more |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { analyze };

--- a/src/map/migrations.js
+++ b/src/map/migrations.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Database-migration extractor (v8.5 C1).
+ *
+ * Detects schema-migration files across the common frameworks — Rails
+ * (db/migrate), Django/Alembic, Prisma, Flyway (`V1__name.sql`), knex/Sequelize,
+ * and timestamped SQL — and surfaces them with a parsed version + name. Pure,
+ * zero-dependency, deterministic.
+ *
+ * @param {string[]} files — absolute file paths (unused; the tree is walked)
+ * @param {string}   cwd   — project root
+ * @returns {string} formatted markdown table (empty string if none found)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_DEPTH = 6;
+const MAX_ROWS = 200;
+const SKIP_DIR = new Set(['.git', 'node_modules', 'vendor', 'dist', 'build', 'target', '.venv', 'venv', '__pycache__']);
+const MIG_EXT = new Set(['.sql', '.rb', '.py', '.js', '.ts']);
+
+// A directory whose path marks its children as migrations.
+const MIG_DIR_RE = /(^|\/)(db\/migrate|migrations?|alembic\/versions|prisma\/migrations)$/i;
+// A filename that is itself a migration regardless of directory.
+const FLYWAY_RE = /^V\d+(?:[._]\d+)*__(.+)\.(sql|java)$/;
+const TIMESTAMP_RE = /^(\d{8,})[_-](.+)\.(sql|rb|py|js|ts)$/;
+const NAMED_RE = /[._-]migrations?[._-]/i;
+
+function walk(dir, cwd, depth, out) {
+  if (depth > MAX_DEPTH) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  const relDir = path.relative(cwd, dir).replace(/\\/g, '/');
+  const dirIsMigration = MIG_DIR_RE.test(relDir);
+
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (SKIP_DIR.has(e.name)) continue;
+      walk(path.join(dir, e.name), cwd, depth + 1, out);
+      continue;
+    }
+    const ext = path.extname(e.name).toLowerCase();
+    if (!MIG_EXT.has(ext)) continue;
+
+    const rel = path.relative(cwd, path.join(dir, e.name)).replace(/\\/g, '/');
+    let version = null;
+    let name = null;
+
+    let m;
+    if ((m = e.name.match(FLYWAY_RE))) { version = e.name.split('__')[0]; name = m[1].replace(/_/g, ' '); }
+    else if ((m = e.name.match(TIMESTAMP_RE))) { version = m[1]; name = m[2].replace(/[_-]/g, ' '); }
+    else if (dirIsMigration) { version = '—'; name = e.name.replace(ext, ''); }
+    else if (NAMED_RE.test(e.name)) { version = '—'; name = e.name.replace(ext, ''); }
+    else continue;
+
+    out.push({ version, name, file: rel });
+  }
+}
+
+function analyze(files, cwd) {
+  const found = [];
+  walk(cwd, cwd, 0, found);
+  if (found.length === 0) return '';
+
+  found.sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+
+  const lines = [
+    '| Version | Migration | File |',
+    '|---------|-----------|------|',
+  ];
+  for (const r of found.slice(0, MAX_ROWS)) {
+    lines.push(`| ${r.version} | ${r.name} | ${r.file} |`);
+  }
+  if (found.length > MAX_ROWS) {
+    lines.push(`| … | +${found.length - MAX_ROWS} more | |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { analyze };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -21,6 +21,10 @@ const MAP_SECTIONS = {
   imports: '### Import graph',
   classes: '### Class hierarchy',
   routes: '### Route table',
+  env: '### Environment variables',
+  buildci: '### Build & CI',
+  manifests: '### Config & manifests',
+  migrations: '### Database migrations',
 };
 
 /**
@@ -106,7 +110,7 @@ function getMap(args, cwd) {
 
   const header = MAP_SECTIONS[args.type];
   if (!header) {
-    return `Unknown map type: "${args.type}". Use: imports, classes, routes`;
+    return `Unknown map type: "${args.type}". Use: ${Object.keys(MAP_SECTIONS).join(', ')}`;
   }
 
   const mapPath = path.join(cwd, 'PROJECT_MAP.md');

--- a/test/integration/benchmark-latest.test.js
+++ b/test/integration/benchmark-latest.test.js
@@ -81,9 +81,28 @@ function test(name, fn) {
       assert.strictEqual(out.metrics.baseline_hit_at_5, 0.1);
       assert.strictEqual(out.metrics.retrieval_lift, 8); // 80 / 10
       assert.strictEqual(out.repos_token, 7);
+      // Optional test-discovery report absent → key must be omitted (not throw).
+      assert.strictEqual('test_discovery' in out, false);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  // ── Test discovery (v8.5 C2) ──────────────────────────────────────────────
+  test('test-discovery report is committed and well-formed', () => {
+    const rep = require(path.join(ROOT, 'benchmarks/reports/test-discovery.json'));
+    assert.ok(rep.repos >= 1 && rep.pairs >= 1, 'expected measured repos/pairs');
+    for (const k of ['precision', 'recall', 'f1', 'hitAt1']) {
+      assert.ok(rep.metrics[k] >= 0 && rep.metrics[k] <= 1, `${k} out of [0,1]`);
+    }
+  });
+
+  test('latest.json surfaces the measured test-discovery number', () => {
+    const td = computeLatest(ROOT).test_discovery;
+    assert.ok(td, 'test_discovery block missing from latest.json');
+    assert.ok(td.f1 > 0 && td.f1 <= 1, 'f1 out of range');
+    assert.ok(td.hit_at_1 > 0 && td.hit_at_1 <= 1, 'hit_at_1 out of range');
+    assert.strictEqual(td.repos, require(path.join(ROOT, 'benchmarks/reports/test-discovery.json')).repos);
   });
 
   console.log(`\nbenchmark-latest: ${pass} passed, ${fail} failed`);

--- a/test/integration/evidence-pack.test.js
+++ b/test/integration/evidence-pack.test.js
@@ -96,15 +96,26 @@ test('parseAnchor returns null lines when no anchor present', () => {
   assert.strictEqual(r.end, null);
 });
 
-test('riskLabelFor classifies generated/test/config/security/source', () => {
+test('riskLabelFor classifies the v8.5 richer label set (C3)', () => {
+  // preserved semantics
   assert.strictEqual(pack.riskLabelFor('dist/bundle.js'), 'generated');
   assert.strictEqual(pack.riskLabelFor('api.generated.ts'), 'generated');
-  assert.strictEqual(pack.riskLabelFor('test/auth.test.js'), 'test');
+  assert.strictEqual(pack.riskLabelFor('test/widget.test.js'), 'test');
   assert.strictEqual(pack.riskLabelFor('src/test_helpers.py'), 'test');
-  assert.strictEqual(pack.riskLabelFor('settings.json'), 'config');
-  assert.strictEqual(pack.riskLabelFor('src/auth.js'), 'security');
-  assert.strictEqual(pack.riskLabelFor('src/payment.js'), 'security');
+  assert.strictEqual(pack.riskLabelFor('settings.yaml'), 'config');
   assert.strictEqual(pack.riskLabelFor('src/widget.js'), 'source');
+  // richer labels (C3)
+  assert.strictEqual(pack.riskLabelFor('db/migrate/20180917_create_users.rb'), 'migration');
+  assert.strictEqual(pack.riskLabelFor('sql/V2__add_index.sql'), 'migration');
+  assert.strictEqual(pack.riskLabelFor('src/payment.js'), 'payment');
+  assert.strictEqual(pack.riskLabelFor('src/billing/checkout.ts'), 'payment');
+  assert.strictEqual(pack.riskLabelFor('src/auth.js'), 'auth');
+  assert.strictEqual(pack.riskLabelFor('src/oauth/session.py'), 'auth');
+  assert.strictEqual(pack.riskLabelFor('src/crypto/secret.js'), 'security');
+  assert.strictEqual(pack.riskLabelFor('src/api/handler.js'), 'public-api');
+  assert.strictEqual(pack.riskLabelFor('packages/core/index.ts'), 'public-api');
+  // precedence: a migration touching auth is still a migration
+  assert.strictEqual(pack.riskLabelFor('db/migrate/20200101_add_auth_tokens.rb'), 'migration');
 });
 
 test('findRelatedTests matches a test file by stem', () => {
@@ -112,6 +123,25 @@ test('findRelatedTests matches a test file by stem', () => {
   assert.deepStrictEqual(pack.findRelatedTests('src/widget.js', universe), ['test/widget.test.js']);
   // a test file maps to nothing
   assert.deepStrictEqual(pack.findRelatedTests('test/widget.test.js', universe), []);
+});
+
+test('findRelatedTests resolves cross-language test conventions (C2)', () => {
+  // Python: test_foo.py ↔ foo.py
+  assert.deepStrictEqual(
+    pack.findRelatedTests('src/parser.py', ['src/parser.py', 'tests/test_parser.py']),
+    ['tests/test_parser.py']);
+  // Go: foo_test.go ↔ foo.go
+  assert.deepStrictEqual(
+    pack.findRelatedTests('pkg/router.go', ['pkg/router.go', 'pkg/router_test.go']),
+    ['pkg/router_test.go']);
+  // JVM PascalCase: FooTest.java ↔ Foo.java
+  assert.deepStrictEqual(
+    pack.findRelatedTests('src/Widget.java', ['src/Widget.java', 'test/WidgetTest.java']),
+    ['test/WidgetTest.java']);
+  // .spec.ts ↔ .ts
+  assert.deepStrictEqual(
+    pack.findRelatedTests('src/store.ts', ['src/store.ts', 'src/store.spec.ts']),
+    ['src/store.spec.ts']);
 });
 
 test('buildEvidencePack produces a stable contextHash given the same index', () => {

--- a/test/integration/project-map.test.js
+++ b/test/integration/project-map.test.js
@@ -92,8 +92,8 @@ test('creates PROJECT_MAP.md', () => {
   }
 });
 
-// ── 2. All three sections are present ────────────────────────────────────
-test('writes all three ### sections', () => {
+// ── 2. All sections are present (3 core + 4 v8.5 C1 coverage) ─────────────
+test('writes all ### sections including v8.5 coverage', () => {
   const tmp = mkTmp();
   try {
     writeFixtures(tmp, {
@@ -104,9 +104,46 @@ test('writes all three ### sections', () => {
     runMap(tmp);
     const content = fs.readFileSync(path.join(tmp, 'PROJECT_MAP.md'), 'utf8');
 
-    assert.ok(content.includes('### Import graph'),    'Missing ### Import graph');
-    assert.ok(content.includes('### Class hierarchy'), 'Missing ### Class hierarchy');
-    assert.ok(content.includes('### Route table'),     'Missing ### Route table');
+    assert.ok(content.includes('### Import graph'),          'Missing ### Import graph');
+    assert.ok(content.includes('### Class hierarchy'),       'Missing ### Class hierarchy');
+    assert.ok(content.includes('### Route table'),           'Missing ### Route table');
+    assert.ok(content.includes('### Environment variables'), 'Missing ### Environment variables');
+    assert.ok(content.includes('### Build & CI'),            'Missing ### Build & CI');
+    assert.ok(content.includes('### Config & manifests'),    'Missing ### Config & manifests');
+    assert.ok(content.includes('### Database migrations'),   'Missing ### Database migrations');
+  } finally {
+    rmdir(tmp);
+  }
+});
+
+// ── 2b. v8.5 C1: coverage analyzers populate their sections ───────────────
+test('C1 coverage: env / build-ci / manifest / migration content', () => {
+  const tmp = mkTmp();
+  try {
+    writeFixtures(tmp, {
+      'src/config.js': 'const url = process.env.DATABASE_URL;\nconst key = process.env["API_KEY"];\n',
+      '.env.example': '# sample\nDATABASE_URL=\nLOG_LEVEL=info\n',
+      'package.json': JSON.stringify({ name: 'demo', version: '1.2.3', scripts: { test: 'node t.js', build: 'tsc' } }),
+      '.github/workflows/ci.yml': 'name: CI\non:\n  push:\n  pull_request:\njobs:\n  build:\n    runs-on: ubuntu-latest\n',
+      'db/migrate/20240101000000_create_users.rb': 'class CreateUsers; end',
+      'gen-context.config.json': JSON.stringify({ srcDirs: ['src'] }),
+    });
+
+    runMap(tmp);
+    const content = fs.readFileSync(path.join(tmp, 'PROJECT_MAP.md'), 'utf8');
+
+    // env-schema: from code and from .env.example
+    assert.ok(content.includes('DATABASE_URL'), 'env var DATABASE_URL missing');
+    assert.ok(content.includes('API_KEY'), 'env var API_KEY missing');
+    assert.ok(content.includes('LOG_LEVEL'), 'env var LOG_LEVEL (.env.example) missing');
+    // build-ci: npm scripts + CI workflow
+    assert.ok(content.includes('npm run build'), 'npm script missing');
+    assert.ok(/\bCI\b/.test(content), 'CI workflow name missing');
+    // config-manifest
+    assert.ok(content.includes('demo@1.2.3'), 'manifest name@version missing');
+    // migrations
+    assert.ok(content.includes('20240101000000'), 'migration version missing');
+    assert.ok(content.includes('create users'), 'migration name missing');
   } finally {
     rmdir(tmp);
   }


### PR DESCRIPTION
Closes #401. Ships the v8.x trio (C1+C2+C3) from the Master Plan — all zero-dep, deterministic, in-boundary.

## C1 — Repo-context coverage expansion [HIGH]
Map coverage was functions/classes + routes only. Adds four dedicated `src/map/*` analyzers (mirroring `route-table.js`), wired into `gen-project-map.js` and `MAP_SECTIONS` (so `get_map` can slice them):
- `env-schema.js` → **Environment variables** — env reads across JS/TS/Py/Ruby/Go + `.env.example` keys
- `build-ci.js` → **Build & CI** — npm scripts, GitHub Actions workflows, Makefile targets
- `config-manifest.js` → **Config & manifests** — package manifests (npm/py/rust/go/maven/gradle/ruby/php) + notable config files
- `migrations.js` → **Database migrations** — Rails/Alembic/Prisma/Flyway/timestamped-SQL detection

## C2 — Test discovery, measured [HIGH]
- `findRelatedTests` now normalizes cross-language test conventions: `test_x.py`↔`x.py`, `x_test.go`↔`x.go`, `XTest.java`↔`X.java`, `x.spec.ts`↔`x.ts`.
- New reproducible harness `scripts/run-test-discovery-benchmark.mjs` (`npm run benchmark:test-discovery`) scores it against an **independent canonical-name gold oracle** over `benchmarks/repos` — no LLM, pure string math.
- **Measured: F1 98.0%, hit@1 97.4%** across 28 repos / 3701 gold pairs → surfaced in `benchmarks/latest.json` under `test_discovery` (top-level, so version.json's metrics mirror is unaffected).

## C3 — Richer risk labels [MED]
`riskLabelFor` now returns the v8.5 set — `migration | payment | auth | security | public-api | config | test | generated | source` — with strict most-specific-risk precedence (a migration touching auth is still `migration`; payment/auth outrank the generic `security` bucket). `test`/`generated` semantics preserved so `findRelatedTests` and the verifier keep working.

## Verification
- Bundle rebuilt from `src/` (133 modules) — `bundle-repro` byte-for-byte green.
- Full integration suite **100/100**, extractor suite **23/23**.
- Supply-chain local audit clean: no shell spawns · no install scripts · `main` exports API · no fingerprinting.

## Acceptance criteria
- [x] C1: four new PROJECT_MAP sections, each from a dedicated analyzer; `get_map` slices them
- [x] C2: cross-language pairs match; measured F1/hit@1 in `test-discovery.json` + `latest.json`
- [x] C3: richer labels with stable precedence; every Evidence Pack file carries a `riskLabel`
- [x] Bundle reproducible, suite green, supply-chain audit clean