### PR TITLE
fix: harden gen-context output determinism (3 sources)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -3202,7 +3202,11 @@ __factories["./src/discovery/source-root-resolver"] = function(module, exports) 
         score: scoreCandidate(name, full, context),
       }))
       .filter(c => c.score > 0)
-      .sort((a, b) => b.score - a.score);
+      // Final tie-break on dir keeps selection deterministic when scores tie — the
+      // top-MAX_ROOTS slice below would otherwise admit different dirs run to run
+      // (candidate order comes from filesystem readdir), changing which files are
+      // collected and making the generated context non-reproducible.
+      .sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
 
     // Handle special rules
     let roots = _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks);
@@ -3245,9 +3249,12 @@ __factories["./src/discovery/source-root-resolver"] = function(module, exports) 
     const candidates = [];
     const excSet     = new Set(excludeList);
 
-    // Root-level dirs
+    // Root-level dirs (sorted so candidate order — and downstream dedupe/selection
+    // — is deterministic regardless of filesystem readdir order)
     try {
-      for (const e of fs.readdirSync(cwd, { withFileTypes: true })) {
+      const rootEntries = fs.readdirSync(cwd, { withFileTypes: true })
+        .sort((a, b) => a.name.localeCompare(b.name));
+      for (const e of rootEntries) {
         if (!e.isDirectory()) continue;
         if (excSet.has(e.name)) continue;
         if (matchesIgnorePattern(e.name, ignorePatterns)) continue;
@@ -3316,7 +3323,7 @@ __factories["./src/discovery/source-root-resolver"] = function(module, exports) 
           }
         }
       } catch (_) {}
-      roots.sort((a, b) => b.score - a.score);
+      roots.sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
     }
 
     // Swift project dir: dirs with ≥3 .swift files
@@ -3331,7 +3338,7 @@ __factories["./src/discovery/source-root-resolver"] = function(module, exports) 
           }
         }
       } catch (_) {}
-      roots.sort((a, b) => b.score - a.score);
+      roots.sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
     }
 
     return roots;
@@ -18264,6 +18271,10 @@ function walkDir(dir, exclude, maxDepth, depth = 0) {
   } catch (_) {
     return [];
   }
+  // Sort by name so the collected file list — and therefore the output section
+  // order — is deterministic. Raw readdir order is filesystem-dependent and can
+  // vary run to run, making the generated context non-byte-stable.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {
     if (exclude.includes(entry.name)) continue;
     const full = path.join(dir, entry.name);
@@ -18475,10 +18486,15 @@ function applyTokenBudget(fileEntries, maxTokens) {
   });
 
   // Best-first order: lowest drop-priority, then most-recent, then most-informative.
+  // Final tie-break on filePath keeps the selection deterministic when priority,
+  // mtime, and signalQuality all tie (common for test files sharing a git-checkout
+  // mtime) — otherwise the choice fell through to filesystem readdir order, making
+  // which files are kept vs dropped non-reproducible run to run.
   const bestFirst = withPriority.slice().sort((a, b) => {
     if (a.priority !== b.priority) return a.priority - b.priority;
     if ((b.mtime || 0) !== (a.mtime || 0)) return (b.mtime || 0) - (a.mtime || 0);
-    return (b.signalQuality || 0) - (a.signalQuality || 0);
+    if ((b.signalQuality || 0) !== (a.signalQuality || 0)) return (b.signalQuality || 0) - (a.signalQuality || 0);
+    return a.filePath.localeCompare(b.filePath);
   });
 
   const entryCost = (e) => estimateTokens(e.sigs.join('\n')) + sectionOverhead(e);

--- a/src/discovery/source-root-resolver.js
+++ b/src/discovery/source-root-resolver.js
@@ -43,7 +43,11 @@ function resolveSourceRoots(cwd, opts = {}) {
       score: scoreCandidate(name, full, context),
     }))
     .filter(c => c.score > 0)
-    .sort((a, b) => b.score - a.score);
+    // Final tie-break on dir keeps selection deterministic when scores tie — the
+    // top-MAX_ROOTS slice below would otherwise admit different dirs run to run
+    // (candidate order comes from filesystem readdir), changing which files are
+    // collected and making the generated context non-reproducible.
+    .sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
 
   // Handle special rules
   let roots = _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks);
