### PR TITLE
feat: sigmap wiki — deterministic architecture narrative (D9, no --llm)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,12 @@ Always run `sigmap ask` (or `sigmap --query`) before searching for files relevan
 src/extractors/python_ast.py ← ast
 ```
 
-## changes (last 5 commits — 2 days ago)
+## changes (last 5 commits — 0 seconds ago)
 ```
+src/format/terse.js                           +splitAnchor  +encodeTerseSig  +encodeTerseSigs  +_tokens
+src/wiki/generate.js                          +_rel  +_pct  +_identity  +_modules
 src/conventions/extract.js                    ~classifyNaming  ~scoreConvention
 src/conventions/fix.js                        ~buildFixList
-src/daemon/daemon.js                          +daemonDir  +pidFile  +logFile  +isAlive
 src/extractors/javascript.js                  ~extract  ~extractClassMembers  ~extractBlock  ~buildReturnHints
 src/extractors/typescript.js                  ~extract  ~extractInterfaceMembers  ~extractClassMembers  ~extractBlock
 src/graph/builder.js                          +probeJs  +resolveJsPath  +stripJsonc  +loadAliasMap
@@ -179,6 +180,21 @@ code-fence ---
 
 ## src
 
+### src/config/defaults.js
+```
+module.exports = { DEFAULTS }  :161-161
+```
+
+### src/format/terse.js
+```
+module.exports = { encodeTerseSig, encodeTerseSigs, measureTerse, splitAnchor }  :86-86
+function splitAnchor(sig) → { text: string, suffix: s  :25-30
+function encodeTerseSig(sig) → string  :37-50
+function encodeTerseSigs(sigs) → string[]  :57-59
+function _tokens(sigs)  :62-64
+function measureTerse(sigsList) → { beforeTokens: number, a  :72-84
+```
+
 ### src/mcp/server.js
 ```
 module.exports = { start }  :140-140
@@ -186,6 +202,20 @@ function respond(id, result)  :28-30
 function respondError(id, code, message)  :32-36
 function dispatch(msg, cwd)  :41-107
 function start(cwd)  :112-138
+```
+
+### src/wiki/generate.js
+```
+module.exports = { buildWiki, renderWikiMarkdown }  :250-250
+function _rel(cwd, f)  :22-24
+function _pct(fraction)  :26-28
+function _identity(cwd)  :31-37
+function _modules(index)  :40-67
+function _flow(cwd)  :70-97
+function _conventions(cwd, index)  :100-117
+function _health(cwd)  :119-127
+function buildWiki(cwd, opts = {}) → { data: object, markdown:  :137-162
+function renderWikiMarkdown(data, sigmapVersion) → string  :171-248
 ```
 
 ### src/analysis/coverage-score.js
