### PR TITLE
fix: make gen-context recency boost deterministic (#440)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -18368,6 +18368,26 @@ function annotateCoverage(sigs, testIndex, enabled) {
 // ---------------------------------------------------------------------------
 // Token budget enforcement
 // ---------------------------------------------------------------------------
+// Deterministic recency boost for recently-committed files so the token budget
+// doesn't drop them first. Previously this used `Date.now()`, which encoded the
+// (alphabetical) processing order as a monotonically increasing mtime — but on
+// repos where nearly every file is "recently changed", consecutive files often
+// landed on the *same* millisecond. Which files shared a millisecond (and so
+// fell through to the filePath tie-break instead of sorting by a distinct
+// mtime) shifted run to run, swapping which files survived at the budget cutoff
+// and making the output non-byte-stable. A monotonic integer counter preserves
+// the exact processing-order ranking Date.now() produced — recent files stay
+// ahead of non-recent ones, ordered among themselves by walk order — but is
+// collision-free and reproducible. RECENT_MTIME_BASE sits far above any real
+// filesystem mtime (ms since epoch ≈ 1.7e12) so boosted files always out-rank
+// non-boosted ones, and far below MAX_SAFE_INTEGER so the counter never
+// overflows. Call nextRecentMtime() once per boosted file, in walk order. (#440)
+const RECENT_MTIME_BASE = 1e15;
+let _recentMtimeSeq = 0;
+function nextRecentMtime() {
+  return RECENT_MTIME_BASE + (_recentMtimeSeq++);
+}
+
 function estimateTokens(str) {
   return Math.ceil(str.length / 4);
 }
@@ -19348,7 +19368,7 @@ function runDiff(cwd, config, stagedOnly, baseRef) {
 
     sigs = annotateCoverage(sigs, testIndex, !!config.testCoverage);
 
-    fileEntries.push({ filePath, sigs, deps: extractFileDeps(filePath, content, config), content, mtime: Date.now() });
+    fileEntries.push({ filePath, sigs, deps: extractFileDeps(filePath, content, config), content, mtime: nextRecentMtime() });
   }
 
   if (fileEntries.length === 0) {
@@ -19496,8 +19516,11 @@ function runGenerate(cwd, config, reportMode, reportJson = false) {
       mtime = fs.statSync(filePath).mtimeMs;
     } catch (_) {}
 
-    // Boost recently committed files (give them max mtime so they aren't dropped first)
-    if (recentFiles.has(filePath)) mtime = Date.now();
+    // Boost recently committed files (give them a max mtime so they aren't
+    // dropped first). A deterministic monotonic counter — not Date.now() — keeps
+    // the budget selection byte-stable when many files are recent, while
+    // preserving the original processing-order ranking (see nextRecentMtime, #440).
+    if (recentFiles.has(filePath)) mtime = nextRecentMtime();
 
     fileEntries.push({ filePath, sigs, deps: extractFileDeps(filePath, content, config), content, mtime });
   }

--- a/test/integration/gen-context-determinism.test.js
+++ b/test/integration/gen-context-determinism.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * Regression guard for #440 — gen-context output must be byte-stable.
+ *
+ * Root cause fixed: the token-budget recency boost stamped
+ * `mtime = Date.now()` on every recently-committed file. On repos where nearly
+ * every file is "recently changed", almost every entry got a distinct wall-clock
+ * mtime, but consecutive files often landed on the *same* millisecond. Which
+ * files shared a millisecond (and thus fell through to the filePath tie-break
+ * instead of sorting by a distinct mtime) shifted run to run — swapping which
+ * files survived at the budget cutoff and making the generated context
+ * non-byte-stable. The fix replaces Date.now() with a deterministic monotonic
+ * counter (nextRecentMtime) that reproduces the same processing-order ranking
+ * without millisecond collisions.
+ *
+ * This guard reproduces the trigger conditions (many equal-cost files, all
+ * committed → all "recent", a budget small enough to force a drop) and asserts
+ * two clean runs produce byte-identical output (excluding the `Updated:`
+ * timestamp comment).
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function git(args, cwd) {
+  execFileSync('git', args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+function runGenerate(cwd) {
+  execFileSync('node', [GEN_CONTEXT], { cwd, env: { ...process.env }, stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+/** Output content with the volatile `Updated:` timestamp line removed. */
+function stableOutput(cwd) {
+  const p = path.join(cwd, '.github', 'copilot-instructions.md');
+  const raw = fs.readFileSync(p, 'utf8');
+  return raw.split('\n').filter((l) => !l.startsWith('<!-- Updated:')).join('\n');
+}
+
+function withGitFixture(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-determinism-'));
+  try {
+    // Many equal-cost files with identical content: priority and signalQuality
+    // tie, so the recency boost (mtime) drives the ordering — exactly the path
+    // that used to flake. A small fixed budget forces a drop, so which files
+    // survive the cutoff is the selection that must be reproducible run to run.
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    for (let i = 0; i < 400; i++) {
+      const n = String(i).padStart(3, '0');
+      fs.writeFileSync(path.join(srcDir, `mod${n}.js`), 'export function handler() { return 1; }\n');
+    }
+    fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({
+      autoMaxTokens: false,
+      maxTokens: 4000,
+      srcDirs: ['src'],
+      outputs: ['copilot'],
+      secretScan: false,
+    }));
+
+    // Commit everything so getRecentlyCommittedFiles() marks every file "recent"
+    // — the exact condition that made the recency boost non-deterministic.
+    git(['init'], dir);
+    git(['config', 'user.email', 'test@example.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    git(['add', '-A'], dir);
+    git(['commit', '-m', 'fixture'], dir);
+
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('two clean runs produce byte-identical output (excluding Updated: line)', () => {
+  withGitFixture((dir) => {
+    runGenerate(dir);
+    const first = stableOutput(dir);
+
+    // Clean slate for the second run — remove output and sig cache so nothing
+    // carries over between runs.
+    fs.rmSync(path.join(dir, '.github', 'copilot-instructions.md'), { force: true });
+    fs.rmSync(path.join(dir, '.sigmap-cache.json'), { force: true });
+
+    runGenerate(dir);
+    const second = stableOutput(dir);
+
+    assert.strictEqual(second, first, 'gen-context output differs between two clean runs on an unchanged repo');
+  });
+});
+
+test('the fixture actually forces a budget cutoff (guard exercises the tie-break)', () => {
+  withGitFixture((dir) => {
+    runGenerate(dir);
+    const out = fs.readFileSync(path.join(dir, '.github', 'copilot-instructions.md'), 'utf8');
+    const sections = (out.match(/^### /gm) || []).length;
+    // 400 files written; a 4000-token budget must drop some — otherwise the test
+    // never reaches the selection-among-ties path that used to be flaky.
+    assert.ok(sections > 0, 'expected some sections in output');
+    assert.ok(sections < 400, `expected a budget cutoff (some files dropped), but all ${sections} survived`);
+  });
+});
+
+console.log('');
+console.log(`gen-context-determinism: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 19,
-  "tests": 110,
+  "tests": 111,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Problem
`gen-context` output was non-byte-stable run-to-run for ~5 large repos (fastapi, laravel, serilog, vapor, svelte), making the retrieval benchmark's hit@5 non-reproducible (**86.7 → 85.6 → 87.8%** over three unchanged runs). This is the residual tracked in #440 after the first pass (#441).

## Root cause
The token-budget recency boost stamped `mtime = Date.now()` on every recently-committed file. On repos where nearly every file is "recently changed" (svelte: 8743 recent files), consecutive files often landed on the **same millisecond**. Which files shared a millisecond — and thus fell through to the `filePath` tie-break instead of sorting by a distinct mtime — shifted run to run, swapping which equal-priority files survived at the budget cutoff.

The `Date.now()` value wasn't just a boost: it encoded the (alphabetical) walk order as a monotonic mtime that `bestFirst` (mtime desc) relied on. The nondeterminism was only the millisecond *collisions*.

## Fix
Replace `Date.now()` with a deterministic monotonic counter (`nextRecentMtime`) that reproduces the **exact same** processing-order ranking without collisions. Recent files stay ahead of non-recent ones and keep their walk-order ordering among themselves.

- An earlier attempt collapsing all recent files to one sentinel value regressed hit@5 to 63.3% (signalQuality dominated). The counter preserves the intended ordering.

## Results
- **All 43 benchmark repos**: byte-identical across two clean runs (excluding the `Updated:` timestamp comment).
- **Retrieval benchmark**: identical per-repo results and **87.8% hit@5** across runs — quality unchanged, now reproducible. The published headline (87.8%) is no longer stale.

## Acceptance criteria
- [x] `gen-context` output byte-identical (excluding `Updated:`) across two clean runs for all benchmark repos
- [x] Regression guard runs gen-context twice on a fixture and asserts byte-equality (`test/integration/gen-context-determinism.test.js`) — verified it fails on the old `Date.now()` behaviour
- [x] Retrieval benchmark re-baselined to a single reproducible headline: **87.8%** (weighted = unweighted over 18 repos)
- [ ] (Optional) omittable `Updated:` timestamp — deferred; touches 4 bundled-adapter sites + their source copies, disproportionate for an optional item. Guard already handles it by excluding the line.

## Tests
- New: `test/integration/gen-context-determinism.test.js` (2 assertions)
- Full integration suite: **105 passed, 0 failed**
- `version.json` derived test count 110 → 111

## Supply-chain gate
Local audit PASS — no shell spawns · no install scripts · `main` exports API · no fingerprinting. Change is limited to an mtime assignment in `gen-context.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)