@@ -86,9 +90,12 @@ function _enumerateCandidates(cwd, isMonorepo, ignorePatterns, excludeList) {
   const candidates = [];
   const excSet     = new Set(excludeList);
 
-  // Root-level dirs
+  // Root-level dirs (sorted so candidate order — and downstream dedupe/selection
+  // — is deterministic regardless of filesystem readdir order)
   try {
-    for (const e of fs.readdirSync(cwd, { withFileTypes: true })) {
+    const rootEntries = fs.readdirSync(cwd, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const e of rootEntries) {
       if (!e.isDirectory()) continue;
       if (excSet.has(e.name)) continue;
       if (matchesIgnorePattern(e.name, ignorePatterns)) continue;
@@ -157,7 +164,7 @@ function _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks) {
         }
       }
     } catch (_) {}
-    roots.sort((a, b) => b.score - a.score);
+    roots.sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
   }
 
   // Swift project dir: dirs with ≥3 .swift files
@@ -172,7 +179,7 @@ function _applySpecialRules(scored, cwd, primaryFw, fwEntry, frameworks) {
         }
       }
     } catch (_) {}
-    roots.sort((a, b) => b.score - a.score);
+    roots.sort((a, b) => b.score - a.score || a.dir.localeCompare(b.dir));
   }
 
   return roots;

--- a/test/integration/v650-source-root-resolver.test.js
+++ b/test/integration/v650-source-root-resolver.test.js
@@ -511,4 +511,25 @@ test('resolveSourceRoots includes test JVM paths in DEEP_PATHS', () => {
   assert(result.roots.some(r => r === 'src/test/kotlin'), 'should find src/test/kotlin');
 });
 
+// Determinism guard (#440): tied-score dirs must resolve to the SAME set/order
+// on every call. Before the tie-break fix, candidate order came from filesystem
+// readdir and the score sort had no final key, so the MAX_ROOTS cutoff could
+// admit different dirs run to run — making the generated context non-reproducible.
+test('resolveSourceRoots is deterministic across repeated calls (tied scores)', () => {
+  const files = {};
+  for (const name of ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel']) {
+    files[`${name}/index.js`] = 'export function f() {}';
+    files[`${name}/util.js`] = 'export function g() {}';
+  }
+  const cwd = makeRepo(files);
+  const first = resolveSourceRoots(cwd).roots;
+  for (let i = 0; i < 10; i++) {
+    assert.deepStrictEqual(resolveSourceRoots(cwd).roots, first,
+      'roots must be identical on every call');
+  }
+  const tied = first.filter(r => /^[a-z]+$/.test(r));
+  assert.deepStrictEqual(tied, tied.slice().sort((x, y) => x.localeCompare(y)),
+    'tied-score dirs must be in a stable alphabetical order');
+});
+
 console.log('\nAll tests passed!');


### PR DESCRIPTION
Refs #440.

## Why
While re-running the full benchmark, retrieval hit@5 came out **86.7 → 85.6 → 87.8%** over three *unchanged* runs. Root cause: `gen-context`'s signature output is **not byte-stable** for some repos — which undermines the core "byte-stable output on an unchanged repo" claim and makes the published headline non-reproducible.

## What this fixes (3 confirmed sources)
1. **Budget drop-order** ([gen-context.js](../blob/fix/gen-context-determinism-440/gen-context.js) `applyTokenBudget`): the `bestFirst` sort had no final tie-break, so among test files sharing a git-checkout mtime (tied on priority, mtime, signalQuality) the survivor was decided by filesystem `readdir` order. → added a `filePath` tie-break.
2. **Source walk** (`walkDir`): unsorted `readdirSync` → nondeterministic section order. → sort entries by name.
3. **Auto srcDir detection** ([source-root-resolver.js](../blob/fix/gen-context-determinism-440/src/discovery/source-root-resolver.js)): unsorted candidate enumeration + score sorts with no tie-break, then truncation to `MAX_ROOTS=6` — tied-score dirs near the cutoff swapped, changing which files were collected. → sorted enumeration + tie-breaks on all three sorts.

## Result
- Byte-stable now: riverpod, akka, vue-core, click, cobra, dio, express, ggplot2, okhttp.
- srcDir detection and extraction proven deterministic (200-file extraction test: 0 flips).
- New regression guard: `resolveSourceRoots is deterministic across repeated calls (tied scores)`.
- Bundle reproducible; **full integration suite 104/104**; no shell spawns / install scripts introduced.

## Not fixed (tracked in #440)
~5 large repos (fastapi, laravel, serilog, vapor, svelte) still vary — a **file-set selection** variance in the CLI-core collection→budget pipeline that survives these tie-breaks; mechanism not yet pinned. #440 has the repro and rules-out. Recommend re-baselining the benchmark to a single reproducible headline (or a measured range) only once that residual lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)