### PR TITLE
feat(mcp): verify_suggestion — ground agent suggestions against installed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 17 on-demand tools for Claude Code and Cursor:
+**MCP server** — 18 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,13 +1,13 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 17 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 18 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
       content: "SigMap MCP Server — on-demand codebase context"
   - - meta
     - property: og:description
-      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 17 MCP tools over stdio."
+      content: "Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. 18 MCP tools over stdio."
   - - meta
     - property: og:url
       content: "https://sigmap.io/guide/mcp"
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 17 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 18 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 17 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 18 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.
@@ -119,6 +119,7 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.15.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
 | `get_diff_context` | Returns every changed file (working tree, staged, or vs a base ref) with its current signatures + blast radius (importers, tests, routes) + risk label. Lists files shell-free. New in v8.0. | `base` (optional string), `staged` (optional bool), `depth` (optional number, default 2) | `get_diff_context(base="main")` |
 | `get_architecture_overview` | One-call codebase map: module breakdown (files/tokens), most-depended-on hub files, dependency-cycle count, route totals. Extends `get_map`. New in v8.0. | none | `get_architecture_overview()` |
+| `verify_suggestion` | Ground an AI code suggestion before writing it — verify a snippet against the repo **and the libraries actually installed** in `node_modules` (the grounding moat); flags fake files/imports/symbols/scripts and reports the installed libraries verified against with pinned versions. New in v8.2. | `code` (required string) | `verify_suggestion(code="const r = Router()")` |
 
 ## Token cost per tool call
 
@@ -149,7 +150,7 @@ Use `ask` to create `.context/query-context.md`, let the model answer, then run 
 
 ## Test the server
 
-Send a raw JSON-RPC request to confirm the server starts and returns all 17 tool definitions.
+Send a raw JSON-RPC request to confirm the server starts and returns all 18 tool definitions.
 
 ```bash
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node gen-context.js --mcp

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.46 (48.8% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 17 |
+| MCP tools | — | 18 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -127,7 +127,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 17 tools
+## MCP server — 18 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -269,6 +269,14 @@ A high-level map of the codebase in one call: module breakdown (files/tokens), t
 
 ```
 Input:  { } (no arguments)
+```
+
+### verify_suggestion
+
+Ground an AI code suggestion before writing it: verify a snippet or answer against the repository AND the libraries actually installed in node_modules (the grounding moat). Flags fake file paths, unresolvable imports, symbols absent from both the repo index and the installed libraries, and non-existent npm scripts — deterministic, offline, no LLM. Reports the installed libraries it verified against with pinned versions.
+
+```
+Input:  { code: string }
 ```
 
 ---

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.46 vs 2.84 baseline (48.8% fewer)
-- Languages: 33 supported · MCP tools: 17
+- Languages: 33 supported · MCP tools: 18
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/gen-context.js
+++ b/gen-context.js
@@ -12892,7 +12892,52 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     }
   }
 
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview };
+  /**
+   * verify_suggestion({ code }) → string
+   *
+   * Ground an AI code suggestion before it is written: run the Hallucination
+   * Guard against the repo AND the installed-library symbol index (the moat), and
+   * render a verdict + issues + the installed libraries verified against (pinned
+   * versions, D8). Deterministic, offline.
+   */
+  function verifySuggestion(args, cwd) {
+    const code = args && typeof args.code === 'string' ? args.code : '';
+    if (!code.trim()) {
+      return 'Usage: verify_suggestion({ code: "<AI-suggested code or answer>" }) — provide the snippet to verify against the repo + installed libraries.';
+    }
+
+    let result;
+    try {
+      const { verify } = __require('./src/verify/hallucination-guard');
+      result = verify(code, cwd);
+    } catch (err) {
+      return `_verify_suggestion failed: ${err.message}_`;
+    }
+
+    const { issues, summary } = result;
+    const out = [];
+    if (summary.clean) {
+      out.push('✓ Grounded — no fake files, imports, symbols, or scripts detected.');
+    } else {
+      out.push(`✗ ${summary.total} issue(s) found:`);
+      for (const i of issues) {
+        out.push(`  L${i.line}  [${i.type}]  ${i.message}`);
+        if (i.suggestion) out.push(`         ↳ ${i.suggestion}`);
+      }
+    }
+
+    // D8: report the installed libraries the suggestion was verified against.
+    const pins = (summary.libraries || []).filter((l) => l.version).map((l) => `${l.name}@${l.version}`);
+    const n = summary.librariesIndexed || 0;
+    out.push('');
+    out.push(
+      `Grounded against ${summary.symbolsIndexed} repo + library symbol(s)` +
+      (n ? ` · ${n} installed librar${n === 1 ? 'y' : 'ies'}${pins.length ? ': ' + pins.join(', ') : ''}` : '')
+    );
+    return out.join('\n');
+  }
+
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion };
   
 };
 
@@ -13053,13 +13098,13 @@ __factories["./src/mcp/server"] = function(module, exports) {
    *
    * Supported methods:
    *   initialize        → serverInfo + capabilities
-   *   tools/list        → 17 tool definitions
+   *   tools/list        → 18 tool definitions
    *   tools/call        → dispatch to handler, return result
    */
 
   const readline = require('readline');
   const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview } = __require('./src/mcp/handlers');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion } = __require('./src/mcp/handlers');
 
   const SERVER_INFO = {
     name: 'sigmap',
@@ -13128,6 +13173,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
         else if (name === 'sigmap_notify_file_deleted') text = notifyFileDeleted(args, cwd);
         else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
         else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
+        else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
         else {
           respondError(id, -32601, `Unknown tool: ${name}`);
           return;
@@ -13501,6 +13547,26 @@ __factories["./src/mcp/tools"] = function(module, exports) {
         type: 'object',
         properties: {},
         required: [],
+      },
+    },
+    {
+      name: 'verify_suggestion',
+      description:
+        'Ground an AI code suggestion before writing it: verify a snippet or answer against the ' +
+        'repository AND the libraries actually installed in node_modules (the grounding moat). ' +
+        'Flags fake file paths, unresolvable imports, symbols absent from both the repo index and ' +
+        'the installed libraries, and non-existent npm scripts — deterministic, offline, no LLM. ' +
+        'Reports the installed libraries it verified against with pinned versions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description:
+              'The AI-suggested code snippet or answer text to verify against the repo + installed libraries.',
+          },
+        },
+        required: ['code'],
       },
     },
   ];

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.46 (48.8% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 17 |
+| MCP tools | — | 18 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -127,7 +127,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 17 tools
+## MCP server — 18 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -269,6 +269,14 @@ A high-level map of the codebase in one call: module breakdown (files/tokens), t
 
 ```
 Input:  { } (no arguments)
