### PR TITLE
feat: detached watch daemon (daemon start/stop/status) — #447

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -59,6 +59,7 @@ sigmap --format cache                    Also write Anthropic prompt-cache JSON
 sigmap --track                           Append run metrics to .context/usage.ndjson
 sigmap --watch                           Generate + watch for file changes
 sigmap --setup                           Generate + install git hook + watch
+sigmap daemon start|stop|status          Run --watch as a detached background daemon
 sigmap --mcp                             Start MCP server on stdio
 sigmap --report                          Token reduction stats to stdout
 sigmap --report --json                   Token report as JSON (for CI; exits 1 if over budget)

--- a/gen-context.js
+++ b/gen-context.js
@@ -2592,6 +2592,134 @@ __factories["./src/create/orchestrate"] = function(module, exports) {
   
 };
 
+// ── ./src/daemon/daemon ──
+__factories["./src/daemon/daemon"] = function(module, exports) {
+  
+  /**
+   * Detached watch daemon (D1).
+   *
+   * Runs the existing `--watch` mode as a background process so the index stays
+   * fresh without holding a terminal. State lives under `.context/` (consistent
+   * with session/usage): `daemon.pid` records the watcher's PID, `daemon.log`
+   * captures its output.
+   *
+   * Zero-dependency and shell-free: the watcher is launched with
+   * `spawn(process.execPath, [gen-context.js, '--watch'], { detached: true })` —
+   * an arguments array, never a shell command string.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { spawn } = require('child_process');
+
+  module.exports = { start, stop, status, pidFile, logFile, isAlive, readPid };
+
+  function daemonDir(cwd) {
+    return path.join(cwd, '.context');
+  }
+
+  function pidFile(cwd) {
+    return path.join(daemonDir(cwd), 'daemon.pid');
+  }
+
+  function logFile(cwd) {
+    return path.join(daemonDir(cwd), 'daemon.log');
+  }
+
+  /** True if a process with this PID exists (signal 0 probes without killing). */
+  function isAlive(pid) {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      // EPERM = the process exists but is owned by another user — treat as alive.
+      return err.code === 'EPERM';
+    }
+  }
+
+  /** Read the recorded PID, or null if the file is missing/unparseable. */
+  function readPid(cwd) {
+    try {
+      const raw = fs.readFileSync(pidFile(cwd), 'utf8').trim();
+      const pid = parseInt(raw, 10);
+      return Number.isInteger(pid) && pid > 0 ? pid : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function removePidFile(cwd) {
+    try {
+      fs.unlinkSync(pidFile(cwd));
+    } catch (_) {}
+  }
+
+  /**
+   * @returns {{ running: boolean, pid: number|null, pidFile: string, logFile: string }}
+   */
+  function status(cwd) {
+    const pid = readPid(cwd);
+    const running = pid != null && isAlive(pid);
+    // A recorded-but-dead PID is stale — clean it up so the state stays truthful.
+    if (pid != null && !running) removePidFile(cwd);
+    return { running, pid: running ? pid : null, pidFile: pidFile(cwd), logFile: logFile(cwd) };
+  }
+
+  /**
+   * Launch a detached `--watch` process. Idempotent: if one is already running
+   * this is a no-op that reports the existing PID.
+   *
+   * @param {string} cwd
+   * @param {{ scriptPath: string }} opts - path to gen-context.js (the CLI entry)
+   * @returns {{ status: 'started'|'already', pid: number, logFile: string }}
+   */
+  function start(cwd, opts = {}) {
+    const scriptPath = opts.scriptPath;
+    if (!scriptPath) throw new Error('daemon.start requires opts.scriptPath');
+
+    const current = status(cwd);
+    if (current.running) {
+      return { status: 'already', pid: current.pid, logFile: logFile(cwd) };
+    }
+
+    fs.mkdirSync(daemonDir(cwd), { recursive: true });
+    const out = fs.openSync(logFile(cwd), 'a');
+    try {
+      const child = spawn(process.execPath, [scriptPath, '--watch'], {
+        cwd,
+        detached: true,
+        stdio: ['ignore', out, out],
+      });
+      child.unref();
+      fs.writeFileSync(pidFile(cwd), String(child.pid) + '\n');
+      return { status: 'started', pid: child.pid, logFile: logFile(cwd) };
+    } finally {
+      try { fs.closeSync(out); } catch (_) {}
+    }
+  }
+
+  /**
+   * Stop the running watcher (SIGTERM) and clear its PID file.
+   *
+   * @returns {{ status: 'stopped'|'not-running'|'stale', pid?: number }}
+   */
+  function stop(cwd) {
+    const pid = readPid(cwd);
+    if (pid == null) return { status: 'not-running' };
+    if (!isAlive(pid)) {
+      removePidFile(cwd);
+      return { status: 'stale', pid };
+    }
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch (_) {}
+    removePidFile(cwd);
+    return { status: 'stopped', pid };
+  }
+  
+};
+
 // ── ./src/discovery/framework-detector ──
 __factories["./src/discovery/framework-detector"] = function(module, exports) {
   
@@ -19962,6 +20090,7 @@ Usage:
   ${cmd} --track                           Append run metrics to .context/usage.ndjson
   ${cmd} --watch                           Generate + watch for file changes
   ${cmd} --setup                           Generate + install git hook + watch
+  ${cmd} daemon start|stop|status          Run --watch as a detached background daemon
   ${cmd} --mcp                             Start MCP server on stdio
   ${cmd} --report                          Token reduction stats to stdout
   ${cmd} --report --json                   Token report as JSON (for CI; exits 1 if over budget)
@@ -21500,6 +21629,46 @@ function main() {
     }
 
     console.error('[sigmap] usage: sigmap mcp install <client> | sigmap mcp list');
+    process.exit(1);
+  }
+
+  // `sigmap daemon start|stop|status` — run `--watch` as a detached background
+  // process (D1). PID + log live under .context/. Mirrors the `mcp` sub-dispatch.
+  if (args[0] === 'daemon') {
+    const daemon = requireSourceOrBundled('./src/daemon/daemon');
+    const sub = args[1];
+    const jsonOut = args.includes('--json');
+
+    if (sub === 'start') {
+      const r = daemon.start(cwd, { scriptPath });
+      if (jsonOut) { process.stdout.write(JSON.stringify(r) + '\n'); process.exit(0); }
+      if (r.status === 'already') {
+        console.log(`[sigmap] daemon already running (pid ${r.pid})`);
+      } else {
+        console.log(`[sigmap] daemon started (pid ${r.pid}) — watching for changes`);
+        console.log(`[sigmap] logs: ${_displayPath(r.logFile, cwd)}   stop with: sigmap daemon stop`);
+      }
+      process.exit(0);
+    }
+
+    if (sub === 'stop') {
+      const r = daemon.stop(cwd);
+      if (jsonOut) { process.stdout.write(JSON.stringify(r) + '\n'); process.exit(0); }
+      if (r.status === 'not-running') console.log('[sigmap] daemon not running');
+      else if (r.status === 'stale') console.log(`[sigmap] removed stale pid file (pid ${r.pid} no longer alive)`);
+      else console.log(`[sigmap] daemon stopped (pid ${r.pid})`);
+      process.exit(0);
+    }
+
+    if (sub === 'status') {
+      const r = daemon.status(cwd);
+      if (jsonOut) { process.stdout.write(JSON.stringify(r) + '\n'); process.exit(r.running ? 0 : 1); }
+      if (r.running) console.log(`[sigmap] daemon running (pid ${r.pid}) — logs: ${_displayPath(r.logFile, cwd)}`);
+      else console.log('[sigmap] daemon not running');
+      process.exit(r.running ? 0 : 1);
+    }
+
+    console.error('[sigmap] usage: sigmap daemon start | stop | status');
     process.exit(1);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -59,6 +59,7 @@ sigmap --format cache                    Also write Anthropic prompt-cache JSON
 sigmap --track                           Append run metrics to .context/usage.ndjson
 sigmap --watch                           Generate + watch for file changes
 sigmap --setup                           Generate + install git hook + watch
+sigmap daemon start|stop|status          Run --watch as a detached background daemon
 sigmap --mcp                             Start MCP server on stdio
 sigmap --report                          Token reduction stats to stdout
 sigmap --report --json                   Token report as JSON (for CI; exits 1 if over budget)

--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Detached watch daemon (D1).
+ *
+ * Runs the existing `--watch` mode as a background process so the index stays
+ * fresh without holding a terminal. State lives under `.context/` (consistent
+ * with session/usage): `daemon.pid` records the watcher's PID, `daemon.log`
+ * captures its output.
+ *
+ * Zero-dependency and shell-free: the watcher is launched with
+ * `spawn(process.execPath, [gen-context.js, '--watch'], { detached: true })` —
+ * an arguments array, never a shell command string.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+module.exports = { start, stop, status, pidFile, logFile, isAlive, readPid };
+
+function daemonDir(cwd) {
+  return path.join(cwd, '.context');
+}
+
+function pidFile(cwd) {
+  return path.join(daemonDir(cwd), 'daemon.pid');
+}
+
+function logFile(cwd) {
+  return path.join(daemonDir(cwd), 'daemon.log');
+}
+
+/** True if a process with this PID exists (signal 0 probes without killing). */
+function isAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = the process exists but is owned by another user — treat as alive.
+    return err.code === 'EPERM';
+  }
+}
+
+/** Read the recorded PID, or null if the file is missing/unparseable. */
+function readPid(cwd) {
+  try {
+    const raw = fs.readFileSync(pidFile(cwd), 'utf8').trim();
+    const pid = parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function removePidFile(cwd) {
+  try {
+    fs.unlinkSync(pidFile(cwd));
+  } catch (_) {}
+}
+
+/**
+ * @returns {{ running: boolean, pid: number|null, pidFile: string, logFile: string }}
+ */
+function status(cwd) {
+  const pid = readPid(cwd);
+  const running = pid != null && isAlive(pid);
+  // A recorded-but-dead PID is stale — clean it up so the state stays truthful.
+  if (pid != null && !running) removePidFile(cwd);
+  return { running, pid: running ? pid : null, pidFile: pidFile(cwd), logFile: logFile(cwd) };
+}
+
+/**
+ * Launch a detached `--watch` process. Idempotent: if one is already running
+ * this is a no-op that reports the existing PID.
+ *
+ * @param {string} cwd
+ * @param {{ scriptPath: string }} opts - path to gen-context.js (the CLI entry)
+ * @returns {{ status: 'started'|'already', pid: number, logFile: string }}
+ */
+function start(cwd, opts = {}) {
+  const scriptPath = opts.scriptPath;
+  if (!scriptPath) throw new Error('daemon.start requires opts.scriptPath');
+
+  const current = status(cwd);
+  if (current.running) {
+    return { status: 'already', pid: current.pid, logFile: logFile(cwd) };
+  }
+
+  fs.mkdirSync(daemonDir(cwd), { recursive: true });
+  const out = fs.openSync(logFile(cwd), 'a');
+  try {
+    const child = spawn(process.execPath, [scriptPath, '--watch'], {
+      cwd,
+      detached: true,
+      stdio: ['ignore', out, out],
+    });
+    child.unref();
+    fs.writeFileSync(pidFile(cwd), String(child.pid) + '\n');
+    return { status: 'started', pid: child.pid, logFile: logFile(cwd) };
+  } finally {
+    try { fs.closeSync(out); } catch (_) {}
+  }
+}
+
+/**
+ * Stop the running watcher (SIGTERM) and clear its PID file.
+ *
+ * @returns {{ status: 'stopped'|'not-running'|'stale', pid?: number }}
+ */
+function stop(cwd) {
+  const pid = readPid(cwd);
+  if (pid == null) return { status: 'not-running' };
+  if (!isAlive(pid)) {
+    removePidFile(cwd);
+    return { status: 'stale', pid };
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (_) {}
+  removePidFile(cwd);
+  return { status: 'stopped', pid };
+}

--- a/test/integration/daemon.test.js
+++ b/test/integration/daemon.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * Integration tests for the detached watch daemon (D1, #447).
+ *
+ * `sigmap daemon start|stop|status` runs `--watch` as a background process,
+ * tracked by a PID file under `.context/`. These tests exercise the full
+ * lifecycle and always stop any process they start (finally-kill) so the suite
+ * never leaves an orphaned watcher behind.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function daemon(dir, ...args) {
+  const res = spawnSync(process.execPath, [GEN_CONTEXT, 'daemon', ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+  return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status };
+}
+
+function pidFilePath(dir) {
+  return path.join(dir, '.context', 'daemon.pid');
+}
+
+function readPid(dir) {
+  try {
+    return parseInt(fs.readFileSync(pidFilePath(dir), 'utf8').trim(), 10);
+  } catch (_) {
+    return null;
+  }
+}
+
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch (err) { return err.code === 'EPERM'; }
+}
+
+/** Create a minimal project and always kill any daemon it spawned. */
+function withProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-daemon-'));
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'a.js'), 'export function hello(name) { return name; }\n');
+  try {
+    fn(dir);
+  } finally {
+    const pid = readPid(dir);
+    if (pid && alive(pid)) { try { process.kill(pid, 'SIGKILL'); } catch (_) {} }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── status before start ──────────────────────────────────────────────────────
+
+test('status reports "not running" and exits 1 before start', () => {
+  withProject((dir) => {
+    const r = daemon(dir, 'status');
+    assert.strictEqual(r.code, 1, 'status should exit 1 when not running');
+    assert.ok(/not running/.test(r.stdout), `expected "not running", got: ${r.stdout}`);
+  });
+});
+
+// ── start → status → stop lifecycle ──────────────────────────────────────────
+
+test('start launches a detached watcher, writes a live PID, and returns', () => {
+  withProject((dir) => {
+    const r = daemon(dir, 'start');
+    assert.strictEqual(r.code, 0, `start should exit 0, got ${r.code}`);
+    assert.ok(/daemon started/.test(r.stdout), `expected "daemon started", got: ${r.stdout}`);
+
+    const pid = readPid(dir);
+    assert.ok(Number.isInteger(pid) && pid > 0, 'pid file should hold a valid PID');
+    assert.ok(alive(pid), 'the recorded PID should be a live process');
+
+    const st = daemon(dir, 'status');
+    assert.strictEqual(st.code, 0, 'status should exit 0 while running');
+    assert.ok(new RegExp(`pid ${pid}`).test(st.stdout), `status should report pid ${pid}`);
+  });
+});
+
+test('start is idempotent — a second start reports "already running", no new process', () => {
+  withProject((dir) => {
+    daemon(dir, 'start');
+    const pid1 = readPid(dir);
+    const r = daemon(dir, 'start');
+    assert.ok(/already running/.test(r.stdout), `expected "already running", got: ${r.stdout}`);
+    const pid2 = readPid(dir);
+    assert.strictEqual(pid2, pid1, 'PID must not change on a repeat start');
+  });
+});
+
+test('stop terminates the watcher and removes the PID file', () => {
+  withProject((dir) => {
+    daemon(dir, 'start');
+    const pid = readPid(dir);
+    const r = daemon(dir, 'stop');
+    assert.strictEqual(r.code, 0, 'stop should exit 0');
+    assert.ok(/daemon stopped/.test(r.stdout), `expected "daemon stopped", got: ${r.stdout}`);
+    assert.ok(!fs.existsSync(pidFilePath(dir)), 'pid file should be removed after stop');
+    // give the OS a moment to reap the signalled process
+    const deadline = Date.now() + 3000;
+    while (alive(pid) && Date.now() < deadline) { /* spin briefly */ }
+    assert.ok(!alive(pid), 'the watcher process should be gone after stop');
+
+    const st = daemon(dir, 'status');
+    assert.strictEqual(st.code, 1, 'status should exit 1 after stop');
+  });
+});
+
+// ── edge cases ───────────────────────────────────────────────────────────────
+
+test('stop when nothing is running is a no-op ("not running")', () => {
+  withProject((dir) => {
+    const r = daemon(dir, 'stop');
+    assert.ok(/not running/.test(r.stdout), `expected "not running", got: ${r.stdout}`);
+  });
+});
+
+test('a stale PID file is cleaned up by status', () => {
+  withProject((dir) => {
+    fs.mkdirSync(path.join(dir, '.context'), { recursive: true });
+    fs.writeFileSync(pidFilePath(dir), '999999\n'); // very unlikely to be a live PID
+    const r = daemon(dir, 'status');
+    assert.strictEqual(r.code, 1, 'stale pid → not running (exit 1)');
+    assert.ok(!fs.existsSync(pidFilePath(dir)), 'stale pid file should be removed');
+  });
+});
+
+test('unknown or missing subcommand prints usage and exits 1', () => {
+  withProject((dir) => {
+    const bad = daemon(dir, 'frobnicate');
+    assert.strictEqual(bad.code, 1);
+    assert.ok(/usage: sigmap daemon/.test(bad.stderr), `expected usage, got: ${bad.stderr}`);
+    const none = daemon(dir);
+    assert.strictEqual(none.code, 1);
+    assert.ok(/usage: sigmap daemon/.test(none.stderr), `expected usage, got: ${none.stderr}`);
+  });
+});
+
+test('--json emits a machine-readable status', () => {
+  withProject((dir) => {
+    const before = daemon(dir, 'status', '--json');
+    const b = JSON.parse(before.stdout);
+    assert.strictEqual(b.running, false, 'running:false before start');
+
+    daemon(dir, 'start');
+    const after = daemon(dir, 'status', '--json');
+    const a = JSON.parse(after.stdout);
+    assert.strictEqual(a.running, true, 'running:true after start');
+    assert.strictEqual(a.pid, readPid(dir), 'json pid matches pid file');
+    assert.ok(typeof a.logFile === 'string' && a.logFile.length > 0, 'json includes logFile');
+  });
+});
+
+console.log('');
+console.log(`daemon: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 19,
-  "tests": 111,
+  "tests": 112,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary
- Detaches the existing `--watch` into a managed background daemon so the index stays fresh without holding a terminal (D1 — the roadmap's #1 friction win). Closes #447.

## Changes
- **`src/daemon/daemon.js`** (new): `start` / `stop` / `status`, zero-dependency. Launches the watcher with `spawn(process.execPath, [gen-context.js, '--watch'], { detached: true })` — arguments array, **no shell** — and tracks it via `.context/daemon.pid` (log → `.context/daemon.log`), consistent with existing `.context/` runtime state.
- **`gen-context.js`** (CLI core): `sigmap daemon start|stop|status` dispatch, mirroring `sigmap mcp <sub>`; `--json` on each; `--help` entry. Bundle regenerated (`build:bundle`), `check:bundle:repro` green.
- Behaviour: `start` is idempotent (reports "already running", no second process) and cleans a stale PID file; `stop` SIGTERMs the PID and removes the file (no-op when nothing runs); `status` exits 0 running / 1 not and self-cleans stale PIDs.

## Test plan
- [x] `node test/integration/daemon.test.js` — 8/8 (lifecycle, idempotency, stale-PID cleanup, error cases, `--json`); each test finally-kills any process it spawns (no orphans)
- [x] `node test/integration/all.js` — 106 passed, 0 failed
- [x] `node scripts/build-bundle.mjs --check` — bundle reproducible from `src/`
- [x] Supply-chain gate: no shell spawns · no install scripts · main exports API · no fingerprinting

## Notes
- `version.json` test count 111 → 112 (new suite); `llms-full.txt` regenerated for the new `--help` line.
- Docs (README `daemon` section) are D2's scope, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)