### PR TITLE
feat(mcp): squeeze_output tool + squeeze --response (D6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 18 on-demand tools for Claude Code and Cursor:
+**MCP server** — 19 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp
 ```
 
-Tools: `read_context`, `search_signatures`, `get_map`, `create_checkpoint`, `get_routing`, `explain_file`, `list_modules`, `query_context`, `get_impact`, `get_lines`, `read_memory`, `get_callee_signatures`, `get_diff_context` (changed files + signatures + blast radius), `get_architecture_overview` (modules, hub files, cycles), plus the live-index notifications `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, and `sigmap_notify_file_deleted`. Full reference: [llms-full.txt](llms-full.txt).
+Tools: `read_context`, `search_signatures`, `get_map`, `create_checkpoint`, `get_routing`, `explain_file`, `list_modules`, `query_context`, `get_impact`, `get_lines`, `read_memory`, `get_callee_signatures`, `get_diff_context` (changed files + signatures + blast radius), `get_architecture_overview` (modules, hub files, cycles), `verify_suggestion` (ground AI code against repo + installed libraries), `squeeze_output` (compress noisy tool/log/JSON output mid-session), plus the live-index notifications `sigmap_notify_file_created`, `sigmap_notify_symbol_added`, and `sigmap_notify_file_deleted`. Full reference: [llms-full.txt](llms-full.txt).
 
 ---
 
@@ -265,7 +265,7 @@ SigMap treats coding agents as **consumers, not competitors**: it hands them a d
 
 | Agent | One-time setup | How it consumes SigMap |
 |---|---|---|
-| **Claude Code** | `sigmap mcp install claude` | 17 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`…) |
+| **Claude Code** | `sigmap mcp install claude` | 19 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`, `squeeze_output`…) |
 | **Cursor** | `sigmap mcp install cursor` | MCP tools, plus the `cursor` adapter writes `.cursorrules` |
 | **Cline** | `sigmap mcp install cursor` | Reads `.cursorrules`; same MCP server |
 | **Continue** | `sigmap mcp install vscode` | MCP tools inside the Continue extension |

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 18 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 19 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 18 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 19 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 18 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 19 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.
@@ -120,6 +120,7 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `get_diff_context` | Returns every changed file (working tree, staged, or vs a base ref) with its current signatures + blast radius (importers, tests, routes) + risk label. Lists files shell-free. New in v8.0. | `base` (optional string), `staged` (optional bool), `depth` (optional number, default 2) | `get_diff_context(base="main")` |
 | `get_architecture_overview` | One-call codebase map: module breakdown (files/tokens), most-depended-on hub files, dependency-cycle count, route totals. Extends `get_map`. New in v8.0. | none | `get_architecture_overview()` |
 | `verify_suggestion` | Ground an AI code suggestion before writing it — verify a snippet against the repo **and the libraries actually installed** in `node_modules` (the grounding moat); flags fake files/imports/symbols/scripts and reports the installed libraries verified against with pinned versions. New in v8.2. | `code` (required string) | `verify_suggestion(code="const r = Router()")` |
