### PR TITLE
docs(seo): re-anchor npm description + keywords on grounding positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sigmap",
   "version": "8.9.1",
-  "description": "97% token reduction for AI coding. Extracts function & class signatures with TF-IDF ranking to feed only the right files to Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP. Zero dependencies, runs offline via npx.",
+  "description": "The deterministic, verifiable grounding layer for AI code work — a zero-dependency signature-and-evidence map that grounds Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP agents against your real code (repo + installed libraries) so they stop hallucinating files, imports & APIs. Runs offline via npx; byte-stable output; ~97% token reduction as proof.",
   "main": "packages/core/index.js",
   "exports": {
     ".": "./packages/core/index.js",
@@ -80,7 +80,13 @@
     "mcp",
     "function-signatures",
     "code-intelligence",
-    "context-compression",
+    "ai-grounding",
+    "hallucination-detection",
+    "deterministic",
+    "verifiable-ai",
+    "code-signatures",
+    "ai-code-review",
+    "evidence-pack",
     "local-llm",
     "ollama",
     "ai-coding"


### PR DESCRIPTION
## Summary
Aligns the discoverability surfaces with SigMap's actual positioning (the deterministic, verifiable grounding layer) instead of the "context compression" frame the master plan §0/§4 explicitly demotes to *proof*.

Prompted by a review of a proposed SEO/GEO plan that (a) misdescribed SigMap as "tree-sitter"-based — **false**, it's zero-dependency hand-written extractors — and (b) optimized the losing Lens B ("general context tool") where Claude Code/Cursor win, rather than the winning Lens A (grounding/determinism).

## Changes
- **`package.json` description** — now leads with the grounding-layer positioning; `~97% token reduction` retained but demoted to proof at the end.
- **`package.json` keywords** — added `ai-grounding`, `hallucination-detection`, `deterministic`, `verifiable-ai`, `code-signatures`, `ai-code-review`, `evidence-pack`; dropped `context-compression`.
- **GitHub repo topics** (applied via settings, not code) — same realignment: +6 moat topics, −`context-compression`/`nodejs`/`copilot`/`developer-experience`/`vscode`/`gemini` (20-topic cap).

## Not changed (already correct)
README tagline + `docs/index.html` JSON-LD + `llms.txt` already carry the grounding positioning and are test-pinned (`repositioning.test.js`). The proposed plan's JSON-LD block (`softwareVersion: "1.0"`) would have been a downgrade — rejected.

## Test plan
- [x] `package.json` valid JSON
- [x] `node test/integration/repositioning.test.js` — 8/8
- [x] `node test/integration/features/readme-structure.test.js` — 52/52

## Deferred (per North-Star §4)
FAQ/problem-solution GEO blocks, comparison table ("agentic grep vs deterministic grounding"), and MCP-registry listing → staged for the next docs pass. The Reddit/Dev.to content campaign is EN4 growth (v10), deliberately held until the moat is proven.