+```
+
+### verify_suggestion
+
+Ground an AI code suggestion before writing it: verify a snippet or answer against the repository AND the libraries actually installed in node_modules (the grounding moat). Flags fake file paths, unresolvable imports, symbols absent from both the repo index and the installed libraries, and non-existent npm scripts — deterministic, offline, no LLM. Reports the installed libraries it verified against with pinned versions.
+
+```
+Input:  { code: string }
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.46 vs 2.84 baseline (48.8% fewer)
-- Languages: 33 supported · MCP tools: 17
+- Languages: 33 supported · MCP tools: 18
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -853,4 +853,49 @@ function getArchitectureOverview(args, cwd) {
   }
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview };
+/**
+ * verify_suggestion({ code }) → string
+ *
+ * Ground an AI code suggestion before it is written: run the Hallucination
+ * Guard against the repo AND the installed-library symbol index (the moat), and
+ * render a verdict + issues + the installed libraries verified against (pinned
+ * versions, D8). Deterministic, offline.
+ */
+function verifySuggestion(args, cwd) {
+  const code = args && typeof args.code === 'string' ? args.code : '';
+  if (!code.trim()) {
+    return 'Usage: verify_suggestion({ code: "<AI-suggested code or answer>" }) — provide the snippet to verify against the repo + installed libraries.';
+  }
+
+  let result;
+  try {
+    const { verify } = require('../verify/hallucination-guard');
+    result = verify(code, cwd);
+  } catch (err) {
+    return `_verify_suggestion failed: ${err.message}_`;
+  }
+
+  const { issues, summary } = result;
+  const out = [];
+  if (summary.clean) {
+    out.push('✓ Grounded — no fake files, imports, symbols, or scripts detected.');
+  } else {
+    out.push(`✗ ${summary.total} issue(s) found:`);
+    for (const i of issues) {
+      out.push(`  L${i.line}  [${i.type}]  ${i.message}`);
+      if (i.suggestion) out.push(`         ↳ ${i.suggestion}`);
+    }
+  }
+
+  // D8: report the installed libraries the suggestion was verified against.
+  const pins = (summary.libraries || []).filter((l) => l.version).map((l) => `${l.name}@${l.version}`);
+  const n = summary.librariesIndexed || 0;
+  out.push('');
+  out.push(
+    `Grounded against ${summary.symbolsIndexed} repo + library symbol(s)` +
+    (n ? ` · ${n} installed librar${n === 1 ? 'y' : 'ies'}${pins.length ? ': ' + pins.join(', ') : ''}` : '')
+  );
+  return out.join('\n');
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -8,13 +8,13 @@
  *
  * Supported methods:
  *   initialize        → serverInfo + capabilities
- *   tools/list        → 17 tool definitions
+ *   tools/list        → 18 tool definitions
  *   tools/call        → dispatch to handler, return result
  */
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -83,6 +83,7 @@ function dispatch(msg, cwd) {
       else if (name === 'sigmap_notify_file_deleted') text = notifyFileDeleted(args, cwd);
       else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
       else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
+      else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -316,6 +316,26 @@ const TOOLS = [
       required: [],
     },
   },
+  {
+    name: 'verify_suggestion',
+    description:
+      'Ground an AI code suggestion before writing it: verify a snippet or answer against the ' +
+      'repository AND the libraries actually installed in node_modules (the grounding moat). ' +
+      'Flags fake file paths, unresolvable imports, symbols absent from both the repo index and ' +
+      'the installed libraries, and non-existent npm scripts — deterministic, offline, no LLM. ' +
+      'Reports the installed libraries it verified against with pinned versions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description:
+            'The AI-suggested code snippet or answer text to verify against the repo + installed libraries.',
+        },
+      },
+      required: ['code'],
+    },
+  },
 ];
 
 module.exports = { TOOLS };

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 17 tools (not 12)', () => {
+test('mcp.md: description mentions 18 tools (not 12)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('17 tools'), 'missing "17 tools" in mcp.md');
+  assert.ok(src.includes('18 tools'), 'missing "18 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -77,9 +77,9 @@ test('version.json: extractors field is derived (>= languages)', () => {
   assert.ok(Number.isInteger(v.extractors) && v.extractors >= v.languages, `extractors=${v.extractors}`);
 });
 
