### PR TITLE
docs(seo): ready-to-publish GEO content blocks (FAQ + comparison + MCP registry)

### DIFF
--- a/docs/readmes/SEO_GUIDE.md
+++ b/docs/readmes/SEO_GUIDE.md
@@ -197,3 +197,56 @@ Change frequency guide:
 - [ ] JSON-LD uses the right schema type for this page
 - [ ] `sitemap.xml` `<lastmod>` updated to today on modified pages
 - [ ] New pages are added to `sitemap.xml`, nav, and footer on all pages
+
+---
+
+## GEO content blocks (ready to publish)
+
+Drop-in content for AI search (Perplexity, SearchGPT, Gemini) and traditional SEO. **Positioning rules** — every block leads with *grounding / determinism / verifiability* (Lens A, uncontested); token reduction appears only as **proof**, never the headline. **Never** describe SigMap as a "compression tool," a "skeletonizer," or "tree-sitter"-based — it is a zero-dependency, hand-written signature extractor. All numbers below trace to `version.json` / `benchmarks/latest.json`; refresh them when those change.
+
+### 1 · FAQ (problem → solution)
+
+Each answer opens with a one-sentence direct answer AI search can lift verbatim, then the command. Publish on a public FAQ page and wrap in the `FAQPage` JSON-LD (schema above).
+
+**Q: How do I stop my AI coding agent from hallucinating file paths, imports, or APIs?**
+Run `sigmap verify` (or the `verify_suggestion` MCP tool). It deterministically checks an AI suggestion against your repo, your private symbols, **and the libraries actually installed** in `node_modules` / site-packages — flagging fake files, unresolvable imports, and non-existent symbols before they ship. No LLM, no network, byte-stable.
+
+**Q: How do I give Cursor or Claude Code the right files without pasting my whole repo?**
+Run `sigmap ask "<task>"`. A deterministic offline ranker (identifier-aware BM25 + intent + graph-boost) returns the most relevant files as a compact signature map — roughly 2–5k tokens instead of 80k+ (~97% reduction) — written to `.context/query-context.md`, or served live via the `query_context` MCP tool.
+
+**Q: How do I prove an AI answer is grounded in real code for CI or code review?**
+Run `sigmap evidence "<query>"`. It emits a byte-stable Evidence Pack JSON — every file anchored to real symbols and exact line ranges, signed with a sha256 grounding hash. An unchanged repo yields byte-identical output, so CI can diff it and reviewers can audit it — which an agentic-grep loop cannot reproduce.
+
+**Q: How do I reduce token costs in Claude Code, Cursor, or Copilot?**
+SigMap maps your codebase to function and class signatures and ranks only the files a task needs, cutting a session's context ~40–98% (avg ~97% across 21 real repos). Install with `npx sigmap` — zero dependencies, runs offline.
+
+**Q: Does SigMap use embeddings, a vector database, or an LLM?**
+No. SigMap is fully deterministic and offline: hand-written signature extractors for 33 languages, a local ranker, and a grounding verifier. Zero runtime dependencies, no API keys, byte-stable output. That is the point — reproducible, auditable context an agent's live search cannot produce.
+
+**Q: How does SigMap verify against private or internal APIs that public-doc tools can't know?**
+It indexes your repo's own symbols plus the signatures of your installed dependencies (`.d.ts` / site-packages), so `verify_suggestion` can flag a call to `Internal.PaymentService.authorize()` or a wrong `lodash@4.17` API — private-API grounding no public-docs tool (e.g. Context7) can offer.
+
+### 2 · Comparison — agentic grep vs deterministic grounding
+
+The honest competitive wedge: SigMap does not compete *with* an agent's live search — it provides the one thing that loop cannot. Publish as a table on `compare-alternatives`.
+
+| Capability | SigMap — deterministic grounding | Agentic grep (Claude Code / Cursor live search) |
+|---|---|---|
+| Determinism / reproducibility | Byte-stable — same repo yields an identical map | Non-deterministic — differs run to run |
+| Auditability | sha256 grounding hash; CI-diffable Evidence Pack | No audit trail |
+| Cost per lookup | $0 — local, no API calls | LLM tokens per search loop |
+| Hallucination guard | Flags fake files / imports / symbols vs repo + installed libs | None — the loop can invent paths |
+| Private-API grounding | Yes — repo + installed-library signatures | Only what the loop happens to read |
+| Speed | Instant local rank | Multi-step agent loop |
+| Live semantic recall | Limited (BM25 + intent, by design) | Strong — this is its strength |
+
+**Reading:** different instruments. Reach for agentic grep on open-ended exploration; reach for SigMap when you need context you can **trust, reproduce, and audit** — CI gates, code review, and grounding.
+
+### 3 · MCP registry listing
+
+For the official Model Context Protocol registry and community `awesome-mcp` lists.
+
+- **Name:** SigMap
+- **One-liner:** Deterministic grounding + 19 code-context MCP tools — verify AI code against your repo and installed libraries, rank the right files, and compress tool output. Zero-dependency, offline, byte-stable.
+- **Longer:** SigMap's MCP server exposes 19 deterministic tools — `verify_suggestion` (ground an AI suggestion against repo + installed-library symbols), `query_context` (rank the files a task needs), `get_diff_context` / `get_impact` (blast radius), `get_callee_signatures` (exact signatures before a call is written), `squeeze_output` (compress noisy tool output), and more. No embeddings, no network, no API keys.
+- **Where to list:** official MCP registry · community MCP server directories · `awesome-mcp-servers` lists.