@@ -223,11 +253,6 @@ function loadCache(cwd, currentVersion) → Map<string, { mtime: numb  :32-42
 function saveCache(cwd, currentVersion, cache)  :51-61
 function getChangedFiles(files, cache) → { changed: string[], unch  :71-88
 function updateCacheEntries(cache, extracted)  :96-103
-```
-
-### src/config/defaults.js
-```
-module.exports = { DEFAULTS }  :161-161
 ```
 
 ### src/config/loader.js
@@ -902,16 +927,6 @@ function outputPath(cwd)  :7-7
 function getShortCommit(cwd)  :9-11
 function detectVersion(cwd)  :13-19
 function format(context, cwd, writtenFiles, sigmapVersion)  :21-69
-```
-
-### src/format/terse.js
-```
-module.exports = { encodeTerseSig, encodeTerseSigs, measureTerse, splitAnchor }  :86-86
-function splitAnchor(sig) → { text: string, suffix: s  :25-30
-function encodeTerseSig(sig) → string  :37-50
-function encodeTerseSigs(sigs) → string[]  :57-59
-function _tokens(sigs)  :62-64
-function measureTerse(sigsList) → { beforeTokens: number, a  :72-84
 ```
 
 ### src/format/usage-guidance.js

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -114,6 +114,7 @@ sigmap verify-plan <plan.md|->           Check a plan vs the live index — file
 sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
 sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
+sigmap wiki                              Deterministic architecture wiki from signatures + graph — no LLM (--json, --out <path>)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)

--- a/gen-context.js
+++ b/gen-context.js
@@ -18625,6 +18625,260 @@ __factories["./src/verify/parsers"] = function(module, exports) {
   
 };
 
+// ── ./src/wiki/generate ──
+__factories["./src/wiki/generate"] = function(module, exports) {
+  
+  /**
+   * Wiki generation (D9) — `sigmap wiki`.
+   *
+   * Deterministic architecture narrative composed from data SigMap already
+   * computes: the signature index, the dependency graph, conventions, and the
+   * health score. Template prose only — no LLM, no network, no timestamps —
+   * so two runs on an unchanged repo produce byte-identical markdown.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const HUB_LIMIT = 8;
+  const ENTRY_LIMIT = 8;
+  const MODULE_LIMIT = 20;
+  const KEY_FILE_LIMIT = 3;
+
+  // Graph keys come from src/graph/builder's normalizePath (normalized +
+  // lowercased), so relativize against the same normalization of cwd.
+  function _rel(cwd, f) {
+    return path.relative(path.normalize(cwd).toLowerCase(), f).replace(/\\/g, '/');
+  }
+
+  function _pct(fraction) {
+    return Math.round(fraction * 100);
+  }
+
+  /** Project name + version from package.json, falling back to the dir name. */
+  function _identity(cwd) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      if (pkg && pkg.name) return { name: pkg.name, version: pkg.version || null };
+    } catch (_) {}
+    return { name: path.basename(cwd), version: null };
+  }
+
+  /** Module rollup from the signature index (keys are cwd-relative paths). */
+  function _modules(index) {
+    const groups = new Map();
+    let totalTokens = 0;
+    for (const [rel, sigs] of index.entries()) {
+      const parts = String(rel).replace(/\\/g, '/').split('/');
+      const mod = parts.length > 1 ? parts[0] : '.';
+      const tokens = Math.ceil((sigs || []).join('\n').length / 4);
+      totalTokens += tokens;
+      if (!groups.has(mod)) groups.set(mod, { name: mod, files: 0, tokens: 0, fileSigs: [] });
+      const g = groups.get(mod);
+      g.files++;
+      g.tokens += tokens;
+      g.fileSigs.push({ file: rel, sigCount: (sigs || []).length });
+    }
+    const modules = [...groups.values()]
+      .sort((a, b) => b.tokens - a.tokens || a.name.localeCompare(b.name))
+      .slice(0, MODULE_LIMIT)
+      .map((g) => ({
+        name: g.name,
+        files: g.files,
+        tokens: g.tokens,
+        keyFiles: g.fileSigs
+          .sort((a, b) => b.sigCount - a.sigCount || a.file.localeCompare(b.file))
+          .slice(0, KEY_FILE_LIMIT)
+          .map((f) => f.file),
+      }));
+    return { modules, totalTokens };
+  }
+
+  /** Hubs, entry points, and cycle count from the dependency graph. */
+  function _flow(cwd) {
+    try {
+      const { buildFromCwd } = __require('./src/graph/builder');
+      const { detectCycles } = __require('./src/map/import-graph');
+      const graph = buildFromCwd(cwd);
+      if (!graph || !graph.forward || graph.forward.size === 0) return null;
+
+      const importersOf = (f) => (graph.reverse.get(f) || []).length;
+      const hubs = [...graph.reverse.entries()]
+        .map(([f, importers]) => ({ file: _rel(cwd, f), importers: importers.length }))
+        .filter((h) => h.importers > 0)
+        .sort((a, b) => b.importers - a.importers || a.file.localeCompare(b.file))
+        .slice(0, HUB_LIMIT);
+
+      const entryPoints = [...graph.forward.entries()]
+        .filter(([f, deps]) => deps.length > 0 && importersOf(f) === 0)
+        .map(([f, deps]) => ({ file: _rel(cwd, f), imports: deps.length }))
+        .sort((a, b) => b.imports - a.imports || a.file.localeCompare(b.file))
+        .slice(0, ENTRY_LIMIT);
+
+      let cycles = 0;
+      try { cycles = detectCycles(graph.forward).length; } catch (_) {}
+
+      return { hubs, entryPoints, cycles, edges: graph.forward.size };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /** Conventions summary; index keys are resolved back to absolute paths. */
+  function _conventions(cwd, index) {
+    try {
+      const { extractConventions } = __require('./src/conventions/extract');
+      const files = [...index.keys()].map((rel) => path.join(cwd, rel));
+      const c = extractConventions(cwd, files);
+      return {
+        fileNaming: c.fileNaming
+          ? { dominant: c.fileNaming.dominant, pct: _pct(c.fileNaming.dominantPct || 0), tier: c.fileNaming.tier }
+          : null,
+        exportStyle: c.exportStyle
+          ? { dominant: c.exportStyle.dominant, pct: _pct(c.exportStyle.dominantPct || 0), tier: c.exportStyle.tier }
+          : null,
+        testFramework: c.testFramework || null,
+      };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function _health(cwd) {
+    try {
+      const { score } = __require('./src/health/scorer');
+      const h = score(cwd);
+      return { score: h.score, grade: h.grade };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Build the wiki. Every data source is optional — a repo with no context file
+   * or no resolvable graph still yields a valid document.
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {string} [opts.version] SigMap version stamped in the header
+   * @returns {{ data: object, markdown: string }}
+   */
+  function buildWiki(cwd, opts = {}) {
+    let index = new Map();
+    try {
+      const { buildSigIndex } = __require('./src/retrieval/ranker');
+      index = buildSigIndex(cwd);
+    } catch (_) {}
+
+    const identity = _identity(cwd);
+    const { modules, totalTokens } = _modules(index);
+    const flow = _flow(cwd);
+    const conventions = index.size ? _conventions(cwd, index) : null;
+    const health = _health(cwd);
+
+    const data = {
+      name: identity.name,
+      version: identity.version,
+      files: index.size,
+      modules,
+      totalTokens,
+      flow,
+      conventions,
+      health,
+    };
+
+    return { data, markdown: renderWikiMarkdown(data, opts.version) };
+  }
+
+  /**
+   * Render the narrative markdown. Pure function of `data` — no clocks, no
+   * randomness — so output is byte-stable for a fixed repo state.
+   * @param {object} data
+   * @param {string} [sigmapVersion]
+   * @returns {string}
+   */
+  function renderWikiMarkdown(data, sigmapVersion) {
+    const L = [];
+    const title = data.version ? `${data.name} v${data.version}` : data.name;
+    L.push(`# ${title} — Architecture Wiki`);
+    L.push('');
+    L.push(`_Deterministically generated from signatures + dependency graph by SigMap${sigmapVersion ? ` v${sigmapVersion}` : ''} — no LLM. Regenerate: \`sigmap wiki\`._`);
+    L.push('');
+
+    L.push('## Overview');
+    if (data.files === 0) {
+      L.push('No signature index found yet — run `sigmap` (or `node gen-context.js`) to generate context, then regenerate this wiki.');
+    } else {
+      const fileWord = data.files === 1 ? 'indexed file' : 'indexed files';
+      const modWord = data.modules.length === 1 ? 'top-level module' : 'top-level modules';
+      L.push(`The codebase spans **${data.files} ${fileWord}** across **${data.modules.length} ${modWord}**, with ~${data.totalTokens} tokens of extracted signatures.`);
+      if (data.health) {
+        L.push(`Context health: **${data.health.score}/100 (${data.health.grade})**.`);
+      }
+    }
+    L.push('');
+
+    if (data.modules.length) {
+      L.push('## Modules');
+      L.push('| Module | Files | Sig tokens | Key files |');
+      L.push('|--------|-------|------------|-----------|');
+      for (const m of data.modules) {
+        L.push(`| \`${m.name}\` | ${m.files} | ~${m.tokens} | ${m.keyFiles.map((f) => `\`${f}\``).join(', ')} |`);
+      }
+      const top = data.modules[0];
+      L.push('');
+      L.push(`The largest module by signature volume is \`${top.name}\` (${top.files} files, ~${top.tokens} tokens) — start there for the core logic.`);
+      L.push('');
+    }
+
+    if (data.flow) {
+      L.push('## Dependency flow');
+      if (data.flow.hubs.length) {
+        L.push('The most depended-on files — changes here have the widest blast radius:');
+        L.push('');
+        L.push('| Hub file | Importers |');
+        L.push('|----------|-----------|');
+        for (const h of data.flow.hubs) L.push(`| \`${h.file}\` | ${h.importers} |`);
+        L.push('');
+      }
+      if (data.flow.entryPoints.length) {
+        L.push('Entry points (imported by nothing, importing the rest):');
+        L.push('');
+        for (const e of data.flow.entryPoints) L.push(`- \`${e.file}\` → ${e.imports} imports`);
+        L.push('');
+      }
+      L.push(data.flow.cycles
+        ? `**Dependency cycles:** ${data.flow.cycles} — untangle these first when refactoring.`
+        : '**Dependency cycles:** none detected.');
+      L.push('');
+    }
+
+    if (data.conventions) {
+      L.push('## Conventions');
+      const c = data.conventions;
+      const bits = [];
+      if (c.fileNaming && c.fileNaming.dominant) bits.push(`file naming is predominantly **${c.fileNaming.dominant}** (${c.fileNaming.pct}%, ${c.fileNaming.tier})`);
+      if (c.exportStyle && c.exportStyle.dominant) bits.push(`exports use the **${c.exportStyle.dominant}** style (${c.exportStyle.pct}%, ${c.exportStyle.tier})`);
+      if (c.testFramework) bits.push(`tests run on **${c.testFramework}**`);
+      L.push(bits.length
+        ? `In this repo, ${bits.join('; ')}. New code should match.`
+        : 'No dominant conventions detected (repo too small or styles mixed).');
+      L.push('');
+    }
+
+    L.push('## Navigating');
+    L.push('- `sigmap ask "<question>"` — ranked, budgeted mini-context for any task');
+    L.push('- `sigmap --impact <file>` / `--callers <symbol>` — blast radius before you change something');
+    L.push('- `sigmap evidence "<query>"` — machine-consumable Evidence Pack (JSON) for agents/CI');
+    L.push('- MCP: `get_architecture_overview`, `get_map`, `get_callee_signatures` for live agent access');
+    L.push('');
+
+    return L.join('\n');
+  }
+
+  module.exports = { buildWiki, renderWikiMarkdown };
+  
+};
+
 // ── ./src/workspace/detector ──
 __factories["./src/workspace/detector"] = function(module, exports) {
   
@@ -20607,6 +20861,7 @@ Usage:
   ${cmd} review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
   ${cmd} review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
   ${cmd} create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
+  ${cmd} wiki                              Deterministic architecture wiki from signatures + graph — no LLM (--json, --out <path>)
   ${cmd} squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
   ${cmd} squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
   ${cmd} ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)
@@ -22225,6 +22480,30 @@ function main() {
       console.log(formatDoctor(result));
     }
     process.exit(result.ok ? 0 : 1);
+  }
+
+  // D9: `sigmap wiki` — deterministic architecture narrative (no LLM).
+  if (args[0] === 'wiki') {
+    const { buildWiki } = requireSourceOrBundled('./src/wiki/generate');
+    const result = buildWiki(cwd, { version: VERSION });
+    if (args.includes('--json')) {
+      process.stdout.write(JSON.stringify(result.data, null, 2) + '\n');
+      process.exit(0);
+    }
+    const outIdx = args.indexOf('--out');
+    const outRel = outIdx >= 0 && args[outIdx + 1] && !args[outIdx + 1].startsWith('--')
+      ? args[outIdx + 1]
+      : path.join('.context', 'WIKI.md');
+    const outPath = path.resolve(cwd, outRel);
+    try {
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.writeFileSync(outPath, result.markdown, 'utf8');
+    } catch (e) {
+      console.error(`[sigmap] cannot write ${outPath}: ${e.message}`);
+      process.exit(1);
+    }
+    console.log(`[sigmap] wiki → ${path.relative(cwd, outPath)} (${result.data.files} files · ${result.data.modules.length} modules)`);
+    process.exit(0);
   }
 
   // Layer 3: `sigmap conventions` — extract & report repo coding conventions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -114,6 +114,7 @@ sigmap verify-plan <plan.md|->           Check a plan vs the live index — file
 sigmap review-pr                         Audit a diff — scope drift, god-node edits, missing tests, security files (--staged, --base, --json, --markdown)
 sigmap review-pr --markdown              PR Evidence Report — branded Markdown (signatures + blast radius + tests) to post as a PR comment
 sigmap create "<task>"                   Grounded-creation pipeline: scaffold → verify-plan → verify-ai-output → review-pr (--staged)
+sigmap wiki                              Deterministic architecture wiki from signatures + graph — no LLM (--json, --out <path>)
 sigmap squeeze <file|->                  Minimize a pasted stacktrace/CI-log/JSON blob (--json for stats)
 sigmap squeeze --response <file|->       Minimize an agent/tool response (same engine; also exposed as the squeeze_output MCP tool)
 sigmap ask "<query>" --squeeze           Auto-accept input minimization (no prompt; for scripts/CI)

--- a/src/wiki/generate.js
+++ b/src/wiki/generate.js
@@ -1,0 +1,250 @@
+'use strict';
+
+/**
+ * Wiki generation (D9) — `sigmap wiki`.
+ *
+ * Deterministic architecture narrative composed from data SigMap already
+ * computes: the signature index, the dependency graph, conventions, and the
+ * health score. Template prose only — no LLM, no network, no timestamps —
+ * so two runs on an unchanged repo produce byte-identical markdown.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HUB_LIMIT = 8;
+const ENTRY_LIMIT = 8;
+const MODULE_LIMIT = 20;
+const KEY_FILE_LIMIT = 3;
+
+// Graph keys come from src/graph/builder's normalizePath (normalized +
+// lowercased), so relativize against the same normalization of cwd.
+function _rel(cwd, f) {
+  return path.relative(path.normalize(cwd).toLowerCase(), f).replace(/\\/g, '/');
+}
+
+function _pct(fraction) {
+  return Math.round(fraction * 100);
+}
+
+/** Project name + version from package.json, falling back to the dir name. */
+function _identity(cwd) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    if (pkg && pkg.name) return { name: pkg.name, version: pkg.version || null };
+  } catch (_) {}
+  return { name: path.basename(cwd), version: null };
+}
+
+/** Module rollup from the signature index (keys are cwd-relative paths). */
+function _modules(index) {
+  const groups = new Map();
+  let totalTokens = 0;
+  for (const [rel, sigs] of index.entries()) {
+    const parts = String(rel).replace(/\\/g, '/').split('/');
+    const mod = parts.length > 1 ? parts[0] : '.';
+    const tokens = Math.ceil((sigs || []).join('\n').length / 4);
+    totalTokens += tokens;
+    if (!groups.has(mod)) groups.set(mod, { name: mod, files: 0, tokens: 0, fileSigs: [] });
+    const g = groups.get(mod);
+    g.files++;
+    g.tokens += tokens;
+    g.fileSigs.push({ file: rel, sigCount: (sigs || []).length });
+  }
+  const modules = [...groups.values()]
+    .sort((a, b) => b.tokens - a.tokens || a.name.localeCompare(b.name))
+    .slice(0, MODULE_LIMIT)
+    .map((g) => ({
+      name: g.name,
+      files: g.files,
+      tokens: g.tokens,
+      keyFiles: g.fileSigs
+        .sort((a, b) => b.sigCount - a.sigCount || a.file.localeCompare(b.file))
+        .slice(0, KEY_FILE_LIMIT)
+        .map((f) => f.file),
+    }));
+  return { modules, totalTokens };
+}
+
+/** Hubs, entry points, and cycle count from the dependency graph. */
+function _flow(cwd) {
+  try {
+    const { buildFromCwd } = require('../graph/builder');
+    const { detectCycles } = require('../map/import-graph');
+    const graph = buildFromCwd(cwd);
+    if (!graph || !graph.forward || graph.forward.size === 0) return null;
+
+    const importersOf = (f) => (graph.reverse.get(f) || []).length;
+    const hubs = [...graph.reverse.entries()]
+      .map(([f, importers]) => ({ file: _rel(cwd, f), importers: importers.length }))
+      .filter((h) => h.importers > 0)
+      .sort((a, b) => b.importers - a.importers || a.file.localeCompare(b.file))
+      .slice(0, HUB_LIMIT);
+
+    const entryPoints = [...graph.forward.entries()]
+      .filter(([f, deps]) => deps.length > 0 && importersOf(f) === 0)
+      .map(([f, deps]) => ({ file: _rel(cwd, f), imports: deps.length }))
+      .sort((a, b) => b.imports - a.imports || a.file.localeCompare(b.file))
+      .slice(0, ENTRY_LIMIT);
+
+    let cycles = 0;
+    try { cycles = detectCycles(graph.forward).length; } catch (_) {}
+
+    return { hubs, entryPoints, cycles, edges: graph.forward.size };
+  } catch (_) {
+    return null;
+  }
+}
+
+/** Conventions summary; index keys are resolved back to absolute paths. */
+function _conventions(cwd, index) {
+  try {
+    const { extractConventions } = require('../conventions/extract');
+    const files = [...index.keys()].map((rel) => path.join(cwd, rel));
+    const c = extractConventions(cwd, files);
+    return {
+      fileNaming: c.fileNaming
+        ? { dominant: c.fileNaming.dominant, pct: _pct(c.fileNaming.dominantPct || 0), tier: c.fileNaming.tier }
+        : null,
+      exportStyle: c.exportStyle
+        ? { dominant: c.exportStyle.dominant, pct: _pct(c.exportStyle.dominantPct || 0), tier: c.exportStyle.tier }
+        : null,
+      testFramework: c.testFramework || null,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function _health(cwd) {
+  try {
+    const { score } = require('../health/scorer');
+    const h = score(cwd);
+    return { score: h.score, grade: h.grade };
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Build the wiki. Every data source is optional — a repo with no context file
+ * or no resolvable graph still yields a valid document.
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {string} [opts.version] SigMap version stamped in the header
+ * @returns {{ data: object, markdown: string }}
+ */
+function buildWiki(cwd, opts = {}) {
+  let index = new Map();
+  try {
+    const { buildSigIndex } = require('../retrieval/ranker');
+    index = buildSigIndex(cwd);
+  } catch (_) {}
+
+  const identity = _identity(cwd);
+  const { modules, totalTokens } = _modules(index);
+  const flow = _flow(cwd);
+  const conventions = index.size ? _conventions(cwd, index) : null;
+  const health = _health(cwd);
+
+  const data = {
+    name: identity.name,
+    version: identity.version,
+    files: index.size,
+    modules,
+    totalTokens,
+    flow,
+    conventions,
+    health,
+  };
+
+  return { data, markdown: renderWikiMarkdown(data, opts.version) };
+}
+
+/**
+ * Render the narrative markdown. Pure function of `data` — no clocks, no
+ * randomness — so output is byte-stable for a fixed repo state.
+ * @param {object} data
+ * @param {string} [sigmapVersion]
+ * @returns {string}
+ */
+function renderWikiMarkdown(data, sigmapVersion) {
+  const L = [];
+  const title = data.version ? `${data.name} v${data.version}` : data.name;
+  L.push(`# ${title} — Architecture Wiki`);
+  L.push('');
+  L.push(`_Deterministically generated from signatures + dependency graph by SigMap${sigmapVersion ? ` v${sigmapVersion}` : ''} — no LLM. Regenerate: \`sigmap wiki\`._`);
+  L.push('');
+
+  L.push('## Overview');
+  if (data.files === 0) {
+    L.push('No signature index found yet — run `sigmap` (or `node gen-context.js`) to generate context, then regenerate this wiki.');
+  } else {
+    const fileWord = data.files === 1 ? 'indexed file' : 'indexed files';
+    const modWord = data.modules.length === 1 ? 'top-level module' : 'top-level modules';
+    L.push(`The codebase spans **${data.files} ${fileWord}** across **${data.modules.length} ${modWord}**, with ~${data.totalTokens} tokens of extracted signatures.`);
+    if (data.health) {
+      L.push(`Context health: **${data.health.score}/100 (${data.health.grade})**.`);
+    }
+  }
+  L.push('');
+
+  if (data.modules.length) {
+    L.push('## Modules');
+    L.push('| Module | Files | Sig tokens | Key files |');
+    L.push('|--------|-------|------------|-----------|');
+    for (const m of data.modules) {
+      L.push(`| \`${m.name}\` | ${m.files} | ~${m.tokens} | ${m.keyFiles.map((f) => `\`${f}\``).join(', ')} |`);
+    }
+    const top = data.modules[0];
+    L.push('');
+    L.push(`The largest module by signature volume is \`${top.name}\` (${top.files} files, ~${top.tokens} tokens) — start there for the core logic.`);
+    L.push('');
+  }
+
+  if (data.flow) {
+    L.push('## Dependency flow');
+    if (data.flow.hubs.length) {
+      L.push('The most depended-on files — changes here have the widest blast radius:');
+      L.push('');
+      L.push('| Hub file | Importers |');
+      L.push('|----------|-----------|');
+      for (const h of data.flow.hubs) L.push(`| \`${h.file}\` | ${h.importers} |`);
+      L.push('');
+    }
+    if (data.flow.entryPoints.length) {
+      L.push('Entry points (imported by nothing, importing the rest):');
+      L.push('');
+      for (const e of data.flow.entryPoints) L.push(`- \`${e.file}\` → ${e.imports} imports`);
+      L.push('');
+    }
+    L.push(data.flow.cycles
+      ? `**Dependency cycles:** ${data.flow.cycles} — untangle these first when refactoring.`
+      : '**Dependency cycles:** none detected.');
+    L.push('');
+  }
+
+  if (data.conventions) {
+    L.push('## Conventions');
+    const c = data.conventions;
+    const bits = [];
+    if (c.fileNaming && c.fileNaming.dominant) bits.push(`file naming is predominantly **${c.fileNaming.dominant}** (${c.fileNaming.pct}%, ${c.fileNaming.tier})`);
+    if (c.exportStyle && c.exportStyle.dominant) bits.push(`exports use the **${c.exportStyle.dominant}** style (${c.exportStyle.pct}%, ${c.exportStyle.tier})`);
+    if (c.testFramework) bits.push(`tests run on **${c.testFramework}**`);
+    L.push(bits.length
+      ? `In this repo, ${bits.join('; ')}. New code should match.`
+      : 'No dominant conventions detected (repo too small or styles mixed).');
+    L.push('');
+  }
+
+  L.push('## Navigating');
+  L.push('- `sigmap ask "<question>"` — ranked, budgeted mini-context for any task');
+  L.push('- `sigmap --impact <file>` / `--callers <symbol>` — blast radius before you change something');
+  L.push('- `sigmap evidence "<query>"` — machine-consumable Evidence Pack (JSON) for agents/CI');
+  L.push('- MCP: `get_architecture_overview`, `get_map`, `get_callee_signatures` for live agent access');
+  L.push('');
+
+  return L.join('\n');
+}
+
+module.exports = { buildWiki, renderWikiMarkdown };

--- a/test/integration/wiki.test.js
+++ b/test/integration/wiki.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap wiki` (D9, #465).
+ *
+ * Covers: generation of .context/WIKI.md with the required sections,
+ * byte-identical determinism across consecutive runs, --json structured
+ * output, --out path override, the no-context fallback, and --help.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function run(dir, ...args) {
+  return spawnSync(process.execPath, [GEN_CONTEXT, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+function withProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-wiki-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'util.js'), [
+      'function formatUser(user, style) {',
+      '  return String(user);',
+      '}',
+      'module.exports = { formatUser };',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(dir, 'src', 'app.js'), [
+      "const { formatUser } = require('./util');",
+      'async function fetchUser(id, opts = {}) {',
+      '  return formatUser({ id });',
+      '}',
+      'module.exports = { fetchUser };',
+      '',
+    ].join('\n'));
+    const gen = run(dir);
+    assert.strictEqual(gen.status, 0, gen.stderr);
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── generation ──────────────────────────────────────────────────────────────
+
+test('wiki writes .context/WIKI.md with the required sections', () => {
+  withProject((dir) => {
+    const res = run(dir, 'wiki');
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(/\[sigmap\] wiki → \.context\/WIKI\.md \(\d+ files · \d+ modules\)/.test(res.stdout), res.stdout);
+    const md = fs.readFileSync(path.join(dir, '.context', 'WIKI.md'), 'utf8');
+    for (const section of ['## Overview', '## Modules', '## Dependency flow', '## Conventions', '## Navigating']) {
+      assert.ok(md.includes(section), `missing ${section}`);
+    }
+    assert.ok(md.includes('**2 indexed files**'), md.split('\n').find((l) => l.includes('indexed')));
+    assert.ok(md.includes('`src/util.js`'), 'util.js missing from wiki');
+    assert.ok(md.includes('Entry points'), 'entry points missing');
+    assert.ok(md.includes('none detected'), 'cycle line missing');
+  });
+});
+
+test('wiki output is byte-identical across consecutive runs (determinism)', () => {
+  withProject((dir) => {
+    assert.strictEqual(run(dir, 'wiki').status, 0);
+    const first = fs.readFileSync(path.join(dir, '.context', 'WIKI.md'), 'utf8');
+    assert.strictEqual(run(dir, 'wiki').status, 0);
+    const second = fs.readFileSync(path.join(dir, '.context', 'WIKI.md'), 'utf8');
+    assert.strictEqual(first, second, 'consecutive runs differ');
+    assert.ok(!/\d{4}-\d{2}-\d{2}T\d{2}/.test(first), 'wiki contains a timestamp');
+  });
+});
+
+test('wiki --json emits structured data and writes no file', () => {
+  withProject((dir) => {
+    const res = run(dir, 'wiki', '--json');
+    assert.strictEqual(res.status, 0, res.stderr);
+    const data = JSON.parse(res.stdout);
+    assert.strictEqual(data.files, 2);
+    assert.ok(Array.isArray(data.modules) && data.modules[0].name === 'src', JSON.stringify(data.modules));
+    assert.ok(data.flow && data.flow.hubs.some((h) => h.file === 'src/util.js'), JSON.stringify(data.flow));
+    assert.ok(!fs.existsSync(path.join(dir, '.context', 'WIKI.md')), '--json should not write WIKI.md');
+  });
+});
+
+test('wiki --out overrides the output path', () => {
+  withProject((dir) => {
+    const res = run(dir, 'wiki', '--out', 'docs/ARCH.md');
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(fs.existsSync(path.join(dir, 'docs', 'ARCH.md')), 'custom path missing');
+    assert.ok(!fs.existsSync(path.join(dir, '.context', 'WIKI.md')), 'default path should not be written with --out');
+  });
+});
+
+test('wiki degrades gracefully with no context file (no crash, valid doc)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-wiki-empty-'));
+  try {
+    const res = run(dir, 'wiki');
+    assert.strictEqual(res.status, 0, res.stderr);
+    const md = fs.readFileSync(path.join(dir, '.context', 'WIKI.md'), 'utf8');
+    assert.ok(md.includes('No signature index found'), md.slice(0, 300));
+    assert.ok(md.includes('## Navigating'), 'navigating section missing in fallback');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--help documents wiki', () => {
+  const res = spawnSync(process.execPath, [GEN_CONTEXT, '--help'], { encoding: 'utf8' });
+  assert.ok((res.stdout || '').includes('wiki'), 'missing wiki in help');
+});
+
+console.log(`\nwiki: ${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 19,
-  "tests": 116,
+  "tests": 117,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #465. Implements MASTER_PLAN §3.5 **D9** — the last unstarted in-boundary item. With this merged, every in-boundary initiative in the v7.26→v9.5 backlog is shipped.

## What
- **`sigmap wiki`** writes `.context/WIKI.md` — a deterministic architecture narrative composed from data SigMap already computes (signature index, dependency graph, conventions, health). Template prose only: **no LLM, no network, no timestamps** — the Philosophy Gate holds.
- Sections: Overview (files/modules/sig tokens + health grade) · Modules (rollup + key files) · Dependency flow (hubs, entry points, cycle count) · Conventions (naming/export style/test framework) · Navigating (ask/impact/evidence/MCP pointers).
- `--out <path>` overrides the target; `--json` emits the structured data instead of writing a file.

## Determinism (tested)
Two consecutive runs on an unchanged repo are **byte-identical** — asserted both on a fixture (integration test) and manually on this repo. No clocks or randomness anywhere in the render path.

## Fix folded in
Graph keys from `src/graph/builder` are normalized + lowercased absolute paths; the wiki relativizes against the same normalized base so hub/entry paths render repo-relative (caught by the test suite on macOS tmpdirs — `get_architecture_overview` has the same latent quirk, left untouched/out of scope).

## Tests
6 new integration tests (`test/integration/wiki.test.js`): sections, byte-identical determinism, `--json`, `--out`, no-context fallback, `--help`. Full suite **111/111 green** + unit pass; version-meta 116→117; llms regenerated. `AGENTS.md` refresh is a **separate commit** this time for a clean review diff.

Supply-chain gate: local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 529KB/157 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)