### PR TITLE
feat(retrieval): deterministic query expansion — vocabulary-mismatch recall aid

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -13923,6 +13923,78 @@ __factories["./src/retrieval/bm25"] = function(module, exports) {
   // are counted PATH_BOOST times when building the document term-frequency map.
   const PATH_BOOST = 3;
 
+  // Curated, high-precision code-domain synonym / abbreviation expansions. A query
+  // for `authentication` should still surface a file whose signatures only say
+  // `auth`. Kept deliberately tight — over-broad synonyms hurt precision. Groups
+  // are expanded bidirectionally (every member maps to the others). Values are
+  // tokenized+stemmed at load, so entries are written in natural form.
+  const EXPANSION_GROUPS = [
+    ['auth', 'authenticate', 'authentication', 'login', 'signin', 'credential'],
+    ['authorize', 'authorization', 'permission', 'access'],
+    ['config', 'configuration', 'settings', 'options'],
+    ['db', 'database'],
+    ['ctx', 'context'],
+    ['req', 'request'],
+    ['res', 'response'],
+    ['err', 'error'],
+    ['msg', 'message'],
+    ['init', 'initialize', 'initialization', 'setup'],
+    ['async', 'asynchronous'],
+    ['sync', 'synchronize', 'synchronous'],
+    ['repo', 'repository'],
+    ['impl', 'implementation'],
+    ['util', 'utility', 'helper'],
+    ['param', 'parameter', 'argument'],
+    ['fn', 'func', 'function'],
+    ['btn', 'button'],
+    ['calc', 'calculate', 'calculation'],
+    ['gen', 'generate', 'generator'],
+    ['val', 'validate', 'validation'],
+    ['del', 'delete', 'remove'],
+    ['dir', 'directory', 'folder'],
+    ['env', 'environment'],
+    ['doc', 'document', 'documentation'],
+    ['id', 'identifier'],
+    ['num', 'number'],
+    ['str', 'string'],
+  ];
+
+  // The weight applied to an expanded (synonym) query term, so an exact match on
+  // the literal query token always outranks a synonym-only match.
+  const EXPANSION_WEIGHT = 0.15;
+
+  // Build a stemmed lookup: stem(member) → Set of the group's other stemmed members.
+  const EXPANSIONS = (() => {
+    const map = new Map();
+    for (const group of EXPANSION_GROUPS) {
+      const stemmed = [...new Set(group.map((w) => tokenize(w).join('')).filter(Boolean))];
+      for (const s of stemmed) {
+        if (!map.has(s)) map.set(s, new Set());
+        for (const other of stemmed) if (other !== s) map.get(s).add(other);
+      }
+    }
+    return map;
+  })();
+
+  /**
+   * Expand stemmed query tokens with curated synonyms. Returns a Map of
+   * token → weight (1 for the original query tokens, EXPANSION_WEIGHT for
+   * synonyms). Original tokens always keep full weight even if also a synonym.
+   *
+   * @param {string[]} qToks  stemmed, de-duplicated query tokens
+   * @returns {Map<string, number>}
+   */
+  function expandQuery(qToks) {
+    const weights = new Map();
+    for (const t of qToks) weights.set(t, 1);
+    for (const t of qToks) {
+      const syns = EXPANSIONS.get(t);
+      if (!syns) continue;
+      for (const s of syns) if (!weights.has(s)) weights.set(s, EXPANSION_WEIGHT);
+    }
+    return weights;
+  }
+
   /**
    * BM25 re-rank of candidates against a query. Each candidate is
    * `{ file, sigs }`; the returned objects preserve all original candidate
@@ -13958,23 +14030,24 @@ __factories["./src/retrieval/bm25"] = function(module, exports) {
     }
 
     const qToks = [...new Set(tokenize(query))];
+    const qWeights = expandQuery(qToks); // token → weight (1 exact, <1 synonym)
 
     return docs
       .map((d) => {
         let score = 0;
-        for (const t of qToks) {
+        for (const [t, w] of qWeights) {
           const f = d.tf.get(t);
           if (!f) continue;
           const dfT = df.get(t);
           const idf = Math.log(1 + (N - dfT + 0.5) / (dfT + 0.5));
-          score += (idf * (f * (k1 + 1))) / (f + k1 * (1 - b + (b * d.len) / avgdl));
+          score += w * ((idf * (f * (k1 + 1))) / (f + k1 * (1 - b + (b * d.len) / avgdl)));
         }
         return Object.assign({}, d.cand, { score });
       })
       .sort((a, c) => c.score - a.score || String(a.file).localeCompare(String(c.file)));
   }
 
-  module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP };
+  module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT };
   
 };
 

--- a/src/retrieval/bm25.js
+++ b/src/retrieval/bm25.js
@@ -68,6 +68,78 @@ function tokenize(text) {
 // are counted PATH_BOOST times when building the document term-frequency map.
 const PATH_BOOST = 3;
 
+// Curated, high-precision code-domain synonym / abbreviation expansions. A query
+// for `authentication` should still surface a file whose signatures only say
+// `auth`. Kept deliberately tight — over-broad synonyms hurt precision. Groups
+// are expanded bidirectionally (every member maps to the others). Values are
+// tokenized+stemmed at load, so entries are written in natural form.
+const EXPANSION_GROUPS = [
+  ['auth', 'authenticate', 'authentication', 'login', 'signin', 'credential'],
+  ['authorize', 'authorization', 'permission', 'access'],
+  ['config', 'configuration', 'settings', 'options'],
+  ['db', 'database'],
+  ['ctx', 'context'],
+  ['req', 'request'],
+  ['res', 'response'],
+  ['err', 'error'],
+  ['msg', 'message'],
+  ['init', 'initialize', 'initialization', 'setup'],
+  ['async', 'asynchronous'],
+  ['sync', 'synchronize', 'synchronous'],
+  ['repo', 'repository'],
+  ['impl', 'implementation'],
+  ['util', 'utility', 'helper'],
+  ['param', 'parameter', 'argument'],
+  ['fn', 'func', 'function'],
+  ['btn', 'button'],
+  ['calc', 'calculate', 'calculation'],
+  ['gen', 'generate', 'generator'],
+  ['val', 'validate', 'validation'],
+  ['del', 'delete', 'remove'],
+  ['dir', 'directory', 'folder'],
+  ['env', 'environment'],
+  ['doc', 'document', 'documentation'],
+  ['id', 'identifier'],
+  ['num', 'number'],
+  ['str', 'string'],
+];
+
+// The weight applied to an expanded (synonym) query term, so an exact match on
+// the literal query token always outranks a synonym-only match.
+const EXPANSION_WEIGHT = 0.15;
+
+// Build a stemmed lookup: stem(member) → Set of the group's other stemmed members.
+const EXPANSIONS = (() => {
+  const map = new Map();
+  for (const group of EXPANSION_GROUPS) {
+    const stemmed = [...new Set(group.map((w) => tokenize(w).join('')).filter(Boolean))];
+    for (const s of stemmed) {
+      if (!map.has(s)) map.set(s, new Set());
+      for (const other of stemmed) if (other !== s) map.get(s).add(other);
+    }
+  }
+  return map;
+})();
+
+/**
+ * Expand stemmed query tokens with curated synonyms. Returns a Map of
+ * token → weight (1 for the original query tokens, EXPANSION_WEIGHT for
+ * synonyms). Original tokens always keep full weight even if also a synonym.
+ *
+ * @param {string[]} qToks  stemmed, de-duplicated query tokens
+ * @returns {Map<string, number>}
+ */
+function expandQuery(qToks) {
+  const weights = new Map();
+  for (const t of qToks) weights.set(t, 1);
+  for (const t of qToks) {
+    const syns = EXPANSIONS.get(t);
+    if (!syns) continue;
+    for (const s of syns) if (!weights.has(s)) weights.set(s, EXPANSION_WEIGHT);
+  }
+  return weights;
+}
+
 /**
  * BM25 re-rank of candidates against a query. Each candidate is
  * `{ file, sigs }`; the returned objects preserve all original candidate
@@ -103,20 +175,21 @@ function bm25rank(query, candidates) {
   }
 
   const qToks = [...new Set(tokenize(query))];
+  const qWeights = expandQuery(qToks); // token → weight (1 exact, <1 synonym)
 
   return docs
     .map((d) => {
       let score = 0;
-      for (const t of qToks) {
+      for (const [t, w] of qWeights) {
         const f = d.tf.get(t);
         if (!f) continue;
         const dfT = df.get(t);
         const idf = Math.log(1 + (N - dfT + 0.5) / (dfT + 0.5));
-        score += (idf * (f * (k1 + 1))) / (f + k1 * (1 - b + (b * d.len) / avgdl));
+        score += w * ((idf * (f * (k1 + 1))) / (f + k1 * (1 - b + (b * d.len) / avgdl)));
       }
       return Object.assign({}, d.cand, { score });
     })
     .sort((a, c) => c.score - a.score || String(a.file).localeCompare(String(c.file)));
 }
 
-module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP };
+module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT };

--- a/test/integration/bm25.test.js
+++ b/test/integration/bm25.test.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '../..');
-const { tokenize, stem, bm25rank, PATH_BOOST } =
+const { tokenize, stem, bm25rank, PATH_BOOST, expandQuery, EXPANSIONS, EXPANSION_WEIGHT } =
   require(path.join(ROOT, 'src', 'retrieval', 'bm25'));
 
 let passed = 0;
@@ -131,6 +131,54 @@ test('bm25rank: deterministic tie-break by file path', () => {
 
 test('bm25rank: empty candidate list returns empty array', () => {
   assert.deepStrictEqual(bm25rank('anything', []), []);
+});
+
+// ---------------------------------------------------------------------------
+// Query expansion (#421) — benchmark-neutral recall aid, deterministic
+// ---------------------------------------------------------------------------
+test('EXPANSIONS maps bidirectional code-domain synonyms (stemmed)', () => {
+  // `auth` and `database` resolve to their group members.
+  const authSyns = EXPANSIONS.get(stem('auth')) || new Set();
+  assert.ok(authSyns.has(stem('login')), 'auth should expand to login');
+  const dbSyns = EXPANSIONS.get(stem('db')) || new Set();
+  assert.ok(dbSyns.has(stem('database')), 'db should expand to database');
+  const dbBack = EXPANSIONS.get(stem('database')) || new Set();
+  assert.ok(dbBack.has('db'), 'database should expand back to db');
+});
+
+test('expandQuery: original tokens weight 1, synonyms weight < 1', () => {
+  const q = [...new Set(tokenize('database'))];
+  const w = expandQuery(q);
+  for (const t of q) assert.strictEqual(w.get(t), 1, `original ${t} must keep full weight`);
+  assert.strictEqual(w.get('db'), EXPANSION_WEIGHT, 'db (synonym) should carry the discount weight');
+  assert.ok(EXPANSION_WEIGHT > 0 && EXPANSION_WEIGHT < 1, 'discount weight in (0,1)');
+});
+
+test('a synonym query surfaces a file that only uses the abbreviation', () => {
+  const cands = [
+    { file: 'src/auth.js', sigs: ['function authGuard(token)', 'function login(user)'] },
+    { file: 'src/widget.js', sigs: ['function renderWidget(props)'] },
+  ];
+  const r = bm25rank('authentication', cands); // doc has no literal "authentication"
+  assert.strictEqual(r[0].file, 'src/auth.js', 'expansion should surface the auth file');
+  assert.ok(r[0].score > 0, 'expanded synonym should produce a non-zero score');
+});
+
+test('an exact-term match still outranks a synonym-only match', () => {
+  const cands = [
+    { file: 'src/exact.js', sigs: ['function authentication()'] }, // literal query term
+    { file: 'src/syn.js', sigs: ['function auth()'] },             // synonym only
+  ];
+  const r = bm25rank('authentication', cands);
+  assert.strictEqual(r[0].file, 'src/exact.js', 'exact term must win over synonym');
+  assert.ok(r[0].score > r[1].score, 'exact score strictly greater');
+});
+
+test('expansion is deterministic (identical scores across runs)', () => {
+  const cands = [{ file: 'src/config.js', sigs: ['function loadConfig()'] }];
+  const a = bm25rank('configuration', cands)[0].score;
+  const b = bm25rank('configuration', cands)[0].score;
+  assert.strictEqual(a, b);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #421. Adds a curated, deterministic synonym/abbreviation layer to the BM25 query tokens.

## ⚠️ Honest result: benchmark-neutral, not a hit@5 win
The plan targeted hit@5 86.7% → ~90%. **Measurement did not support that.** On the retrieval benchmark (run before/after), hit@5 stayed within the harness's **86.7–87.8% noise band** at weight 0.15; higher weights (0.25/0.35) **regressed** it. Per the plan's MEASURE-FIRST gate I shipped the **neutral** weight (0.15) and reframed the feature honestly:

- It is a **recall aid for vocabulary mismatch** — a real user typing `authentication` when the code says `auth`, or `database` for `db`. The curated benchmark queries already use code vocabulary, so they don't exercise this; the benefit is plausible but **unmeasured**, and it demonstrably **does not regress** the metric.

(Per maintainer decision, shipping the neutral configuration.)

## Changes
- **`src/retrieval/bm25.js`**: `EXPANSION_GROUPS` (tight, code-domain: auth/db/ctx/config/req/res/init/…) → stemmed bidirectional `EXPANSIONS`; `expandQuery()` adds synonyms at **weight 0.15** while originals keep weight 1, so exact matches always outrank synonym-only matches. Query-only; documents unchanged. Wired through the ranker (`ask`, `--query`, MCP `query_context`).

## Test plan
- [x] `node test/integration/bm25.test.js` — 17/17 (5 new: mapping · discounted weights · synonym-surfaces-abbrev · exact-beats-synonym · determinism)
- [x] `node test/integration/all.js` — 102/102
- [x] Retrieval benchmark: **no regression** at weight 0.15 (87.8% ≈ baseline)
- [x] Bundle reproducible (135 modules); supply-chain audit clean