-test('version.json: mcp_tools is 17', () => {
+test('version.json: mcp_tools is 18', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 17);
+  assert.strictEqual(v.mcp_tools, 18);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 17 tools including get_impact', () => {
+test('MCP tools/list: returns 18 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 17, `expected 17 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 18, `expected 18 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/diff-architecture-tools.test.js
+++ b/test/integration/mcp/diff-architecture-tools.test.js
@@ -61,12 +61,12 @@ function seedContext(dir) {
 
 // ── tools/list registration ────────────────────────────────────────────────
 
-test('tools/list registers 17 tools including both new ones', () => {
+test('tools/list registers 18 tools including both new ones', () => {
   withGitProject((dir) => {
     const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, dir);
     const tools = res.find((r) => r.id === 1).result.tools;
     assert.strictEqual(tools.length, TOOLS.length, 'server list matches TOOLS');
-    assert.strictEqual(tools.length, 17, 'exactly 17 tools');
+    assert.strictEqual(tools.length, 18, 'exactly 18 tools');
     assert.ok(tools.some((t) => t.name === 'get_diff_context'), 'get_diff_context registered');
     assert.ok(tools.some((t) => t.name === 'get_architecture_overview'), 'get_architecture_overview registered');
   });

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (17 tools total)', () => {
+test('get_lines is registered (18 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 17, `expected 17 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 18, `expected 18 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -101,12 +101,12 @@ test('initialize returns serverInfo', () => {
 // ─────────────────────────────────────────────────────────────
 // Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 17 tools', () => {
+test('tools/list returns exactly 18 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 17);
+    assert.strictEqual(res.result.tools.length, 18);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -83,12 +83,12 @@ function seedContextFile(dir) {
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 17 tools', () => {
+test('tools/list returns exactly 18 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 17, `Expected 17 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 18, `Expected 18 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/mcp/verify-suggestion.test.js
+++ b/test/integration/mcp/verify-suggestion.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * MCP tool: verify_suggestion (v8.2.0 — exposes the G5/D5 grounding moat to agents).
+ *
+ * Covers:
+ *   - registered in TOOLS with a required `code` input
+ *   - dirty code → fake symbols flagged, real installed-library calls NOT flagged
+ *   - clean code → clean verdict
+ *   - D8: reports the installed libraries verified against, with pinned versions
+ *   - missing/empty code → graceful usage message (no crash)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const { TOOLS } = require(path.join(ROOT, 'src', 'mcp', 'tools'));
+const { verifySuggestion } = require(path.join(ROOT, 'src', 'mcp', 'handlers'));
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (err) { console.log(`  FAIL  ${name}: ${err.message}`); failed++; }
+}
+
+/** Temp project with an installed typed dependency. */
+function withProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-vs-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'proj', dependencies: { acme: '^1' } }));
+    const lib = path.join(dir, 'node_modules', 'acme');
+    fs.mkdirSync(lib, { recursive: true });
+    fs.writeFileSync(path.join(lib, 'package.json'), JSON.stringify({ name: 'acme', version: '4.19.2', types: 'index.d.ts' }));
+    fs.writeFileSync(path.join(lib, 'index.d.ts'), 'export class Router {}\nexport declare function debounce(fn: any): any;');
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log('\nverify_suggestion MCP tool tests\n');
+
+test('verify_suggestion is registered in TOOLS with a required `code` input', () => {
+  const tool = TOOLS.find((t) => t.name === 'verify_suggestion');
+  assert.ok(tool, 'verify_suggestion not in TOOLS');
+  assert.ok(tool.description && /installed|librar/i.test(tool.description), 'description should mention installed libraries');
+  assert.deepStrictEqual(tool.inputSchema.required, ['code']);
+  assert.ok(tool.inputSchema.properties.code, 'code property missing');
+});
+
+test('dirty code: fake symbol flagged, real installed-library call NOT flagged', () => {
+  withProject((dir) => {
+    const out = verifySuggestion({ code: 'Use `Router()` and `notReal()` from acme.' }, dir);
+    assert.ok(/✗/.test(out), 'should report a verdict of issues');
+    assert.ok(/notReal/.test(out), 'the fake symbol should be flagged');
+    assert.ok(!/fake-symbol\]\s+Symbol not found in repo index: Router/.test(out), 'real library call Router must not be flagged');
+  });
+});
+
+test('clean code (only real library calls) → clean verdict', () => {
+  withProject((dir) => {
+    const out = verifySuggestion({ code: 'Use `Router()` and `debounce(fn)`.' }, dir);
+    assert.ok(/✓ Grounded/.test(out), `expected clean verdict, got: ${out}`);
+  });
+});
+
+test('D8: reports installed libraries verified against, with pinned versions', () => {
+  withProject((dir) => {
+    const out = verifySuggestion({ code: 'Use `Router()`.' }, dir);
+    assert.ok(/1 installed library/.test(out), 'should report the installed-library count');
+    assert.ok(/acme@4\.19\.2/.test(out), 'should pin the library version (D8)');
+  });
+});
+
+test('missing / empty code → graceful usage message', () => {
+  withProject((dir) => {
+    assert.ok(/Usage: verify_suggestion/.test(verifySuggestion({}, dir)));
+    assert.ok(/Usage: verify_suggestion/.test(verifySuggestion({ code: '   ' }, dir)));
+  });
+});
+
+console.log(`\nverify_suggestion: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 17);
+  assert.strictEqual(tools.length, 18);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 17 tools including query_context', () => {
+test('MCP tools/list: returns 18 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 17, `expected 17 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 18, `expected 18 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "benchmark_id": "sigmap-v8.1-main",
   "languages": 33,
   "extractors": 42,
-  "mcp_tools": 17,
-  "tests": 107,
+  "mcp_tools": 18,
+  "tests": 108,
   "metrics": {
     "hit_at_5": 0.867,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #409. Exposes the v8.1.0 grounding moat (G5/D5) to agents as the **18th MCP tool**, so a coding agent can verify its own generated code against the repo **and the libraries actually installed** in `node_modules` — before it writes.

## Summary
- Delivers the D5 "verify AI calls against repo + private + installed-lib symbols" capability to the consumer (agents), per the positioning that agents *consume* SigMap's grounding.

## Changes
- **`src/mcp/tools.js`**: `verify_suggestion` definition (input: `code`, required).
- **`src/mcp/handlers.js`**: `verifySuggestion(args, cwd)` reuses the shipped `verify()` (which already grounds against installed-library symbols) and renders a verdict + one line per issue (type · line · message · suggestion) + a **D8** line: `Grounded against N installed libraries: name@version`. Graceful on missing/empty `code`.
- **`src/mcp/server.js`**: dispatch wired; header 17 → 18.
- **Tool-count surfaces → 18**: nine guarded tests, README, `docs-vp/guide/mcp.md` (+ new tool row), `version.json` `mcp_tools`, `llms.txt`/`llms-full.txt` regenerated.

## Test plan
- [x] `node test/integration/mcp/verify-suggestion.test.js` — 5/5 (registration · dirty flags fake / passes real lib call · clean verdict · D8 version pins · graceful missing-arg)
- [x] `node test/integration/all.js` — **102/102**
- [x] Bundle reproducible (134 modules); `check:metrics` green (mcp_tools=18); supply-chain audit clean