--- a/docs/readmes/SEO_GUIDE.md
+++ b/docs/readmes/SEO_GUIDE.md
@@ -38,7 +38,7 @@ Every page must have **all** of these tags, in this order, before `<link rel="ca
 
 | Page | Title pattern |
 |---|---|
-| index.html | `SigMap — Zero-dependency AI context engine` |
+| index.html | `SigMap — the deterministic grounding layer for AI code` |
 | quick-start.html | `Quick Start — SigMap` |
 | cli.html | `CLI Reference — SigMap` |
 | config.html | `Configuration — SigMap` |
@@ -61,7 +61,7 @@ Keep titles under 60 characters. Put the topic first, brand last.
 - Include the primary keyword in the first 10 words.
 - Do not duplicate the title word-for-word.
 
-Good: `"Set up SigMap MCP server with Claude Code, Cursor, and Windsurf. 8 on-demand tools. Zero-dependency stdio server."`  
+Good: `"Set up SigMap MCP server with Claude Code, Cursor, and Windsurf. 19 on-demand tools. Zero-dependency stdio server."`  
 Bad: `"This page is about the MCP server feature of SigMap."`
 
 ---
@@ -94,7 +94,7 @@ Use one `<script type="application/ld+json">` block per page. Choose the schema 
   "description": "...",
   "url": "https://sigmap.io/",
   "downloadUrl": "https://www.npmjs.com/package/sigmap",
-  "softwareVersion": "3.x.x",
+  "softwareVersion": "8.x.x",
   "operatingSystem": "Any (Node.js 18+)",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "author": { "@type": "Person", "name": "Manoj Mallick", "url": "https://github.com/manojmallick" }


### PR DESCRIPTION
## Summary
Adds a **"GEO content blocks (ready to publish)"** section to `docs/readmes/SEO_GUIDE.md` — staged, grounding-first copy for the next docs pass. Follows the positioning realignment in #454.

## Blocks
1. **FAQ (problem → solution)** — 6 Q&A pairs keyed to grounding (stop hallucinating file paths, get the right files, prove grounding for CI, reduce token cost, no-embeddings, private-API). Direct-answer chunks for AI search + ready for `FAQPage` JSON-LD.
2. **Comparison — agentic grep vs deterministic grounding** — the honest competitive wedge (determinism, auditability, $0 lookup, hallucination guard, private-API) framed as *different instruments*, not "SigMap beats Claude Code."
3. **MCP registry listing copy** — for the official MCP registry + community lists.

## Guardrails baked into the doc
- Lead with grounding/determinism; token reduction is **proof only**.
- Explicitly forbids "compression tool" / "skeletonizer" / **"tree-sitter"** framing (SigMap is zero-dep, hand-written extractors).
- All figures (19 MCP tools, 33 languages, ~97% token, 87.8% hit@5) trace to `version.json` / `benchmarks/latest.json`.

Docs-only; no code, no live-site change yet.