### PR TITLE
feat(verify): local-library signature index — the private-API grounding moat (G5/D5)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -16403,6 +16403,7 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
   const path = require('path');
   const parsers = __require('./src/verify/parsers');
   const { closestMatch, buildSymbolCandidates, formatSuggestion } = __require('./src/verify/closest-match');
+  const { buildLibraryIndex } = __require('./src/verify/lib-index');
 
   // A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
   // a tests/__tests__ directory). Used to flag fake-test-file separately.
@@ -16571,6 +16572,28 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
     }
     if (!fileBasenames) fileBasenames = new Set();
 
+    // Installed-library grounding (G5/D5, the moat): union the exported symbols of
+    // the libraries actually installed in node_modules, so genuine library calls
+    // stop false-flagging as fake-symbol and the summary can pin the versions the
+    // answer was verified against. Auto-runs only when the caller did not override
+    // the symbol set (keeps hermetic callers unchanged); disable with libIndex:false.
+    let libraries = opts.libraries || [];
+    {
+      let libSyms = opts.libSymbols;
+      if (!libSyms && opts.libIndex !== false && !opts.symbolSet) {
+        try {
+          const li = buildLibraryIndex(cwd, { version: opts.version });
+          libSyms = li.symbols;
+          if (!opts.libraries) libraries = li.libraries;
+        } catch (_) { libSyms = null; }
+      }
+      if (libSyms && libSyms.size) {
+        const merged = new Set(symbolSet);
+        for (const s of libSyms) merged.add(s);
+        symbolSet = merged;
+      }
+    }
+
     let deps = opts.deps;
     let hasPkg = opts.hasPkg;
     if (!deps) {
@@ -16694,12 +16717,182 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
       clean: issues.length === 0,
       symbolsIndexed: symbolSet.size,
       withSuggestion: issues.filter((i) => i.suggestion).length,
+      librariesIndexed: libraries.length,
+      libraries: libraries.map((l) => ({ name: l.name, version: l.version, symbols: l.symbols, typed: l.typed })),
     };
 
     return { issues, summary };
   }
 
   module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath };
