### PR TITLE
ci(pages): retry Pages deploy on GitHub's transient failure

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +45,22 @@ jobs:
         with:
           path: docs-vp/.vitepress/dist
 
+      # GitHub's Pages backend intermittently returns "Deployment failed, try
+      # again later" within seconds of a push-triggered deploy (the same artifact
+      # re-deployed a minute later succeeds). deploy-pages treats that status as
+      # terminal and does not retry, so every release's first deploy went red and
+      # needed a manual re-run. Let the first attempt fail softly, wait for the
+      # backend to settle, then retry once — the job is green if either succeeds.
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - name: Wait before retry (Pages backend transient)
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 60
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem
Every release's **first** (push-triggered) GitHub Pages deploy fails and needs a manual re-run. The failed-run log shows the deployment is *created*, then the first status poll (~5s later) returns `Deployment failed, try again later` — and `actions/deploy-pages@v4` treats that status as terminal (no internal retry). The **same artifact/sha re-deployed ~1 min later succeeds** (confirmed on the v8.9.0 release: push-deploy failed at 08:20:53, a `workflow_dispatch` of the identical sha succeeded at 08:22). It's a GitHub-side timing transient, not a build/config error (build + artifact upload pass every time; GitHub status was operational; custom domain healthy).

## Fix
Self-heal with one delayed retry — no new dependencies, same official action:
- first `deploy-pages` runs with `continue-on-error: true` (fails soft)
- if its `outcome == 'failure'`, `sleep 60` for the backend to settle
- retry `deploy-pages` once

The job is **green if either attempt deploys**, and only red if **both** fail — which is the rare *stuck-sha* case that genuinely needs a fresh sha (an `--allow-empty` commit to main), so a persistent failure still surfaces instead of being masked.

## Notes
- CI-only change; not in the published npm surface (no supply-chain impact).
- Takes effect once on `main`: the release merge that carries this file to main will itself use the fixed workflow for its Pages deploy.
- `environment.url` now falls back to the retry step's `page_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)