### PR TITLE
feat(review): PR Evidence Report — branded Markdown diff evidence (G3)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -105,7 +105,8 @@ sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (re
 sigmap conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
 sigmap scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
 sigmap verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
-sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
+sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)

--- a/gen-context.js
+++ b/gen-context.js
@@ -14610,6 +14610,149 @@ __factories["./src/retrieval/tokenizer"] = function(module, exports) {
   
 };
 
+// ── ./src/review/pr-evidence ──
+__factories["./src/review/pr-evidence"] = function(module, exports) {
+  
+  /**
+   * PR Evidence Report (v9.0 G3).
+   *
+   * A single, branded, deterministic Markdown artifact for code review: for each
+   * changed file it folds together the signature context, blast radius (direct /
+   * transitive importers, impacted tests + routes), cross-language related tests,
+   * a risk label, and the `review-pr` findings (scope drift, god-node edits,
+   * missing tests, security-sensitive files). Posted as a PR comment, it answers
+   * "what changed, what it touches, and what to test" — without an LLM.
+   *
+   * Built entirely from shipped zero-dep modules (reviewPr, graph/impact,
+   * evidence/pack, extractors/dispatch). Carries NO wall-clock timestamp, so the
+   * report is byte-stable given a fixed tree — diff-friendly as a comment.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { reviewPr } = __require('./src/review/review-pr');
+
+  /**
+   * Build the structured PR evidence for a changed-file list.
+   * @param {Array<{path:string,status?:string}>|string[]} changedFiles
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {number} [opts.depth=2]   blast-radius BFS depth
+   * @param {string} [opts.scope]     label for the diff scope (e.g. "vs main")
+   * @returns {{ scope:string, files:object[], review:object }}
+   */
+  function buildPrEvidence(changedFiles, cwd, opts = {}) {
+    const files = (changedFiles || []).map((f) =>
+      typeof f === 'string' ? { path: f, status: 'M' } : { path: f.path, status: f.status || 'M' });
+
+    const review = reviewPr(files, cwd, opts);
+
+    let riskLabelFor = () => 'source';
+    let findRelatedTests = () => [];
+    try { ({ riskLabelFor, findRelatedTests } = __require('./src/evidence/pack')); } catch (_) { /* defaults */ }
+    const { extractFile, langFor } = __require('./src/extractors/dispatch');
+
+    let allFiles = [];
+    try { const { buildSigIndex } = __require('./src/retrieval/ranker'); allFiles = [...buildSigIndex(cwd).keys()]; } catch (_) { /* no index */ }
+
+    const depth = Number.isFinite(opts.depth) ? opts.depth : 2;
+    const srcPaths = files.filter((f) => f.status !== 'D' && langFor(f.path)).map((f) => f.path);
+    let impactByFile = new Map();
+    try {
+      const { analyzeImpact } = __require('./src/graph/impact');
+      impactByFile = new Map(analyzeImpact(srcPaths, cwd, { depth }).map((r) => [r.file, r.impact]));
+    } catch (_) { /* graph optional */ }
+
+    const fileReports = files.map((f) => {
+      const deleted = f.status === 'D';
+      let signatures = [];
+      if (!deleted && langFor(f.path)) {
+        try { signatures = extractFile(f.path, fs.readFileSync(path.resolve(cwd, f.path), 'utf8')); } catch (_) { /* unreadable */ }
+      }
+      const impact = impactByFile.get(f.path) || null;
+      return {
+        path: f.path,
+        status: f.status,
+        riskLabel: riskLabelFor(f.path),
+        signatures,
+        blast: impact ? {
+          total: impact.totalImpact,
+          direct: impact.direct || [],
+          transitive: (impact.transitive || []).length,
+          tests: impact.tests || [],
+          routes: impact.routes || [],
+        } : null,
+        relatedTests: deleted ? [] : findRelatedTests(f.path, allFiles),
+      };
+    });
+
+    return { scope: opts.scope || 'diff', files: fileReports, review };
+  }
+
+  const STATUS_LABEL = { M: 'modified', A: 'added', D: 'deleted', R: 'renamed', C: 'copied' };
+
+  /** Render the branded, deterministic "PR Evidence Report" Markdown. */
+  function formatPrEvidenceMarkdown(evidence, opts = {}) {
+    const L = [];
+    const s = evidence.review.summary;
+    const maxSigs = Number.isFinite(opts.maxSignatures) ? opts.maxSignatures : 30;
+
+    L.push('## 🔍 PR Evidence Report');
+    L.push('');
+    L.push(
+      `**${s.filesChanged} file(s) changed** — ${s.sourceChanged} source, ${s.testsChanged} test · ` +
+      (s.ok ? '✅ no review findings' : `⚠️ ${s.findings} finding(s)`) +
+      ` · scope: ${evidence.scope}`
+    );
+    L.push('');
+
+    if (!s.ok) {
+      L.push('### Review findings');
+      for (const f of evidence.review.findings) {
+        if (f.type === 'missing-tests') L.push(`- ⚠️ **missing tests** — \`${f.file}\` changed with no matching test`);
+        else if (f.type === 'security-file') L.push(`- ⚠️ **security-sensitive file** — \`${f.file}\``);
+        else if (f.type === 'god-node') L.push(`- ⚠️ **god node** — \`${f.file}\` → ${f.count} dependents (high blast radius)`);
+        else if (f.type === 'scope-drift') L.push(`- ⚠️ **scope drift** — ${f.count} top-level dirs touched (${f.dirs.join(', ')})`);
+      }
+      L.push('');
+    }
+
+    L.push('### Changed files');
+    for (const f of evidence.files) {
+      const st = STATUS_LABEL[f.status] || f.status;
+      L.push(`#### \`${f.path}\`  _(${st} · risk: ${f.riskLabel})_`);
+      if (f.status === 'D') { L.push('_deleted_', ''); continue; }
+
+      if (f.blast) {
+        L.push(
+          `**Blast radius:** ${f.blast.total} file(s) impacted — ${f.blast.direct.length} direct, ${f.blast.transitive} transitive` +
+          (f.blast.tests.length ? `, ${f.blast.tests.length} test(s)` : '') +
+          (f.blast.routes.length ? `, ${f.blast.routes.length} route(s)` : '')
+        );
+        if (f.blast.tests.length) L.push(`Tests to run: ${f.blast.tests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
+      } else {
+        L.push('**Blast radius:** _(not in dependency graph — new or leaf file)_');
+      }
+      if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
+
+      if (f.signatures.length) {
+        L.push('```');
+        for (const sig of f.signatures.slice(0, maxSigs)) L.push(sig);
+        if (f.signatures.length > maxSigs) L.push(`… +${f.signatures.length - maxSigs} more`);
+        L.push('```');
+      }
+      L.push('');
+    }
+
+    L.push('---');
+    L.push('_Deterministic PR Evidence Report — generated by [SigMap](https://sigmap.io). No LLM; byte-stable given a fixed tree._');
+    return L.join('\n');
+  }
+
+  module.exports = { buildPrEvidence, formatPrEvidenceMarkdown };
+  
+};
+
 // ── ./src/review/review-pr ──
 __factories["./src/review/review-pr"] = function(module, exports) {
   
@@ -19232,7 +19375,8 @@ Usage:
   ${cmd} conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
   ${cmd} scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
   ${cmd} verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
-  ${cmd} review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+  ${cmd} review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
+  ${cmd} review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
   ${cmd} create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
   ${cmd} squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
   ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
@@ -21172,6 +21316,15 @@ function main() {
       const file = parts[parts.length - 1]; // rename → new path
       return { path: file, status };
     });
+
+    // --markdown / --evidence: emit the branded, deterministic PR Evidence Report.
+    if (args.includes('--markdown') || args.includes('--evidence')) {
+      const { buildPrEvidence, formatPrEvidenceMarkdown } = requireSourceOrBundled('./src/review/pr-evidence');
+      const scope = staged ? 'staged' : (baseArg ? `vs ${baseArg}` : 'branch');
+      const ev = buildPrEvidence(changedFiles, cwd, { scope });
+      process.stdout.write(formatPrEvidenceMarkdown(ev) + '\n');
+      process.exit(ev.review.summary.ok ? 0 : 1);
+    }
 
     const { reviewPr } = requireSourceOrBundled('./src/review/review-pr');
     const result = reviewPr(changedFiles, cwd, {});

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -105,7 +105,8 @@ sigmap verify-ai-output <answer.md> --report  Write a standalone HTML report (re
 sigmap conventions                       Extract repo file-naming/export/test conventions (--conflicts, --inject, --report, --fix)
 sigmap scaffold "<name>"                 Propose a convention-matched file/dir scaffold (--ext, --threshold, --force, --json)
 sigmap verify-plan <plan.md|->           Check a plan vs the live index — files/symbols exist, blast radius, scope (--json)
-sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --json)
+sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
+sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)