+| `squeeze_output` | Compress noisy tool/command/agent output — a stack trace, CI/build log, or JSON payload — before it enters context. Same deterministic, offline engine as `sigmap squeeze`: keeps the signal, strips the noise, enriches the top stack frame. Passes the input through unchanged when nothing is squeezable. New in v8.8. | `content` (required string) | `squeeze_output(content="Traceback…")` |
 
 ## Token cost per tool call
 

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.46 (48.8% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 18 |
+| MCP tools | — | 19 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -113,6 +113,7 @@ sigmap review-pr                         Audit a diff — scope drift, god-node 
 sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+sigmap squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
 sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
@@ -132,7 +133,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 18 tools
+## MCP server — 19 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -282,6 +283,14 @@ Ground an AI code suggestion before writing it: verify a snippet or answer again
 
 ```
 Input:  { code: string }
+```
+
+### squeeze_output
+
+Compress noisy tool, command, or agent output before it enters context — a stack trace, CI/build log, or JSON payload. Same deterministic, offline engine as `sigmap squeeze`: keeps the signal (error frames, failing steps, JSON shape), strips the noise, and enriches the top stack frame with its signature. Returns the squeezed text plus token-reduction stats; passes the input through unchanged when no squeezable structure is detected. No LLM, no network.
+
+```
+Input:  { content: string }
 ```
 
 ---

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.46 vs 2.84 baseline (48.8% fewer)
-- Languages: 33 supported · MCP tools: 18
+- Languages: 33 supported · MCP tools: 19
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/gen-context.js
+++ b/gen-context.js
@@ -13345,7 +13345,50 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     return out.join('\n');
   }
 
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion };
+  /**
+   * squeeze_output({ content }) → string
+   *
+   * Compress noisy tool/command/agent output (stack trace, CI/build log, or JSON
+   * payload) through the deterministic squeeze engine. Enriches the top stack
+   * frame with its signature when the symbol index is available. Passes the input
+   * through unchanged when no squeezable structure is detected.
+   */
+  function squeezeOutput(args, cwd) {
+    const content = args && typeof args.content === 'string' ? args.content : '';
+    if (!content.trim()) {
+      return 'Usage: squeeze_output({ content: "<raw tool/log/JSON output>" }) — provide the output to compress.';
+    }
+
+    let sq;
+    try {
+      const { squeeze } = __require('./src/squeeze/index');
+      let srcDirs;
+      let symbolIndex = null;
+      try {
+        const { loadConfig } = __require('./src/config/loader');
+        srcDirs = loadConfig(cwd).srcDirs;
+      } catch (_) {}
+      try {
+        const { buildSigIndex } = __require('./src/retrieval/ranker');
+        symbolIndex = buildSigIndex(cwd);
+      } catch (_) {}
+      sq = squeeze(content, { srcDirs, symbolIndex });
+    } catch (err) {
+      return `_squeeze_output failed: ${err.message}_`;
+    }
+
+    if (!sq.category || !sq.applies) {
+      return `No squeezable structure detected — content unchanged (${sq.rawTokens} tokens).\n\n${content}`;
+    }
+
+    const pct = Math.round(sq.reduction * 100);
+    const header =
+      `Squeezed ${sq.category} — ${sq.rawTokens} → ${sq.squeezedTokens} tokens ` +
+      `(${pct}% smaller)${sq.enriched ? ' · signature-enriched' : ''}\n\n`;
+    return header + sq.squeezed;
+  }
+
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
   
 };
 
@@ -13506,13 +13549,13 @@ __factories["./src/mcp/server"] = function(module, exports) {
    *
    * Supported methods:
    *   initialize        → serverInfo + capabilities
-   *   tools/list        → 18 tool definitions
+   *   tools/list        → 19 tool definitions
    *   tools/call        → dispatch to handler, return result
    */
 
   const readline = require('readline');
   const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion } = __require('./src/mcp/handlers');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = __require('./src/mcp/handlers');
 
   const SERVER_INFO = {
     name: 'sigmap',
@@ -13582,6 +13625,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
         else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
         else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
         else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
+        else if (name === 'squeeze_output') text = squeezeOutput(args, cwd);
         else {
           respondError(id, -32601, `Unknown tool: ${name}`);
           return;
@@ -13642,11 +13686,12 @@ __factories["./src/mcp/server"] = function(module, exports) {
 __factories["./src/mcp/tools"] = function(module, exports) {
   
   /**
-   * MCP tool definitions for SigMap (17 tools).
+   * MCP tool definitions for SigMap (19 tools).
    * read_context, search_signatures, get_map, create_checkpoint, get_routing,
    * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
    * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
-   * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview.
+   * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview,
+   * verify_suggestion, squeeze_output.
    */
 
   const TOOLS = [
@@ -13975,6 +14020,27 @@ __factories["./src/mcp/tools"] = function(module, exports) {
           },
         },
         required: ['code'],
+      },
+    },
+    {
+      name: 'squeeze_output',
+      description:
+        'Compress noisy tool, command, or agent output before it enters context — a stack ' +
+        'trace, CI/build log, or JSON payload. Same deterministic, offline engine as ' +
+        '`sigmap squeeze`: keeps the signal (error frames, failing steps, JSON shape), strips ' +
+        'the noise, and enriches the top stack frame with its signature. Returns the squeezed ' +
+        'text plus token-reduction stats; passes the input through unchanged when no squeezable ' +
+        'structure is detected. No LLM, no network.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            description:
+              'The raw output to compress (a stack trace, CI/build log, or JSON payload).',
+          },
+        },
+        required: ['content'],
       },
     },
   ];