+  
+};
+
+// ── ./src/verify/lib-index ──
+__factories["./src/verify/lib-index"] = function(module, exports) {
+  
+  /**
+   * Local-library signature index (v9.0 G5/D5 — the private-API grounding moat).
+   *
+   * Context7 knows only *public* library docs. SigMap can do something no
+   * competitor can: index the signatures of the libraries **actually installed**
+   * in `node_modules` and verify AI suggestions against repo + private +
+   * installed-lib symbols. This module builds the installed-lib half.
+   *
+   * For each **direct** dependency declared in `package.json`, it locates the
+   * package under `node_modules/<dep>`, reads its version (D8 version pinning),
+   * and extracts the exported symbol names from its TypeScript declaration entry
+   * (`types`/`typings`, else `index.d.ts`). Pure, zero-dependency, deterministic:
+   * byte-stable given a fixed installed tree. Bounded (per-file read cap + dep
+   * cap) and cached via `src/cache/sig-cache.js` so repeat builds are near-free.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { loadCache, saveCache, getChangedFiles, updateCacheEntries } = __require('./src/cache/sig-cache');
+
+  const MAX_DTS_BYTES = 512 * 1024; // per-file read cap
+  const MAX_DEPS = 1000;            // dep count cap
+  const DEP_KEYS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+  /**
+   * Extract exported symbol names from a `.d.ts` declaration file. Deterministic,
+   * regex-based (declaration files are already normalized, so this is robust
+   * without a full TS parser and stays zero-dependency).
+   * @param {string} src
+   * @returns {string[]} sorted unique exported names
+   */
+  function extractDtsExports(src) {
+    const names = new Set();
+    if (!src) return [];
+
+    // export [declare] [default] function|const|let|var|class|interface|type|enum|namespace Name
+    const declRe = /\bexport\s+(?:declare\s+)?(?:default\s+)?(?:abstract\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum|namespace|module)\s+([A-Za-z_$][\w$]*)/g;
+    let m;
+    while ((m = declRe.exec(src)) !== null) names.add(m[1]);
+
+    // export { a, b as c, default as d }
+    const listRe = /\bexport\s*(?:type\s*)?\{([^}]*)\}/g;
+    while ((m = listRe.exec(src)) !== null) {
+      for (const part of m[1].split(',')) {
+        const name = part.trim().split(/\s+as\s+/).pop().trim();
+        if (/^[A-Za-z_$][\w$]*$/.test(name) && name !== 'default') names.add(name);
+      }
+    }
+
+    // export as namespace Name  /  export = Name
+    const nsRe = /\bexport\s+as\s+namespace\s+([A-Za-z_$][\w$]*)/g;
+    while ((m = nsRe.exec(src)) !== null) names.add(m[1]);
+    const assignRe = /\bexport\s*=\s*([A-Za-z_$][\w$]*)/g;
+    while ((m = assignRe.exec(src)) !== null) names.add(m[1]);
+
+    return [...names].sort();
+  }
+
+  /** Read direct dependency names declared in the project's package.json. */
+  function directDeps(cwd) {
+    const names = new Set();
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      for (const k of DEP_KEYS) {
+        if (pkg[k] && typeof pkg[k] === 'object') {
+          for (const n of Object.keys(pkg[k])) names.add(n);
+        }
+      }
+    } catch (_) { /* no/invalid package.json → no deps */ }
+    return [...names].sort();
+  }
+
+  /**
+   * Resolve an installed dependency's version + entry `.d.ts` path.
+   * @returns {{ version: string|null, dtsPath: string|null }|null} null if not installed
+   */
+  function resolveEntry(cwd, dep) {
+    const pkgDir = path.join(cwd, 'node_modules', dep);
+    let pkg;
+    try { pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')); } catch (_) { return null; }
+    const version = typeof pkg.version === 'string' ? pkg.version : null;
+
+    const candidates = [];
+    const typesField = pkg.types || pkg.typings;
+    if (typeof typesField === 'string') {
+      candidates.push(typesField);
+      candidates.push(path.join(typesField, 'index.d.ts')); // typesField may be a dir
+    }
+    candidates.push('index.d.ts');
+    if (typeof pkg.main === 'string') candidates.push(pkg.main.replace(/\.(js|cjs|mjs)$/, '.d.ts'));
+
+    for (const c of candidates) {
+      const p = path.join(pkgDir, c);
+      try { if (fs.statSync(p).isFile()) return { version, dtsPath: p }; } catch (_) { /* next */ }
+    }
+    return { version, dtsPath: null }; // installed but untyped
+  }
+
+  /**
+   * Build the installed-library signature index for `cwd`.
+   *
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {string} [opts.version='0']  sigmap version, for cache busting
+   * @param {boolean} [opts.cache=true]  use the on-disk sig-cache
+   * @returns {{ symbols: Set<string>, libraries: Array<{name,version,symbols,typed}>, count: number }}
+   */
+  function buildLibraryIndex(cwd, opts = {}) {
+    const version = opts.version || '0';
+    const useCache = opts.cache !== false;
+    const deps = directDeps(cwd).slice(0, MAX_DEPS);
+
+    const entries = [];
+    for (const dep of deps) {
+      const r = resolveEntry(cwd, dep);
+      if (r) entries.push({ dep, version: r.version, dtsPath: r.dtsPath });
+    }
+
+    const cache = useCache ? loadCache(cwd, version) : new Map();
+    const dtsFiles = entries.filter((e) => e.dtsPath).map((e) => e.dtsPath);
+    const { unchanged } = getChangedFiles(dtsFiles, cache);
+    const unchangedSet = new Set(unchanged);
+
+    const symbols = new Set();
+    const libraries = [];
+    const fresh = [];
+
+    for (const e of entries) {
+      let names;
+      if (!e.dtsPath) {
+        names = [];
+      } else if (unchangedSet.has(e.dtsPath) && cache.get(e.dtsPath)) {
+        names = cache.get(e.dtsPath).sigs || [];
+      } else {
+        let src = '';
+        try {
+          if (fs.statSync(e.dtsPath).size <= MAX_DTS_BYTES) src = fs.readFileSync(e.dtsPath, 'utf8');
+        } catch (_) { /* unreadable → empty */ }
+        names = extractDtsExports(src);
+        fresh.push({ file: e.dtsPath, sigs: names });
+      }
+      for (const n of names) symbols.add(n);
+      libraries.push({ name: e.dep, version: e.version, symbols: names.length, typed: !!e.dtsPath });
+    }
+
+    if (useCache && fresh.length) {
+      updateCacheEntries(cache, fresh);
+      saveCache(cwd, version, cache);
+    }
+
+    libraries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return { symbols, libraries, count: symbols.size };
+  }
+
+  /** D8: render `name@version` pins for the typed/installed libraries. */
+  function formatVersionPins(libraries) {
+    return (libraries || [])
+      .filter((l) => l.version)
+      .map((l) => `${l.name}@${l.version}`);
+  }
+
+  module.exports = { buildLibraryIndex, extractDtsExports, directDeps, resolveEntry, formatVersionPins };
   
 };
 