--- a/src/review/pr-evidence.js
+++ b/src/review/pr-evidence.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * PR Evidence Report (v9.0 G3).
+ *
+ * A single, branded, deterministic Markdown artifact for code review: for each
+ * changed file it folds together the signature context, blast radius (direct /
+ * transitive importers, impacted tests + routes), cross-language related tests,
+ * a risk label, and the `review-pr` findings (scope drift, god-node edits,
+ * missing tests, security-sensitive files). Posted as a PR comment, it answers
+ * "what changed, what it touches, and what to test" — without an LLM.
+ *
+ * Built entirely from shipped zero-dep modules (reviewPr, graph/impact,
+ * evidence/pack, extractors/dispatch). Carries NO wall-clock timestamp, so the
+ * report is byte-stable given a fixed tree — diff-friendly as a comment.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { reviewPr } = require('./review-pr');
+
+/**
+ * Build the structured PR evidence for a changed-file list.
+ * @param {Array<{path:string,status?:string}>|string[]} changedFiles
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {number} [opts.depth=2]   blast-radius BFS depth
+ * @param {string} [opts.scope]     label for the diff scope (e.g. "vs main")
+ * @returns {{ scope:string, files:object[], review:object }}
+ */
+function buildPrEvidence(changedFiles, cwd, opts = {}) {
+  const files = (changedFiles || []).map((f) =>
+    typeof f === 'string' ? { path: f, status: 'M' } : { path: f.path, status: f.status || 'M' });
+
+  const review = reviewPr(files, cwd, opts);
+
+  let riskLabelFor = () => 'source';
+  let findRelatedTests = () => [];
+  try { ({ riskLabelFor, findRelatedTests } = require('../evidence/pack')); } catch (_) { /* defaults */ }
+  const { extractFile, langFor } = require('../extractors/dispatch');
+
+  let allFiles = [];
+  try { const { buildSigIndex } = require('../retrieval/ranker'); allFiles = [...buildSigIndex(cwd).keys()]; } catch (_) { /* no index */ }
+
+  const depth = Number.isFinite(opts.depth) ? opts.depth : 2;
+  const srcPaths = files.filter((f) => f.status !== 'D' && langFor(f.path)).map((f) => f.path);
+  let impactByFile = new Map();
+  try {
+    const { analyzeImpact } = require('../graph/impact');
+    impactByFile = new Map(analyzeImpact(srcPaths, cwd, { depth }).map((r) => [r.file, r.impact]));
+  } catch (_) { /* graph optional */ }
+
+  const fileReports = files.map((f) => {
+    const deleted = f.status === 'D';
+    let signatures = [];
+    if (!deleted && langFor(f.path)) {
+      try { signatures = extractFile(f.path, fs.readFileSync(path.resolve(cwd, f.path), 'utf8')); } catch (_) { /* unreadable */ }
+    }
+    const impact = impactByFile.get(f.path) || null;
+    return {
+      path: f.path,
+      status: f.status,
+      riskLabel: riskLabelFor(f.path),
+      signatures,
+      blast: impact ? {
+        total: impact.totalImpact,
+        direct: impact.direct || [],
+        transitive: (impact.transitive || []).length,
+        tests: impact.tests || [],
+        routes: impact.routes || [],
+      } : null,
+      relatedTests: deleted ? [] : findRelatedTests(f.path, allFiles),
+    };
+  });
+
+  return { scope: opts.scope || 'diff', files: fileReports, review };
+}
+
+const STATUS_LABEL = { M: 'modified', A: 'added', D: 'deleted', R: 'renamed', C: 'copied' };
+
+/** Render the branded, deterministic "PR Evidence Report" Markdown. */
+function formatPrEvidenceMarkdown(evidence, opts = {}) {
+  const L = [];
+  const s = evidence.review.summary;
+  const maxSigs = Number.isFinite(opts.maxSignatures) ? opts.maxSignatures : 30;
+
+  L.push('## 🔍 PR Evidence Report');
+  L.push('');
+  L.push(
+    `**${s.filesChanged} file(s) changed** — ${s.sourceChanged} source, ${s.testsChanged} test · ` +
+    (s.ok ? '✅ no review findings' : `⚠️ ${s.findings} finding(s)`) +
+    ` · scope: ${evidence.scope}`
+  );
+  L.push('');
+
+  if (!s.ok) {
+    L.push('### Review findings');
+    for (const f of evidence.review.findings) {
+      if (f.type === 'missing-tests') L.push(`- ⚠️ **missing tests** — \`${f.file}\` changed with no matching test`);
+      else if (f.type === 'security-file') L.push(`- ⚠️ **security-sensitive file** — \`${f.file}\``);
+      else if (f.type === 'god-node') L.push(`- ⚠️ **god node** — \`${f.file}\` → ${f.count} dependents (high blast radius)`);
+      else if (f.type === 'scope-drift') L.push(`- ⚠️ **scope drift** — ${f.count} top-level dirs touched (${f.dirs.join(', ')})`);
+    }
+    L.push('');
+  }
+
+  L.push('### Changed files');
+  for (const f of evidence.files) {
+    const st = STATUS_LABEL[f.status] || f.status;
+    L.push(`#### \`${f.path}\`  _(${st} · risk: ${f.riskLabel})_`);
+    if (f.status === 'D') { L.push('_deleted_', ''); continue; }
+
+    if (f.blast) {
+      L.push(
+        `**Blast radius:** ${f.blast.total} file(s) impacted — ${f.blast.direct.length} direct, ${f.blast.transitive} transitive` +
+        (f.blast.tests.length ? `, ${f.blast.tests.length} test(s)` : '') +
+        (f.blast.routes.length ? `, ${f.blast.routes.length} route(s)` : '')
+      );
+      if (f.blast.tests.length) L.push(`Tests to run: ${f.blast.tests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
+    } else {
+      L.push('**Blast radius:** _(not in dependency graph — new or leaf file)_');
+    }
+    if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
+
+    if (f.signatures.length) {
+      L.push('```');
+      for (const sig of f.signatures.slice(0, maxSigs)) L.push(sig);
+      if (f.signatures.length > maxSigs) L.push(`… +${f.signatures.length - maxSigs} more`);
+      L.push('```');
+    }
+    L.push('');
+  }
+
+  L.push('---');
+  L.push('_Deterministic PR Evidence Report — generated by [SigMap](https://sigmap.io). No LLM; byte-stable given a fixed tree._');
+  return L.join('\n');
+}
+
+module.exports = { buildPrEvidence, formatPrEvidenceMarkdown };

--- a/test/integration/review-pr.test.js
+++ b/test/integration/review-pr.test.js
@@ -14,6 +14,7 @@ const { spawnSync, execFileSync } = require('child_process');
 const ROOT = path.resolve(__dirname, '../..');
 const SCRIPT = path.join(ROOT, 'gen-context.js');
 const { reviewPr } = require(path.join(ROOT, 'src/review/review-pr'));
+const { buildPrEvidence, formatPrEvidenceMarkdown } = require(path.join(ROOT, 'src/review/pr-evidence'));
 
 let passed = 0, failed = 0;
 function test(name, fn) {
@@ -112,6 +113,56 @@ test('CLI: review-pr --json emits the result', () => {
     const data = JSON.parse(res.stdout.trim().split('\n').pop());
     assert.ok(data.summary);
     assert.ok(Array.isArray(data.findings));
+  });
+});
+
+// ── PR Evidence Report (G3) ─────────────────────────────────────────────────
+
+/** Temp project with source files for signatures + blast radius. */
+function withSrcProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prev-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({ srcDirs: ['src'] }));
+    fs.writeFileSync(path.join(dir, 'src', 'auth.js'), 'function login(u, p) { return true; }\nmodule.exports = { login };\n');
+    fs.writeFileSync(path.join(dir, 'src', 'consumer.js'), 'const { login } = require("./auth");\nmodule.exports = () => login("a", "b");\n');
+    fn(dir);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+test('buildPrEvidence returns per-file structure + review', () => {
+  withSrcProject((dir) => {
+    const ev = buildPrEvidence([{ path: 'src/auth.js', status: 'M' }], dir, { scope: 'vs main' });
+    const a = ev.files.find((f) => f.path === 'src/auth.js');
+    assert.ok(a, 'auth.js entry missing');
+    assert.strictEqual(a.riskLabel, 'auth');
+    assert.ok(a.signatures.length >= 1, 'expected extracted signatures');
+    assert.ok(a.blast && a.blast.total >= 1, 'expected blast radius (consumer imports auth)');
+    assert.ok(ev.review && ev.review.summary, 'expected review summary');
+    assert.strictEqual(ev.scope, 'vs main');
+  });
+});
+
+test('formatPrEvidenceMarkdown is branded, deterministic, timestamp-free', () => {
+  withSrcProject((dir) => {
+    const md1 = formatPrEvidenceMarkdown(buildPrEvidence([{ path: 'src/auth.js', status: 'M' }], dir, { scope: 'vs main' }));
+    const md2 = formatPrEvidenceMarkdown(buildPrEvidence([{ path: 'src/auth.js', status: 'M' }], dir, { scope: 'vs main' }));
+    assert.strictEqual(md1, md2, 'report is not byte-stable');
+    assert.ok(/^## 🔍 PR Evidence Report/.test(md1), 'missing branded header');
+    assert.ok(/Blast radius:/.test(md1), 'missing blast radius');
+    assert.ok(!/\d{4}-\d\d-\d\dT/.test(md1), 'report contains a wall-clock timestamp');
+  });
+});
+
+test('CLI: review-pr --markdown emits the PR Evidence Report', () => {
+  withGitRepo((dir, g) => {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'auth.js'), 'function login(u, p) { return true; }\nmodule.exports = { login };\n');
+    g(['add', '-A']);
+    const res = spawnSync('node', [SCRIPT, 'review-pr', '--markdown', '--staged'], { cwd: dir, encoding: 'utf8' });
+    assert.ok(/## 🔍 PR Evidence Report/.test(res.stdout), res.stdout + res.stderr);
+    assert.ok(/`src\/auth\.js`/.test(res.stdout), 'changed file not in report');
+    assert.strictEqual(res.status, 1, 'auth.js with no test → finding → exit 1');
   });
 });
 