@@ -19911,6 +19977,7 @@ Usage:
   ${cmd} review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
   ${cmd} create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
   ${cmd} squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+  ${cmd} squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
   ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
   ${cmd} ask "<query>" --no-squeeze        Disable input minimization entirely
   ${cmd} ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
@@ -21681,7 +21748,20 @@ function main() {
   // v7.0.0: `sigmap squeeze <file|->` — minimize a pasted stacktrace / CI-log / JSON blob
   if (args[0] === 'squeeze') {
     const jsonOut = args.includes('--json');
-    const target = args[1] && !args[1].startsWith('--') ? args[1] : '-';
+    // `--response <file|->` names the agent/tool response to squeeze explicitly
+    // (mirrors `sigmap judge --response`); otherwise fall back to the positional arg.
+    const respIdx = args.indexOf('--response');
+    let target;
+    if (respIdx !== -1) {
+      const val = args[respIdx + 1];
+      if (!val || val.startsWith('--')) {
+        console.error('[sigmap] Usage: sigmap squeeze --response <file|-> [--json]');
+        process.exit(1);
+      }
+      target = val;
+    } else {
+      target = args[1] && !args[1].startsWith('--') ? args[1] : '-';
+    }
     let input = '';
     try {
       input = fs.readFileSync(target === '-' ? 0 : path.resolve(cwd, target), 'utf8');

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.46 (48.8% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 18 |
+| MCP tools | — | 19 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -113,6 +113,7 @@ sigmap review-pr                         Audit a diff — scope drift, god-node 
 sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
+sigmap squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
 sigmap ask "<query>" --no-squeeze        Disable input minimization entirely
 sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 30)
@@ -132,7 +133,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 18 tools
+## MCP server — 19 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -282,6 +283,14 @@ Ground an AI code suggestion before writing it: verify a snippet or answer again
 
 ```
 Input:  { code: string }
+```
+
+### squeeze_output
+
+Compress noisy tool, command, or agent output before it enters context — a stack trace, CI/build log, or JSON payload. Same deterministic, offline engine as `sigmap squeeze`: keeps the signal (error frames, failing steps, JSON shape), strips the noise, and enriches the top stack frame with its signature. Returns the squeezed text plus token-reduction stats; passes the input through unchanged when no squeezable structure is detected. No LLM, no network.
+
+```
+Input:  { content: string }
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.46 vs 2.84 baseline (48.8% fewer)
-- Languages: 33 supported · MCP tools: 18
+- Languages: 33 supported · MCP tools: 19
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -898,4 +898,47 @@ function verifySuggestion(args, cwd) {
   return out.join('\n');
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion };
+/**
+ * squeeze_output({ content }) → string
+ *
+ * Compress noisy tool/command/agent output (stack trace, CI/build log, or JSON
+ * payload) through the deterministic squeeze engine. Enriches the top stack
+ * frame with its signature when the symbol index is available. Passes the input
+ * through unchanged when no squeezable structure is detected.
+ */
+function squeezeOutput(args, cwd) {
+  const content = args && typeof args.content === 'string' ? args.content : '';
+  if (!content.trim()) {
+    return 'Usage: squeeze_output({ content: "<raw tool/log/JSON output>" }) — provide the output to compress.';
+  }
+
+  let sq;
+  try {
+    const { squeeze } = require('../squeeze/index');
+    let srcDirs;
+    let symbolIndex = null;
+    try {
+      const { loadConfig } = require('../config/loader');
+      srcDirs = loadConfig(cwd).srcDirs;
+    } catch (_) {}
+    try {
+      const { buildSigIndex } = require('../retrieval/ranker');
+      symbolIndex = buildSigIndex(cwd);
+    } catch (_) {}
+    sq = squeeze(content, { srcDirs, symbolIndex });
+  } catch (err) {
+    return `_squeeze_output failed: ${err.message}_`;
+  }
+
+  if (!sq.category || !sq.applies) {
+    return `No squeezable structure detected — content unchanged (${sq.rawTokens} tokens).\n\n${content}`;
+  }
+
+  const pct = Math.round(sq.reduction * 100);
+  const header =
+    `Squeezed ${sq.category} — ${sq.rawTokens} → ${sq.squeezedTokens} tokens ` +
+    `(${pct}% smaller)${sq.enriched ? ' · signature-enriched' : ''}\n\n`;
+  return header + sq.squeezed;
+}
+
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -8,13 +8,13 @@
  *
  * Supported methods:
  *   initialize        → serverInfo + capabilities
- *   tools/list        → 18 tool definitions
+ *   tools/list        → 19 tool definitions
  *   tools/call        → dispatch to handler, return result
  */
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -84,6 +84,7 @@ function dispatch(msg, cwd) {
       else if (name === 'get_diff_context') text = getDiffContext(args, cwd);
       else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
       else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
+      else if (name === 'squeeze_output') text = squeezeOutput(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,11 +1,12 @@
 'use strict';
 
 /**
- * MCP tool definitions for SigMap (17 tools).
+ * MCP tool definitions for SigMap (19 tools).
  * read_context, search_signatures, get_map, create_checkpoint, get_routing,
  * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
  * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
- * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview.
+ * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview,
+ * verify_suggestion, squeeze_output.
  */
 
 const TOOLS = [
@@ -334,6 +335,27 @@ const TOOLS = [
         },
       },
       required: ['code'],
+    },
+  },
+  {
+    name: 'squeeze_output',
+    description:
+      'Compress noisy tool, command, or agent output before it enters context — a stack ' +
+      'trace, CI/build log, or JSON payload. Same deterministic, offline engine as ' +
+      '`sigmap squeeze`: keeps the signal (error frames, failing steps, JSON shape), strips ' +
+      'the noise, and enriches the top stack frame with its signature. Returns the squeezed ' +
+      'text plus token-reduction stats; passes the input through unchanged when no squeezable ' +
+      'structure is detected. No LLM, no network.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content: {
+          type: 'string',
+          description:
+            'The raw output to compress (a stack trace, CI/build log, or JSON payload).',
+        },
+      },
+      required: ['content'],
     },
   },
 ];

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 18 tools (not 12)', () => {
+test('mcp.md: description mentions 19 tools (not 12)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('18 tools'), 'missing "18 tools" in mcp.md');
+  assert.ok(src.includes('19 tools'), 'missing "19 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -77,9 +77,9 @@ test('version.json: extractors field is derived (>= languages)', () => {
   assert.ok(Number.isInteger(v.extractors) && v.extractors >= v.languages, `extractors=${v.extractors}`);
 });
 
-test('version.json: mcp_tools is 18', () => {
+test('version.json: mcp_tools is 19', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 18);
+  assert.strictEqual(v.mcp_tools, 19);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 18 tools including get_impact', () => {
+test('MCP tools/list: returns 19 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 18, `expected 18 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 19, `expected 19 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/diff-architecture-tools.test.js
+++ b/test/integration/mcp/diff-architecture-tools.test.js
@@ -61,12 +61,12 @@ function seedContext(dir) {
 
 // ── tools/list registration ────────────────────────────────────────────────
 
-test('tools/list registers 18 tools including both new ones', () => {
+test('tools/list registers 19 tools including both new ones', () => {
   withGitProject((dir) => {
     const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, dir);
     const tools = res.find((r) => r.id === 1).result.tools;
     assert.strictEqual(tools.length, TOOLS.length, 'server list matches TOOLS');
-    assert.strictEqual(tools.length, 18, 'exactly 18 tools');
+    assert.strictEqual(tools.length, 19, 'exactly 19 tools');
     assert.ok(tools.some((t) => t.name === 'get_diff_context'), 'get_diff_context registered');
     assert.ok(tools.some((t) => t.name === 'get_architecture_overview'), 'get_architecture_overview registered');
   });

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (18 tools total)', () => {
+test('get_lines is registered (19 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 18, `expected 18 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 19, `expected 19 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -101,12 +101,12 @@ test('initialize returns serverInfo', () => {
 // ─────────────────────────────────────────────────────────────
 // Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 18 tools', () => {
+test('tools/list returns exactly 19 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 18);
+    assert.strictEqual(res.result.tools.length, 19);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');
@@ -123,6 +123,48 @@ test('tools/list returns exactly 18 tools', () => {
     assert.ok(names.includes('sigmap_notify_file_created'), 'Should have notify_file_created');
     assert.ok(names.includes('sigmap_notify_symbol_added'), 'Should have notify_symbol_added');
     assert.ok(names.includes('sigmap_notify_file_deleted'), 'Should have notify_file_deleted');
+    assert.ok(names.includes('verify_suggestion'), 'Should have verify_suggestion');
+    assert.ok(names.includes('squeeze_output'), 'Should have squeeze_output');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// D6: squeeze_output compresses noisy output; passes prose through
+// ─────────────────────────────────────────────────────────────
+test('squeeze_output compresses a stack trace and reports reduction', () => {
+  withTempProject((dir) => {
+    const trace = 'Traceback (most recent call last):\n  File "/app/x.py", line 10, in <module>\n    foo()\n  File "/app/y.py", line 3, in foo\n    raise ValueError("boom")\nValueError: boom\n';
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 30,
+        params: { name: 'squeeze_output', arguments: { content: trace } } },
+      dir
+    );
+    assert.ok(res.result, 'Should have result');
+    const text = res.result.content[0].text;
+    assert.ok(/Squeezed stacktrace/.test(text), 'reports squeezed stacktrace');
+    assert.ok(/tokens/.test(text), 'reports token stats');
+  });
+});
+test('squeeze_output passes non-squeezable prose through unchanged', () => {
+  withTempProject((dir) => {
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 31,
+        params: { name: 'squeeze_output', arguments: { content: 'just prose, nothing structured here' } } },
+      dir
+    );
+    const text = res.result.content[0].text;
+    assert.ok(/No squeezable structure/.test(text), 'notes nothing to squeeze');
+    assert.ok(/just prose/.test(text), 'includes original content');
+  });
+});
+test('squeeze_output with empty content returns usage', () => {
+  withTempProject((dir) => {
+    const [res] = mcpCall(
+      { jsonrpc: '2.0', method: 'tools/call', id: 32,
+        params: { name: 'squeeze_output', arguments: { content: '' } } },
+      dir
+    );
+    assert.ok(/Usage: squeeze_output/.test(res.result.content[0].text), 'returns usage on empty input');
   });
 });
 

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -83,12 +83,12 @@ function seedContextFile(dir) {
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 18 tools', () => {
+test('tools/list returns exactly 19 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 18, `Expected 18 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 19, `Expected 19 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 18);
+  assert.strictEqual(tools.length, 19);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 18 tools including query_context', () => {
+test('MCP tools/list: returns 19 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 18, `expected 18 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 19, `expected 19 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/test/integration/squeeze.test.js
+++ b/test/integration/squeeze.test.js
@@ -184,5 +184,31 @@ test('CLI squeeze: prose passes through unchanged', () => {
   assert.ok(/no squeezable structure/.test(res.stderr));
 });
 
+// ── D6: `squeeze --response <file>` names the response input explicitly ──────
+test('CLI squeeze --response <file>: reads and squeezes the named file', () => {
+  const t = 'TypeError: x\n    at f (/app/node_modules/orm/q.js:5:1)\n    at g (/app/src/a.js:10:2)';
+  const tmp = path.join(os.tmpdir(), `sigmap-resp-${process.pid}.txt`);
+  fs.writeFileSync(tmp, t);
+  try {
+    const res = spawnSync('node', [SCRIPT, 'squeeze', '--response', tmp, '--json'],
+      { cwd: ROOT, encoding: 'utf8' });
+    const obj = JSON.parse(res.stdout.trim());
+    assert.strictEqual(obj.category, 'stacktrace');
+    assert.ok(obj.reduction > 0);
+    assert.ok(!/node_modules/.test(obj.squeezed));
+  } finally { fs.unlinkSync(tmp); }
+});
+test('CLI squeeze --response -: reads the response from stdin', () => {
+  const t = 'TypeError: x\n    at f (/app/node_modules/orm/q.js:5:1)\n    at g (/app/src/a.js:10:2)';
+  const res = spawnSync('node', [SCRIPT, 'squeeze', '--response', '-', '--json'],
+    { input: t, cwd: ROOT, encoding: 'utf8' });
+  assert.strictEqual(JSON.parse(res.stdout.trim()).category, 'stacktrace');
+});
+test('CLI squeeze --response (no value): errors with usage', () => {
+  const res = spawnSync('node', [SCRIPT, 'squeeze', '--response'], { cwd: ROOT, encoding: 'utf8' });
+  assert.strictEqual(res.status, 1);
+  assert.ok(/Usage: sigmap squeeze --response/.test(res.stderr));
+});
+
 console.log(`\nsqueeze: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
   "benchmark_id": "sigmap-v8.7-main",
   "languages": 33,
   "extractors": 42,
-  "mcp_tools": 18,
+  "mcp_tools": 19,
   "tests": 110,
   "metrics": {
     "hit_at_5": 0.867,


### PR DESCRIPTION
Closes #437.

## What
Exposes the already-shipped deterministic squeeze engine (`src/squeeze/`) on two new surfaces — roadmap item **D6**, the last A+ ceiling item (Machine 9→10):

- **`squeeze_output` MCP tool** (18 → 19 tools) — an agent can compress noisy tool/command output (stack trace, CI/build log, or JSON payload) mid-session. Returns squeezed text + token-reduction stats; passes non-squeezable input through unchanged; returns usage on empty input. Offline, deterministic, no LLM.
- **`sigmap squeeze --response <file|->`** — names the response input explicitly, mirroring the existing `sigmap judge --response` convention. Same engine; `--json` supported.

## How
- `src/mcp/tools.js` — tool definition; `src/mcp/handlers.js` — `squeezeOutput()` handler; `src/mcp/server.js` — dispatch + count.
- `gen-context.js` CLI core — `--response` parsing + `--help` line; bundle rebuilt reproducibly (`npm run check:bundle:repro` green).
- Derived `version.json` `mcp_tools` (auto-fixed 18→19), README, `docs-vp/guide/mcp.md`, and regenerated `llms.txt`/`llms-full.txt` synced.

## Tests
- New: 3 MCP handler tests (compress / passthrough / empty) + 3 CLI `--response` tests (file / stdin / missing-value).
- Bumped every hardcoded 18→19 tool-count assertion.
- Full integration suite **104 passed, 0 failed**; unit suite all pass.

## Supply-chain gate
Local audit PASS — no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 498KB/153 files. External scanners re-grade after `/ship`.

Release flow: merge to develop → `/update-docs` → `/ship`.