--- a/src/verify/hallucination-guard.js
+++ b/src/verify/hallucination-guard.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const path = require('path');
 const parsers = require('./parsers');
 const { closestMatch, buildSymbolCandidates, formatSuggestion } = require('./closest-match');
+const { buildLibraryIndex } = require('./lib-index');
 
 // A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
 // a tests/__tests__ directory). Used to flag fake-test-file separately.
@@ -189,6 +190,28 @@ function verify(answerText, cwd, opts = {}) {
   }
   if (!fileBasenames) fileBasenames = new Set();
 
+  // Installed-library grounding (G5/D5, the moat): union the exported symbols of
+  // the libraries actually installed in node_modules, so genuine library calls
+  // stop false-flagging as fake-symbol and the summary can pin the versions the
+  // answer was verified against. Auto-runs only when the caller did not override
+  // the symbol set (keeps hermetic callers unchanged); disable with libIndex:false.
+  let libraries = opts.libraries || [];
+  {
+    let libSyms = opts.libSymbols;
+    if (!libSyms && opts.libIndex !== false && !opts.symbolSet) {
+      try {
+        const li = buildLibraryIndex(cwd, { version: opts.version });
+        libSyms = li.symbols;
+        if (!opts.libraries) libraries = li.libraries;
+      } catch (_) { libSyms = null; }
+    }
+    if (libSyms && libSyms.size) {
+      const merged = new Set(symbolSet);
+      for (const s of libSyms) merged.add(s);
+      symbolSet = merged;
+    }
+  }
+
   let deps = opts.deps;
   let hasPkg = opts.hasPkg;
   if (!deps) {
@@ -312,6 +335,8 @@ function verify(answerText, cwd, opts = {}) {
     clean: issues.length === 0,
     symbolsIndexed: symbolSet.size,
     withSuggestion: issues.filter((i) => i.suggestion).length,
+    librariesIndexed: libraries.length,
+    libraries: libraries.map((l) => ({ name: l.name, version: l.version, symbols: l.symbols, typed: l.typed })),
   };
 
   return { issues, summary };

--- a/src/verify/lib-index.js
+++ b/src/verify/lib-index.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * Local-library signature index (v9.0 G5/D5 — the private-API grounding moat).
+ *
+ * Context7 knows only *public* library docs. SigMap can do something no
+ * competitor can: index the signatures of the libraries **actually installed**
+ * in `node_modules` and verify AI suggestions against repo + private +
+ * installed-lib symbols. This module builds the installed-lib half.
+ *
+ * For each **direct** dependency declared in `package.json`, it locates the
+ * package under `node_modules/<dep>`, reads its version (D8 version pinning),
+ * and extracts the exported symbol names from its TypeScript declaration entry
+ * (`types`/`typings`, else `index.d.ts`). Pure, zero-dependency, deterministic:
+ * byte-stable given a fixed installed tree. Bounded (per-file read cap + dep
+ * cap) and cached via `src/cache/sig-cache.js` so repeat builds are near-free.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadCache, saveCache, getChangedFiles, updateCacheEntries } = require('../cache/sig-cache');
+
+const MAX_DTS_BYTES = 512 * 1024; // per-file read cap
+const MAX_DEPS = 1000;            // dep count cap
+const DEP_KEYS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+/**
+ * Extract exported symbol names from a `.d.ts` declaration file. Deterministic,
+ * regex-based (declaration files are already normalized, so this is robust
+ * without a full TS parser and stays zero-dependency).
+ * @param {string} src
+ * @returns {string[]} sorted unique exported names
+ */
+function extractDtsExports(src) {
+  const names = new Set();
+  if (!src) return [];
+
+  // export [declare] [default] function|const|let|var|class|interface|type|enum|namespace Name
+  const declRe = /\bexport\s+(?:declare\s+)?(?:default\s+)?(?:abstract\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum|namespace|module)\s+([A-Za-z_$][\w$]*)/g;
+  let m;
+  while ((m = declRe.exec(src)) !== null) names.add(m[1]);
+
+  // export { a, b as c, default as d }
+  const listRe = /\bexport\s*(?:type\s*)?\{([^}]*)\}/g;
+  while ((m = listRe.exec(src)) !== null) {
+    for (const part of m[1].split(',')) {
+      const name = part.trim().split(/\s+as\s+/).pop().trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(name) && name !== 'default') names.add(name);
+    }
+  }
+
+  // export as namespace Name  /  export = Name
+  const nsRe = /\bexport\s+as\s+namespace\s+([A-Za-z_$][\w$]*)/g;
+  while ((m = nsRe.exec(src)) !== null) names.add(m[1]);
+  const assignRe = /\bexport\s*=\s*([A-Za-z_$][\w$]*)/g;
+  while ((m = assignRe.exec(src)) !== null) names.add(m[1]);
+
+  return [...names].sort();
+}
+
+/** Read direct dependency names declared in the project's package.json. */
+function directDeps(cwd) {
+  const names = new Set();
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    for (const k of DEP_KEYS) {
+      if (pkg[k] && typeof pkg[k] === 'object') {
+        for (const n of Object.keys(pkg[k])) names.add(n);
+      }
+    }
+  } catch (_) { /* no/invalid package.json → no deps */ }
+  return [...names].sort();
+}
+
+/**
+ * Resolve an installed dependency's version + entry `.d.ts` path.
+ * @returns {{ version: string|null, dtsPath: string|null }|null} null if not installed
+ */
+function resolveEntry(cwd, dep) {
+  const pkgDir = path.join(cwd, 'node_modules', dep);
+  let pkg;
+  try { pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')); } catch (_) { return null; }
+  const version = typeof pkg.version === 'string' ? pkg.version : null;
+
+  const candidates = [];
+  const typesField = pkg.types || pkg.typings;
+  if (typeof typesField === 'string') {
+    candidates.push(typesField);
+    candidates.push(path.join(typesField, 'index.d.ts')); // typesField may be a dir
+  }
+  candidates.push('index.d.ts');
+  if (typeof pkg.main === 'string') candidates.push(pkg.main.replace(/\.(js|cjs|mjs)$/, '.d.ts'));
+
+  for (const c of candidates) {
+    const p = path.join(pkgDir, c);
+    try { if (fs.statSync(p).isFile()) return { version, dtsPath: p }; } catch (_) { /* next */ }
+  }
+  return { version, dtsPath: null }; // installed but untyped
+}
+
+/**
+ * Build the installed-library signature index for `cwd`.
+ *
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {string} [opts.version='0']  sigmap version, for cache busting
+ * @param {boolean} [opts.cache=true]  use the on-disk sig-cache
+ * @returns {{ symbols: Set<string>, libraries: Array<{name,version,symbols,typed}>, count: number }}
+ */
+function buildLibraryIndex(cwd, opts = {}) {
+  const version = opts.version || '0';
+  const useCache = opts.cache !== false;
+  const deps = directDeps(cwd).slice(0, MAX_DEPS);
+
+  const entries = [];
+  for (const dep of deps) {
+    const r = resolveEntry(cwd, dep);
+    if (r) entries.push({ dep, version: r.version, dtsPath: r.dtsPath });
+  }
+
+  const cache = useCache ? loadCache(cwd, version) : new Map();
+  const dtsFiles = entries.filter((e) => e.dtsPath).map((e) => e.dtsPath);
+  const { unchanged } = getChangedFiles(dtsFiles, cache);
+  const unchangedSet = new Set(unchanged);
+
+  const symbols = new Set();
+  const libraries = [];
+  const fresh = [];
+
+  for (const e of entries) {
+    let names;
+    if (!e.dtsPath) {
+      names = [];
+    } else if (unchangedSet.has(e.dtsPath) && cache.get(e.dtsPath)) {
+      names = cache.get(e.dtsPath).sigs || [];
+    } else {
+      let src = '';
+      try {
+        if (fs.statSync(e.dtsPath).size <= MAX_DTS_BYTES) src = fs.readFileSync(e.dtsPath, 'utf8');
+      } catch (_) { /* unreadable → empty */ }
+      names = extractDtsExports(src);
+      fresh.push({ file: e.dtsPath, sigs: names });
+    }
+    for (const n of names) symbols.add(n);
+    libraries.push({ name: e.dep, version: e.version, symbols: names.length, typed: !!e.dtsPath });
+  }
+
+  if (useCache && fresh.length) {
+    updateCacheEntries(cache, fresh);
+    saveCache(cwd, version, cache);
+  }
+
+  libraries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { symbols, libraries, count: symbols.size };
+}
+
+/** D8: render `name@version` pins for the typed/installed libraries. */
+function formatVersionPins(libraries) {
+  return (libraries || [])
+    .filter((l) => l.version)
+    .map((l) => `${l.name}@${l.version}`);
+}
+
+module.exports = { buildLibraryIndex, extractDtsExports, directDeps, resolveEntry, formatVersionPins };

--- a/test/integration/lib-index.test.js
+++ b/test/integration/lib-index.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * Local-library signature index (v9.0 G5/D5 — the moat).
+ *
+ * Covers:
+ *   extractDtsExports — parses the common `.d.ts` export forms
+ *   buildLibraryIndex — resolves installed direct deps → symbols + versions (D8),
+ *                       caches via sig-cache, degrades gracefully
+ *   verify() integration — a real installed-library call is no longer
+ *                          false-flagged; a genuinely fake symbol still flags;
+ *                          summary reports librariesIndexed + version pins
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const ROOT = path.resolve(__dirname, '../..');
+const lib = require(path.join(ROOT, 'src', 'verify', 'lib-index'));
+const { verify } = require(path.join(ROOT, 'src', 'verify', 'hallucination-guard'));
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.log(`  FAIL  ${name}: ${err.message}`); failed++; }
+}
+
+/** Build a temp project: package.json deps + an installed node_modules/<dep>. */
+function withProject(deps, installed, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-libidx-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'proj', dependencies: deps }));
+    for (const [name, spec] of Object.entries(installed || {})) {
+      const pkgDir = path.join(dir, 'node_modules', name);
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify(spec.pkg));
+      if (spec.dts != null) fs.writeFileSync(path.join(pkgDir, spec.dtsName || 'index.d.ts'), spec.dts);
+    }
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log('\nlib-index (G5/D5 moat) tests\n');
+
+// ── extractDtsExports ───────────────────────────────────────────────────────
+test('extractDtsExports parses declaration, list, and namespace exports', () => {
+  const src = [
+    'export declare function debounce(fn: any): any;',
+    'export const VERSION: string;',
+    'export class Router {}',
+    'export interface Options {}',
+    'export type Handler = () => void;',
+    'export enum Level { A, B }',
+    'declare function hidden(): void;',        // not exported → excluded
+    'export { helper as helperAlias, plain };',
+    'export as namespace Acme;',
+  ].join('\n');
+  const names = lib.extractDtsExports(src);
+  for (const want of ['debounce', 'VERSION', 'Router', 'Options', 'Handler', 'Level', 'helperAlias', 'plain', 'Acme']) {
+    assert.ok(names.includes(want), `missing export ${want}`);
+  }
+  assert.ok(!names.includes('hidden'), 'non-exported symbol leaked');
+  assert.deepStrictEqual(names, [...names].sort(), 'output not sorted (determinism)');
+});
+
+// ── buildLibraryIndex ───────────────────────────────────────────────────────
+test('buildLibraryIndex indexes installed direct deps with version (D8)', () => {
+  withProject(
+    { acme: '^1.0.0' },
+    { acme: { pkg: { name: 'acme', version: '1.2.3', types: 'index.d.ts' }, dts: 'export declare function foo(): void;\nexport const bar: string;' } },
+    (dir) => {
+      const idx = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+      assert.deepStrictEqual([...idx.symbols].sort(), ['bar', 'foo']);
+      assert.strictEqual(idx.count, 2);
+      assert.strictEqual(idx.libraries.length, 1);
+      assert.deepStrictEqual(idx.libraries[0], { name: 'acme', version: '1.2.3', symbols: 2, typed: true });
+      assert.deepStrictEqual(lib.formatVersionPins(idx.libraries), ['acme@1.2.3']);
+    });
+});
+
+test('buildLibraryIndex resolves typings dir + main→.d.ts fallback', () => {
+  withProject(
+    { widget: '^2.0.0' },
+    { widget: { pkg: { name: 'widget', version: '2.0.0', main: 'index.js' }, dts: 'export class Widget {}' } },
+    (dir) => {
+      const idx = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+      assert.ok(idx.symbols.has('Widget'), 'did not resolve index.d.ts default');
+    });
+});
+
+test('buildLibraryIndex is cached via sig-cache (repeat build is consistent)', () => {
+  withProject(
+    { acme: '^1' },
+    { acme: { pkg: { name: 'acme', version: '1.0.0', types: 'index.d.ts' }, dts: 'export const A: number;' } },
+    (dir) => {
+      const a = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+      assert.ok(fs.existsSync(path.join(dir, '.sigmap-cache.json')), 'cache file not written');
+      const b = lib.buildLibraryIndex(dir, { version: '8.0.0' }); // second → cache hit
+      assert.deepStrictEqual([...a.symbols].sort(), [...b.symbols].sort());
+    });
+});
+
+test('buildLibraryIndex degrades gracefully (uninstalled / untyped / malformed)', () => {
+  // dep declared but not installed
+  withProject({ ghost: '^1' }, {}, (dir) => {
+    const idx = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+    assert.strictEqual(idx.count, 0);
+    assert.strictEqual(idx.libraries.length, 0);
+  });
+  // installed but untyped (no .d.ts)
+  withProject({ plain: '^1' }, { plain: { pkg: { name: 'plain', version: '3.0.0' }, dts: null } }, (dir) => {
+    const idx = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+    assert.strictEqual(idx.count, 0);
+    assert.deepStrictEqual(idx.libraries[0], { name: 'plain', version: '3.0.0', symbols: 0, typed: false });
+  });
+  // no package.json at all → empty, no throw
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-empty-'));
+  try {
+    const idx = lib.buildLibraryIndex(empty, { version: '8.0.0' });
+    assert.strictEqual(idx.count, 0);
+  } finally { fs.rmSync(empty, { recursive: true, force: true }); }
+});
+
+// ── verify() integration (the moat behavior) ────────────────────────────────
+test('verify() no longer false-flags a real installed-library call', () => {
+  withProject(
+    { acme: '^1' },
+    { acme: { pkg: { name: 'acme', version: '1.2.3', types: 'index.d.ts' }, dts: 'export declare function debounce(fn: any): any;\nexport class Router {}' } },
+    (dir) => {
+      const answer = 'Call `Router()` and `debounce(fn)` and `notARealThing()`.';
+      const base = { symbolSet: new Set(['someRepoFn']), deps: new Set(['acme']), hasPkg: true };
+      const li = lib.buildLibraryIndex(dir, { version: '8.0.0' });
+
+      const off = verify(answer, dir, { ...base, libIndex: false });
+      const on = verify(answer, dir, { ...base, libSymbols: li.symbols, libraries: li.libraries });
+
+      const offFakes = off.issues.filter((i) => i.type === 'fake-symbol').map((i) => i.value).sort();
+      const onFakes = on.issues.filter((i) => i.type === 'fake-symbol').map((i) => i.value).sort();
+      assert.deepStrictEqual(offFakes, ['Router', 'debounce', 'notARealThing'], 'baseline should flag all three');
+      assert.deepStrictEqual(onFakes, ['notARealThing'], 'lib index should suppress only the real library calls');
+    });
+});
+
+test('verify() summary reports librariesIndexed + version pins (D8)', () => {
+  withProject(
+    { acme: '^1' },
+    { acme: { pkg: { name: 'acme', version: '1.2.3', types: 'index.d.ts' }, dts: 'export class Router {}' } },
+    (dir) => {
+      const res = verify('Use `Router()`.', dir, { symbolSet: new Set(['x']), deps: new Set(['acme']), hasPkg: true, version: '8.0.0',
+        libSymbols: lib.buildLibraryIndex(dir, { version: '8.0.0' }).symbols,
+        libraries: lib.buildLibraryIndex(dir, { version: '8.0.0' }).libraries });
+      assert.strictEqual(res.summary.librariesIndexed, 1);
+      assert.deepStrictEqual(res.summary.libraries, [{ name: 'acme', version: '1.2.3', symbols: 1, typed: true }]);
+    });
+});
+
+test('verify() auto-builds the lib index from cwd node_modules', () => {
+  withProject(
+    { acme: '^1' },
+    { acme: { pkg: { name: 'acme', version: '9.9.9', types: 'index.d.ts' }, dts: 'export class Router {}' } },
+    (dir) => {
+      // No symbolSet/libSymbols override → verify must discover node_modules itself.
+      const res = verify('Use `Router()`.', dir, { version: '8.0.0' });
+      assert.strictEqual(res.summary.librariesIndexed, 1);
+      assert.ok(!res.issues.some((i) => i.type === 'fake-symbol' && i.value === 'Router'),
+        'auto lib index should recognize Router');
+    });
+});
+
+console.log(`\nlib-index: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 17,
-  "tests": 106,
+  "tests": 107,
   "metrics": {
     "hit_at_5": 0.867,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #405. Ships **v9.0 G5/D5 v1** — the private-API grounding moat. Per the Master Plan's §7.4, this is the single initiative worth ~80% of the B+→A climb, and it was zero-code until now.

## Summary
- SigMap can now verify AI suggestions against the libraries **actually installed** in `node_modules` — not just declared dependency *names*. Context7 knows only *public* docs; this grounds against the real installed tree, fully local/zero-dep/deterministic.

## Changes
- **`src/verify/lib-index.js` (new):** `buildLibraryIndex(cwd)` resolves direct deps from `package.json`, locates each under `node_modules/<dep>`, reads its version (**D8 pinning**) and entry `.d.ts` (`types`/`typings`, else `index.d.ts`), and extracts exported symbol names deterministically. Bounded (per-file + dep caps), cached via `src/cache/sig-cache.js`, graceful on missing/untyped/malformed packages.
- **`src/verify/hallucination-guard.js`:** `verify()` unions installed-library symbols into its known-symbol universe, so genuine library calls (`Router()`, `debounce()`) stop false-flagging as `fake-symbol`; the summary now reports `librariesIndexed` + `libraries` (`name@version`). Auto-runs from cwd `node_modules`; opt-out via `libIndex:false`; hermetic callers (explicit `symbolSet`) unchanged.
- Scope **v1: JS/TS `.d.ts`**. Python site-packages + a standalone `verify_suggestion` MCP tool deferred to a follow-up.

## Determinism note
Byte-stable **given a fixed installed tree** — the index reflects lockfile state, which is the point ("we verify against what is actually deployed here").

## Test plan
- [x] `node test/integration/lib-index.test.js` — 8/8 (parse forms · versions/D8 · sig-cache reuse · graceful degradation · before/after false-positive suppression · auto-build)
- [x] `node test/integration/all.js` — **101/101**
- [x] Bundle reproducible (134 modules); supply-chain local audit clean (no shell spawns · no install scripts · main exports API · no fingerprinting)