### PR DESCRIPTION
Closes #417. Ships **v9.0 G3** — a single, deterministic, machine-consumable review artifact posted as a PR comment.

## What it does
For each changed file, folds together: **signatures** + **blast radius** (direct/transitive importers, impacted tests + routes) + cross-language **related tests** + a **risk label** + the **review-pr findings** (scope drift, god-node, missing tests, security files) — rendered as a branded **"🔍 PR Evidence Report"** Markdown block. Answers *"what changed, what it touches, and what to test"* — no LLM.

## Changes
- **`src/review/pr-evidence.js` (new)**: `buildPrEvidence(changedFiles, cwd)` → structured per-file evidence + review summary; `formatPrEvidenceMarkdown` → the branded report. Reuses `reviewPr`, `graph/impact`, `evidence/pack` (`riskLabelFor` + `findRelatedTests`), `extractors/dispatch`. **No wall-clock timestamp** → byte-stable given a fixed tree (diff-friendly as a comment).
- **CLI**: `sigmap review-pr --markdown` (alias `--evidence`) emits the report; honors `--staged`/`--base`; exit code reflects review pass/fail so CI can gate. Logic lives in the bundled `src/` module; the CLI handler just calls it (git stays behind the existing shell-free `__tryGit`).

## Test plan
- [x] `node test/integration/review-pr.test.js` — 13/13 (3 new: structure · deterministic+branded+timestamp-free · CLI `--markdown`)
- [x] `node test/integration/all.js` — **102/102**
- [x] Bundle reproducible (135 modules); `check:metrics` green; supply-chain audit clean (no shell/spawn in the module · main exports API · no fingerprinting)