### PR TITLE
feat: method-level blast-radius scoring — review-pr, PR Evidence, get_method_impact MCP (GR2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,22 +33,16 @@ Always run `sigmap ask` (or `sigmap --query`) before searching for files relevan
 src/extractors/python_ast.py ← ast
 ```
 
-## changes (last 5 commits — 0 seconds ago)
+## changes (last 5 commits — 1 second ago)
 ```
 src/format/terse.js                           +splitAnchor  +encodeTerseSig  +encodeTerseSigs  +_tokens
+src/graph/blast-radius.js                     +tierFor  +_normRel  +_bfs  +methodBlastRadius
+src/mcp/handlers.js                           +that  +getMethodImpact  ~queryContext  ~squeezeOutput
+src/mcp/server.js                             ~dispatch
+src/mcp/tools.js                              +it
+src/review/pr-evidence.js                     ~buildPrEvidence  ~formatPrEvidenceMarkdown
+src/review/review-pr.js                       ~isSource  ~reviewPr
 src/wiki/generate.js                          +_rel  +_pct  +_identity  +_modules
-src/conventions/extract.js                    ~classifyNaming  ~scoreConvention
-src/conventions/fix.js                        ~buildFixList
-src/extractors/javascript.js                  ~extract  ~extractClassMembers  ~extractBlock  ~buildReturnHints
-src/extractors/typescript.js                  ~extract  ~extractInterfaceMembers  ~extractClassMembers  ~extractBlock
-src/graph/builder.js                          +probeJs  +resolveJsPath  +stripJsonc  +loadAliasMap
-src/graph/impact.js                           ~formatImpact
-src/health/scorer.js                          +gradeFor  +composeHealth  +score  ~score
-src/judge/judge-engine.js                     +extracts  +claimGrounding  ~groundedness  ~judge
-src/plan/planner.js                           +createPlan  ~createPlan
-src/review/pr-evidence.js                     ~formatPrEvidenceMarkdown
-src/review/review-pr.js                       ~reviewPr
-src/util/truncate.js                          +members  +capWithNotice  +block  +capMembersWithNotice
 ```
 
 ## packages
@@ -195,13 +189,70 @@ function _tokens(sigs)  :62-64
 function measureTerse(sigsList) → { beforeTokens: number, a  :72-84
 ```
 
+### src/graph/blast-radius.js
+```
+module.exports = { methodBlastRadius, tierFor, DIRECT_WEIGHT, TRANSITIVE_WEIGHT }  :132-132
+function tierFor(score)  :25-31
+function _normRel(p)  :33-35
+function _bfs(seedIds, reverse, maxDepth)  :38-60
+function methodBlastRadius(changedFiles, cwd, opts = {}) → { * available: boolean, *  :78-130
+```
+
+### src/mcp/handlers.js
+```
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput }  :966-966
+function _readContextFiles(cwd)  :10-17
+function readContext(args, cwd)  :36-66
+function searchSignatures(args, cwd)  :74-100
+function getMap(args, cwd)  :108-131
+function createCheckpoint(args, cwd)  :143-215
+function getRouting(args, cwd)  :224-261
+function explainFile(args, cwd)  :269-356
+function listModules(args, cwd)  :364-403
+function queryContext(args, cwd)  :411-429
+function getMethodImpact(args, cwd)  :437-451
+function getImpact(args, cwd)  :459-471
+function getLines(args, cwd)  :480-528
+function readMemory(args, cwd)  :536-571
+function getCalleeSignatures(args, cwd)  :580-625
+function _pkgVersion(cwd)  :632-635
+function notifyFileCreated(args, cwd)  :639-661
+function notifySymbolAdded(args, cwd)  :664-684
+function notifyFileDeleted(args, cwd)  :687-701
+function _changedFiles(cwd, args)  :707-719
+function getDiffContext(args, cwd)  :728-799
+function getArchitectureOverview(args, cwd)  :808-876
+function verifySuggestion(args, cwd)  :886-921
+function squeezeOutput(args, cwd)  :931-964
+```
+
 ### src/mcp/server.js
 ```
-module.exports = { start }  :140-140
+module.exports = { start }  :141-141
 function respond(id, result)  :28-30
 function respondError(id, code, message)  :32-36
-function dispatch(msg, cwd)  :41-107
-function start(cwd)  :112-138
+function dispatch(msg, cwd)  :41-108
+function start(cwd)  :113-139
+```
+
+### src/mcp/tools.js
+```
+module.exports = { TOOLS }  :392-392
+```
+
+### src/review/pr-evidence.js
+```
+module.exports = { buildPrEvidence, formatPrEvidenceMarkdown }  :157-157
+function buildPrEvidence(changedFiles, cwd, opts = {}) → { scope:string, files:obj  :31-84
+function formatPrEvidenceMarkdown(evidence, opts = {})  :89-155
+```
+
+### src/review/review-pr.js
+```
+module.exports = { reviewPr, SECURITY_PATTERNS, GOD_NODE_THRESHOLD, SCOPE_DIR_THRESHOLD }  :150-150
+function isTestFile(p)  :32-34
+function isSource(p)  :35-37
+function reviewPr(changedFiles, cwd, opts = {}) → { findings: object[], bla  :48-148
 ```
 
 ### src/wiki/generate.js
@@ -1099,33 +1150,6 @@ function shouldSkipFile(rel)  :18-21
 function analyze(files, cwd)  :23-125
 ```
 
-### src/mcp/handlers.js
-```
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput }  :944-944
-function _readContextFiles(cwd)  :10-17
-function readContext(args, cwd)  :36-66
-function searchSignatures(args, cwd)  :74-100
-function getMap(args, cwd)  :108-131
-function createCheckpoint(args, cwd)  :143-215
-function getRouting(args, cwd)  :224-261
-function explainFile(args, cwd)  :269-356
-function listModules(args, cwd)  :364-403
-function queryContext(args, cwd)  :411-429
-function getImpact(args, cwd)  :437-449
-function getLines(args, cwd)  :458-506
-function readMemory(args, cwd)  :514-549
-function getCalleeSignatures(args, cwd)  :558-603
-function _pkgVersion(cwd)  :610-613
-function notifyFileCreated(args, cwd)  :617-639
-function notifySymbolAdded(args, cwd)  :642-662
-function notifyFileDeleted(args, cwd)  :665-679
-function _changedFiles(cwd, args)  :685-697
-function getDiffContext(args, cwd)  :706-777
-function getArchitectureOverview(args, cwd)  :786-854
-function verifySuggestion(args, cwd)  :864-899
-function squeezeOutput(args, cwd)  :909-942
-```
-
 ### src/mcp/install.js
 ```
 module.exports = { CLIENTS, listClients, installClient, resolveTarget }  :142-142
@@ -1136,11 +1160,6 @@ function _installJson(filePath, scriptPath)  :69-81
 function _installZed(filePath, scriptPath)  :84-96
 function _installYaml(filePath, scriptPath)  :99-117
 function installClient(client, opts = {}) → client, label, path, stat  :124-140
-```
-
-### src/mcp/tools.js
-```
-module.exports = { TOOLS }  :363-363
 ```
 
 ### src/nudge.js
@@ -1198,21 +1217,6 @@ function detectIntent(query)  :562-568
 ```
 module.exports = { tokenize, STOP_WORDS }  :54-54
 function tokenize(text, opts) → string[]  :31-52
-```
-
-### src/review/pr-evidence.js
-```
-module.exports = { buildPrEvidence, formatPrEvidenceMarkdown }  :140-140
-function buildPrEvidence(changedFiles, cwd, opts = {}) → { scope:string, files:obj  :31-77
-function formatPrEvidenceMarkdown(evidence, opts = {})  :82-138
-```
-
-### src/review/review-pr.js
-```
-module.exports = { reviewPr, SECURITY_PATTERNS, GOD_NODE_THRESHOLD, SCOPE_DIR_THRESHOLD }  :128-128
-function isTestFile(p)  :32-34
-function isSource(p)  :35-37
-function reviewPr(changedFiles, cwd, opts = {}) → { findings: object[], bla  :48-126
 ```
 
 ### src/routing/classifier.js

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 19 on-demand tools for Claude Code and Cursor:
+**MCP server** — 20 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp
@@ -267,7 +267,7 @@ SigMap treats coding agents as **consumers, not competitors**: it hands them a d
 
 | Agent | One-time setup | How it consumes SigMap |
 |---|---|---|
-| **Claude Code** | `sigmap mcp install claude` | 19 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`, `squeeze_output`…) |
+| **Claude Code** | `sigmap mcp install claude` | 20 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`, `squeeze_output`…) |
 | **Cursor** | `sigmap mcp install cursor` | MCP tools, plus the `cursor` adapter writes `.cursorrules` |
 | **Cline** | `sigmap mcp install cursor` | Reads `.cursorrules`; same MCP server |
 | **Continue** | `sigmap mcp install vscode` | MCP tools inside the Continue extension |

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 19 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 20 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 19 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 20 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 19 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 20 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.
@@ -115,6 +115,7 @@ All tools are available on-demand — your AI agent calls only what it needs.
 | `get_routing` | Returns the model tier hints table (fast / balanced / powerful per file) based on complexity scores. | none | `get_routing()` |
 | `query_context` | Ranks all files by relevance to a free-text query using TF-IDF scoring. Returns top-K files. New in v2.3. | `query` (required string), `topK` (optional number, default 10) | `query_context(query="authentication flow")` |
 | `get_impact` | Returns the blast radius of a file — direct importers, transitive importers, affected tests and routes. | `file` (required string), `depth` (optional number, default 3) | `get_impact(file="src/auth/service.ts")` |
+| `get_method_impact` | **Method-level blast radius** — every function that (transitively) calls a symbol, or with `direction="callees"` everything it calls. Finer-grained than `get_impact`: which *functions* break, not just which files. JS/TS + Python. New in v8.13. | `symbol` (required string, name or `file#name`), `direction` (optional "callers"\|"callees"), `depth` (optional number, default 0 = unlimited) | `get_method_impact(symbol="validateToken")` |
 | `get_lines` | **Surgical Context** demand-driven fetch: returns an exact line range from a file behind a `:start-end` anchor. Clamped to file bounds, secret-scanned, sandboxed to the project root. New in v6.12.0. | `file` (required string), `start` (required number), `end` (required number) | `get_lines(file="src/config/loader.js", start=42, end=58)` |
 | `read_memory` | **Memory** — recall the cross-session decision log (notes left via `sigmap note`) plus the last `ask` session focus. Kills agent cold-start. New in v6.15.0. | `limit` (optional number, default 10) | `read_memory(limit=10)` |
 | `get_diff_context` | Returns every changed file (working tree, staged, or vs a base ref) with its current signatures + blast radius (importers, tests, routes) + risk label. Lists files shell-free. New in v8.0. | `base` (optional string), `staged` (optional bool), `depth` (optional number, default 2) | `get_diff_context(base="main")` |
@@ -173,6 +174,7 @@ Expected output:
       { "name": "create_checkpoint" },
       { "name": "get_routing" },
       { "name": "query_context" },
+      { "name": "get_method_impact" },
       { "name": "get_impact" },
       { "name": "get_lines" },
       { "name": "read_memory" },

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.44 (49.2% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 19 |
+| MCP tools | — | 20 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -136,7 +136,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 19 tools
+## MCP server — 20 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -206,6 +206,14 @@ Rank and return the most relevant files for a specific task or question. Uses ke
 
 ```
 Input:  { query: string, topK?: number }
+```
+
+### get_method_impact
+
+Method-level blast radius for a symbol: every FUNCTION that (transitively) calls it — or, with direction "callees", every repo function it calls. Finer-grained than the file-level get_impact: tells an agent which functions break, not just which files. JS/TS + Python call-graph; deterministic, no LLM.
+
+```
+Input:  { symbol: string, direction?: string, depth?: number }
 ```
 
 ### get_impact

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer)
-- Languages: 33 supported · MCP tools: 19
+- Languages: 33 supported · MCP tools: 20
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/gen-context.js
+++ b/gen-context.js
@@ -10304,6 +10304,142 @@ __factories["./src/format/verify-report"] = function(module, exports) {
   
 };
 
+// ── ./src/graph/blast-radius ──
+__factories["./src/graph/blast-radius"] = function(module, exports) {
+  
+  /**
+   * Method-level blast-radius scoring (GR2).
+   *
+   * Consumes the D4 call-graph (src/graph/call-graph.js): for each changed file,
+   * resolve the functions it defines, BFS the reverse call edges, and score how
+   * much of the codebase transitively calls into the change. The score is a
+   * documented deterministic formula — no heuristics that vary run to run — so
+   * review-pr findings and PR Evidence lines are byte-stable for a fixed tree.
+   *
+   * Score: min(100, direct×4 + transitive×1). Tiers:
+   *   0 → none · 1–9 → low · 10–29 → medium · 30–59 → high · 60+ → critical
+   */
+
+  const path = require('path');
+  const { buildCallGraph } = __require('./src/graph/call-graph');
+
+  const DIRECT_WEIGHT = 4;
+  const TRANSITIVE_WEIGHT = 1;
+  const IMPACTED_FUNCTIONS_CAP = 12;
+
+  const TEST_FILE_RE = /\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.(py|go)$|(^|\/)(tests?|__tests__|spec)\//;
+
+  function tierFor(score) {
+    if (score >= 60) return 'critical';
+    if (score >= 30) return 'high';
+    if (score >= 10) return 'medium';
+    if (score >= 1) return 'low';
+    return 'none';
+  }
+
+  function _normRel(p) {
+    return String(p).replace(/\\/g, '/');
+  }
+
+  // BFS the reverse edges from a set of symbol ids; returns direct/transitive id sets.
+  function _bfs(seedIds, reverse, maxDepth) {
+    const direct = new Set();
+    const transitive = new Set();
+    const visited = new Set(seedIds);
+    let frontier = [];
+    for (const s of seedIds) {
+      for (const nb of (reverse.get(s) || [])) {
+        if (!visited.has(nb)) { direct.add(nb); visited.add(nb); frontier.push(nb); }
+      }
+    }
+    let depth = 1;
+    while (frontier.length && (maxDepth === 0 || depth < maxDepth)) {
+      const next = [];
+      for (const node of frontier) {
+        for (const nb of (reverse.get(node) || [])) {
+          if (!visited.has(nb)) { transitive.add(nb); visited.add(nb); next.push(nb); }
+        }
+      }
+      frontier = next;
+      depth++;
+    }
+    return { direct, transitive };
+  }
+
+  /**
+   * Score the method-level blast radius of a changed-file list.
+   *
+   * @param {string[]} changedFiles repo-relative paths
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {object} [opts.graph]  injected call graph (tests); else built from cwd
+   * @param {number} [opts.depth=0] BFS depth limit (0 = unlimited)
+   * @returns {{
+   *   available: boolean,
+   *   files: Array<{ file:string, symbols:number, directCallers:number,
+   *                  transitiveCallers:number, testCallers:number,
+   *                  impactedFunctions:string[], score:number, tier:string }>,
+   *   aggregate: { score:number, tier:string, impactedFunctions:number }
+   * }}
+   */
+  function methodBlastRadius(changedFiles, cwd, opts = {}) {
+    const empty = { available: false, files: [], aggregate: { score: 0, tier: 'none', impactedFunctions: 0 } };
+    let graph;
+    try {
+      graph = opts.graph || buildCallGraph(cwd, opts);
+    } catch (_) {
+      return empty;
+    }
+    if (!graph || !graph.defs || graph.defs.size === 0) return empty;
+
+    // Group defined symbol ids by their (normalized) defining file.
+    const idsByFile = new Map();
+    for (const [id, def] of graph.defs.entries()) {
+      const rel = _normRel(def.file);
+      if (!idsByFile.has(rel)) idsByFile.set(rel, []);
+      idsByFile.get(rel).push(id);
+    }
+
+    const depth = Number.isFinite(opts.depth) ? opts.depth : 0;
+    const files = [];
+    const allImpacted = new Set();
+
+    for (const changed of (changedFiles || []).map(_normRel).sort()) {
+      const ids = idsByFile.get(changed);
+      if (!ids || !ids.length) continue;
+      const { direct, transitive } = _bfs(ids, graph.reverse, depth);
+      const impacted = [...direct, ...transitive].sort();
+      for (const id of impacted) allImpacted.add(id);
+      const testCallers = impacted.filter((id) => {
+        const def = graph.defs.get(id);
+        return def && TEST_FILE_RE.test(_normRel(def.file));
+      }).length;
+      const score = Math.min(100, direct.size * DIRECT_WEIGHT + transitive.size * TRANSITIVE_WEIGHT);
+      files.push({
+        file: changed,
+        symbols: ids.length,
+        directCallers: direct.size,
+        transitiveCallers: transitive.size,
+        testCallers,
+        impactedFunctions: impacted.slice(0, IMPACTED_FUNCTIONS_CAP),
+        score,
+        tier: tierFor(score),
+      });
+    }
+
+    if (!files.length) return empty;
+    const maxScore = files.reduce((m, f) => Math.max(m, f.score), 0);
+    return {
+      available: true,
+      files,
+      aggregate: { score: maxScore, tier: tierFor(maxScore), impactedFunctions: allImpacted.size },
+    };
+  }
+
+  module.exports = { methodBlastRadius, tierFor, DIRECT_WEIGHT, TRANSITIVE_WEIGHT };
+  
+};
+
 // ── ./src/graph/builder ──
 __factories["./src/graph/builder"] = function(module, exports) {
   
@@ -13360,6 +13496,28 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
   }
 
   /**
+   * get_method_impact({ symbol, direction?, depth? }) → string
+   *
+   * Method-level blast radius (GR2): every function that transitively calls
+   * `symbol` (direction 'callers', default), or everything it calls ('callees').
+   */
+  function getMethodImpact(args, cwd) {
+    if (!args || !args.symbol) return 'Missing required argument: symbol';
+
+    try {
+      const { methodImpact, methodCallees, formatCallGraph } = __require('./src/graph/call-graph');
+      const kind = args.direction === 'callees' ? 'callees' : 'callers';
+      const depth = Math.max(0, parseInt(args.depth, 10) || 0);
+      const result = kind === 'callees'
+        ? methodCallees(args.symbol, cwd, { depth })
+        : methodImpact(args.symbol, cwd, { depth });
+      return formatCallGraph(result, kind);
+    } catch (err) {
+      return `_get_method_impact failed: ${err.message}_`;
+    }
+  }
+
+  /**
    * get_impact({ file, depth? }) → string
    *
    * Returns a formatted markdown impact report for the given file:
@@ -13872,7 +14030,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     return header + sq.squeezed;
   }
 
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
   
 };
 
@@ -14039,7 +14197,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const readline = require('readline');
   const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = __require('./src/mcp/handlers');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = __require('./src/mcp/handlers');
 
   const SERVER_INFO = {
     name: 'sigmap',
@@ -14099,6 +14257,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
         else if (name === 'explain_file') text = explainFile(args, cwd);
         else if (name === 'list_modules') text = listModules(args, cwd);
         else if (name === 'query_context') text = queryContext(args, cwd);
+        else if (name === 'get_method_impact') text = getMethodImpact(args, cwd);
         else if (name === 'get_impact') text = getImpact(args, cwd);
         else if (name === 'get_lines') text = getLines(args, cwd);
         else if (name === 'read_memory') text = readMemory(args, cwd);
@@ -14170,12 +14329,12 @@ __factories["./src/mcp/server"] = function(module, exports) {
 __factories["./src/mcp/tools"] = function(module, exports) {
   
   /**
-   * MCP tool definitions for SigMap (19 tools).
+   * MCP tool definitions for SigMap (20 tools).
    * read_context, search_signatures, get_map, create_checkpoint, get_routing,
-   * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
-   * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
-   * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview,
-   * verify_suggestion, squeeze_output.
+   * explain_file, list_modules, query_context, get_method_impact, get_impact,
+   * get_lines, read_memory, get_callee_signatures, sigmap_notify_file_created,
+   * sigmap_notify_symbol_added, sigmap_notify_file_deleted, get_diff_context,
+   * get_architecture_overview, verify_suggestion, squeeze_output.
    */
 
   const TOOLS = [
@@ -14315,6 +14474,35 @@ __factories["./src/mcp/tools"] = function(module, exports) {
           },
         },
         required: ['query'],
+      },
+    },
+    {
+      name: 'get_method_impact',
+      description:
+        'Method-level blast radius for a symbol: every FUNCTION that (transitively) calls it — ' +
+        'or, with direction "callees", every repo function it calls. Finer-grained than the ' +
+        'file-level get_impact: tells an agent which functions break, not just which files. ' +
+        'JS/TS + Python call-graph; deterministic, no LLM.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          symbol: {
+            type: 'string',
+            description:
+              'Function/method name (e.g. "validateToken") or a full "file#name" id ' +
+              '(e.g. "src/auth/session.js#validateToken") to disambiguate.',
+          },
+          direction: {
+            type: 'string',
+            enum: ['callers', 'callees'],
+            description: '"callers" (default) = blast radius; "callees" = what the symbol calls.',
+          },
+          depth: {
+            type: 'number',
+            description: 'BFS depth limit (default 0 = unlimited).',
+          },
+        },
+        required: ['symbol'],
       },
     },
     {
@@ -15723,6 +15911,12 @@ __factories["./src/review/pr-evidence"] = function(module, exports) {
       impactByFile = new Map(analyzeImpact(srcPaths, cwd, { depth }).map((r) => [r.file, r.impact]));
     } catch (_) { /* graph optional */ }
 
+    // GR2: method-level blast radius per changed file (reviewPr already computed
+    // it when the call graph resolved — reuse, don't rebuild the graph).
+    const methodBlastByFile = new Map(
+      (review.methodBlast && review.methodBlast.files || []).map((m) => [m.file, m])
+    );
+
     const fileReports = files.map((f) => {
       const deleted = f.status === 'D';
       let signatures = [];
@@ -15731,6 +15925,7 @@ __factories["./src/review/pr-evidence"] = function(module, exports) {
       }
       const impact = impactByFile.get(f.path) || null;
       return {
+        methodBlast: methodBlastByFile.get(f.path.replace(/\\/g, '/')) || null,
         path: f.path,
         status: f.status,
         riskLabel: riskLabelFor(f.path),
@@ -15773,6 +15968,7 @@ __factories["./src/review/pr-evidence"] = function(module, exports) {
         else if (f.type === 'security-file') L.push(`- ⚠️ **sensitive path touched** (path heuristic, not a content scan) — \`${f.file}\``);
         else if (f.type === 'secret-detected') L.push(`- 🔑 **secret detected** (${f.secret}) — \`${f.file}\``);
         else if (f.type === 'god-node') L.push(`- ⚠️ **god node** — \`${f.file}\` → ${f.count} dependents (high blast radius)`);
+        else if (f.type === 'method-blast') L.push(`- ⚠️ **method blast radius ${f.tier}** — \`${f.file}\` → ${f.functions} function(s) transitively call into this change (score ${f.score}/100)`);
         else if (f.type === 'scope-drift') L.push(`- ⚠️ **scope drift** — ${f.count} top-level dirs touched (${f.dirs.join(', ')})`);
       }
       L.push('');
@@ -15793,6 +15989,15 @@ __factories["./src/review/pr-evidence"] = function(module, exports) {
         if (f.blast.tests.length) L.push(`Tests to run: ${f.blast.tests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
       } else {
         L.push('**Blast radius:** _(not in dependency graph — new or leaf file)_');
+      }
+      if (f.methodBlast && (f.methodBlast.directCallers + f.methodBlast.transitiveCallers) > 0) {
+        const mb = f.methodBlast;
+        const total = mb.directCallers + mb.transitiveCallers;
+        L.push(
+          `**Method blast radius:** ${total} function(s) impacted (score ${mb.score}/100, ${mb.tier}) — ` +
+          mb.impactedFunctions.slice(0, 6).map((id) => '`' + id + '`').join(', ') +
+          (total > 6 ? ` +${total - 6} more` : '')
+        );
       }
       if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
 
@@ -15860,7 +16065,7 @@ __factories["./src/review/review-pr"] = function(module, exports) {
    * @param {object} [opts]
    * @param {number} [opts.godNodeThreshold=15]
    * @param {number} [opts.scopeThreshold=5]
-   * @returns {{ findings: object[], blast: object[], summary: object }}
+   * @returns {{ findings: object[], blast: object[], methodBlast: object|null, summary: object }}
    */
   function reviewPr(changedFiles, cwd, opts = {}) {
     const godThreshold = opts.godNodeThreshold != null ? opts.godNodeThreshold : GOD_NODE_THRESHOLD;
@@ -15921,6 +16126,27 @@ __factories["./src/review/review-pr"] = function(module, exports) {
       blast.sort((a, b) => b.totalImpact - a.totalImpact);
     }
 
+    // 3b. Method-level blast radius (GR2) — how many FUNCTIONS transitively call
+    // into the change, scored deterministically. Graph optional, like 3.
+    let methodBlast = null;
+    if (srcChanged.length) {
+      try {
+        const { methodBlastRadius } = __require('./src/graph/blast-radius');
+        const mb = methodBlastRadius(srcChanged, cwd, opts.methodBlastOpts || {});
+        if (mb.available) {
+          methodBlast = mb;
+          for (const f of mb.files) {
+            if (f.tier === 'high' || f.tier === 'critical') {
+              findings.push({
+                type: 'method-blast', file: f.file, severity: 'warn',
+                functions: f.directCallers + f.transitiveCallers, score: f.score, tier: f.tier,
+              });
+            }
+          }
+        }
+      } catch (_) { /* call graph optional */ }
+    }
+
     // 4. Scope drift: distinct top-level directories touched.
     const dirs = [...new Set(paths.map((p) => (p.includes('/') ? p.split('/')[0] : '.')))];
     if (dirs.length > scopeThreshold) {
@@ -15931,6 +16157,7 @@ __factories["./src/review/review-pr"] = function(module, exports) {
     return {
       findings,
       blast,
+      methodBlast,
       summary: {
         filesChanged: files.length,
         sourceChanged: srcChanged.length,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task success proxy | 10% | 67.8% |
 | Prompts per task | 2.84 | 1.44 (49.2% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 19 |
+| MCP tools | — | 20 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -136,7 +136,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 19 tools
+## MCP server — 20 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -206,6 +206,14 @@ Rank and return the most relevant files for a specific task or question. Uses ke
 
 ```
 Input:  { query: string, topK?: number }
+```
+
+### get_method_impact
+
+Method-level blast radius for a symbol: every FUNCTION that (transitively) calls it — or, with direction "callees", every repo function it calls. Finer-grained than the file-level get_impact: tells an agent which functions break, not just which files. JS/TS + Python call-graph; deterministic, no LLM.
+
+```
+Input:  { symbol: string, direction?: string, depth?: number }
 ```
 
 ### get_impact

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 97.0% average across benchmark repos
 - Task success: 67.8% vs 10% without SigMap
 - Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer)
-- Languages: 33 supported · MCP tools: 19
+- Languages: 33 supported · MCP tools: 20
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/src/graph/blast-radius.js
+++ b/src/graph/blast-radius.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * Method-level blast-radius scoring (GR2).
+ *
+ * Consumes the D4 call-graph (src/graph/call-graph.js): for each changed file,
+ * resolve the functions it defines, BFS the reverse call edges, and score how
+ * much of the codebase transitively calls into the change. The score is a
+ * documented deterministic formula — no heuristics that vary run to run — so
+ * review-pr findings and PR Evidence lines are byte-stable for a fixed tree.
+ *
+ * Score: min(100, direct×4 + transitive×1). Tiers:
+ *   0 → none · 1–9 → low · 10–29 → medium · 30–59 → high · 60+ → critical
+ */
+
+const path = require('path');
+const { buildCallGraph } = require('./call-graph');
+
+const DIRECT_WEIGHT = 4;
+const TRANSITIVE_WEIGHT = 1;
+const IMPACTED_FUNCTIONS_CAP = 12;
+
+const TEST_FILE_RE = /\.(test|spec)\.[jt]sx?$|(^|\/)test_|_test\.(py|go)$|(^|\/)(tests?|__tests__|spec)\//;
+
+function tierFor(score) {
+  if (score >= 60) return 'critical';
+  if (score >= 30) return 'high';
+  if (score >= 10) return 'medium';
+  if (score >= 1) return 'low';
+  return 'none';
+}
+
+function _normRel(p) {
+  return String(p).replace(/\\/g, '/');
+}
+
+// BFS the reverse edges from a set of symbol ids; returns direct/transitive id sets.
+function _bfs(seedIds, reverse, maxDepth) {
+  const direct = new Set();
+  const transitive = new Set();
+  const visited = new Set(seedIds);
+  let frontier = [];
+  for (const s of seedIds) {
+    for (const nb of (reverse.get(s) || [])) {
+      if (!visited.has(nb)) { direct.add(nb); visited.add(nb); frontier.push(nb); }
+    }
+  }
+  let depth = 1;
+  while (frontier.length && (maxDepth === 0 || depth < maxDepth)) {
+    const next = [];
+    for (const node of frontier) {
+      for (const nb of (reverse.get(node) || [])) {
+        if (!visited.has(nb)) { transitive.add(nb); visited.add(nb); next.push(nb); }
+      }
+    }
+    frontier = next;
+    depth++;
+  }
+  return { direct, transitive };
+}
+
+/**
+ * Score the method-level blast radius of a changed-file list.
+ *
+ * @param {string[]} changedFiles repo-relative paths
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {object} [opts.graph]  injected call graph (tests); else built from cwd
+ * @param {number} [opts.depth=0] BFS depth limit (0 = unlimited)
+ * @returns {{
+ *   available: boolean,
+ *   files: Array<{ file:string, symbols:number, directCallers:number,
+ *                  transitiveCallers:number, testCallers:number,
+ *                  impactedFunctions:string[], score:number, tier:string }>,
+ *   aggregate: { score:number, tier:string, impactedFunctions:number }
+ * }}
+ */
+function methodBlastRadius(changedFiles, cwd, opts = {}) {
+  const empty = { available: false, files: [], aggregate: { score: 0, tier: 'none', impactedFunctions: 0 } };
+  let graph;
+  try {
+    graph = opts.graph || buildCallGraph(cwd, opts);
+  } catch (_) {
+    return empty;
+  }
+  if (!graph || !graph.defs || graph.defs.size === 0) return empty;
+
+  // Group defined symbol ids by their (normalized) defining file.
+  const idsByFile = new Map();
+  for (const [id, def] of graph.defs.entries()) {
+    const rel = _normRel(def.file);
+    if (!idsByFile.has(rel)) idsByFile.set(rel, []);
+    idsByFile.get(rel).push(id);
+  }
+
+  const depth = Number.isFinite(opts.depth) ? opts.depth : 0;
+  const files = [];
+  const allImpacted = new Set();
+
+  for (const changed of (changedFiles || []).map(_normRel).sort()) {
+    const ids = idsByFile.get(changed);
+    if (!ids || !ids.length) continue;
+    const { direct, transitive } = _bfs(ids, graph.reverse, depth);
+    const impacted = [...direct, ...transitive].sort();
+    for (const id of impacted) allImpacted.add(id);
+    const testCallers = impacted.filter((id) => {
+      const def = graph.defs.get(id);
+      return def && TEST_FILE_RE.test(_normRel(def.file));
+    }).length;
+    const score = Math.min(100, direct.size * DIRECT_WEIGHT + transitive.size * TRANSITIVE_WEIGHT);
+    files.push({
+      file: changed,
+      symbols: ids.length,
+      directCallers: direct.size,
+      transitiveCallers: transitive.size,
+      testCallers,
+      impactedFunctions: impacted.slice(0, IMPACTED_FUNCTIONS_CAP),
+      score,
+      tier: tierFor(score),
+    });
+  }
+
+  if (!files.length) return empty;
+  const maxScore = files.reduce((m, f) => Math.max(m, f.score), 0);
+  return {
+    available: true,
+    files,
+    aggregate: { score: maxScore, tier: tierFor(maxScore), impactedFunctions: allImpacted.size },
+  };
+}
+
+module.exports = { methodBlastRadius, tierFor, DIRECT_WEIGHT, TRANSITIVE_WEIGHT };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -429,6 +429,28 @@ function queryContext(args, cwd) {
 }
 
 /**
+ * get_method_impact({ symbol, direction?, depth? }) → string
+ *
+ * Method-level blast radius (GR2): every function that transitively calls
+ * `symbol` (direction 'callers', default), or everything it calls ('callees').
+ */
+function getMethodImpact(args, cwd) {
+  if (!args || !args.symbol) return 'Missing required argument: symbol';
+
+  try {
+    const { methodImpact, methodCallees, formatCallGraph } = require('../graph/call-graph');
+    const kind = args.direction === 'callees' ? 'callees' : 'callers';
+    const depth = Math.max(0, parseInt(args.depth, 10) || 0);
+    const result = kind === 'callees'
+      ? methodCallees(args.symbol, cwd, { depth })
+      : methodImpact(args.symbol, cwd, { depth });
+    return formatCallGraph(result, kind);
+  } catch (err) {
+    return `_get_method_impact failed: ${err.message}_`;
+  }
+}
+
+/**
  * get_impact({ file, depth? }) → string
  *
  * Returns a formatted markdown impact report for the given file:
@@ -941,4 +963,4 @@ function squeezeOutput(args, cwd) {
   return header + sq.squeezed;
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -14,7 +14,7 @@
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -74,6 +74,7 @@ function dispatch(msg, cwd) {
       else if (name === 'explain_file') text = explainFile(args, cwd);
       else if (name === 'list_modules') text = listModules(args, cwd);
       else if (name === 'query_context') text = queryContext(args, cwd);
+      else if (name === 'get_method_impact') text = getMethodImpact(args, cwd);
       else if (name === 'get_impact') text = getImpact(args, cwd);
       else if (name === 'get_lines') text = getLines(args, cwd);
       else if (name === 'read_memory') text = readMemory(args, cwd);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,12 +1,12 @@
 'use strict';
 
 /**
- * MCP tool definitions for SigMap (19 tools).
+ * MCP tool definitions for SigMap (20 tools).
  * read_context, search_signatures, get_map, create_checkpoint, get_routing,
- * explain_file, list_modules, query_context, get_impact, get_lines, read_memory,
- * get_callee_signatures, sigmap_notify_file_created, sigmap_notify_symbol_added,
- * sigmap_notify_file_deleted, get_diff_context, get_architecture_overview,
- * verify_suggestion, squeeze_output.
+ * explain_file, list_modules, query_context, get_method_impact, get_impact,
+ * get_lines, read_memory, get_callee_signatures, sigmap_notify_file_created,
+ * sigmap_notify_symbol_added, sigmap_notify_file_deleted, get_diff_context,
+ * get_architecture_overview, verify_suggestion, squeeze_output.
  */
 
 const TOOLS = [
@@ -146,6 +146,35 @@ const TOOLS = [
         },
       },
       required: ['query'],
+    },
+  },
+  {
+    name: 'get_method_impact',
+    description:
+      'Method-level blast radius for a symbol: every FUNCTION that (transitively) calls it — ' +
+      'or, with direction "callees", every repo function it calls. Finer-grained than the ' +
+      'file-level get_impact: tells an agent which functions break, not just which files. ' +
+      'JS/TS + Python call-graph; deterministic, no LLM.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description:
+            'Function/method name (e.g. "validateToken") or a full "file#name" id ' +
+            '(e.g. "src/auth/session.js#validateToken") to disambiguate.',
+        },
+        direction: {
+          type: 'string',
+          enum: ['callers', 'callees'],
+          description: '"callers" (default) = blast radius; "callees" = what the symbol calls.',
+        },
+        depth: {
+          type: 'number',
+          description: 'BFS depth limit (default 0 = unlimited).',
+        },
+      },
+      required: ['symbol'],
     },
   },
   {

--- a/src/review/pr-evidence.js
+++ b/src/review/pr-evidence.js
@@ -50,6 +50,12 @@ function buildPrEvidence(changedFiles, cwd, opts = {}) {
     impactByFile = new Map(analyzeImpact(srcPaths, cwd, { depth }).map((r) => [r.file, r.impact]));
   } catch (_) { /* graph optional */ }
 
+  // GR2: method-level blast radius per changed file (reviewPr already computed
+  // it when the call graph resolved — reuse, don't rebuild the graph).
+  const methodBlastByFile = new Map(
+    (review.methodBlast && review.methodBlast.files || []).map((m) => [m.file, m])
+  );
+
   const fileReports = files.map((f) => {
     const deleted = f.status === 'D';
     let signatures = [];
@@ -58,6 +64,7 @@ function buildPrEvidence(changedFiles, cwd, opts = {}) {
     }
     const impact = impactByFile.get(f.path) || null;
     return {
+      methodBlast: methodBlastByFile.get(f.path.replace(/\\/g, '/')) || null,
       path: f.path,
       status: f.status,
       riskLabel: riskLabelFor(f.path),
@@ -100,6 +107,7 @@ function formatPrEvidenceMarkdown(evidence, opts = {}) {
       else if (f.type === 'security-file') L.push(`- ⚠️ **sensitive path touched** (path heuristic, not a content scan) — \`${f.file}\``);
       else if (f.type === 'secret-detected') L.push(`- 🔑 **secret detected** (${f.secret}) — \`${f.file}\``);
       else if (f.type === 'god-node') L.push(`- ⚠️ **god node** — \`${f.file}\` → ${f.count} dependents (high blast radius)`);
+      else if (f.type === 'method-blast') L.push(`- ⚠️ **method blast radius ${f.tier}** — \`${f.file}\` → ${f.functions} function(s) transitively call into this change (score ${f.score}/100)`);
       else if (f.type === 'scope-drift') L.push(`- ⚠️ **scope drift** — ${f.count} top-level dirs touched (${f.dirs.join(', ')})`);
     }
     L.push('');
@@ -120,6 +128,15 @@ function formatPrEvidenceMarkdown(evidence, opts = {}) {
       if (f.blast.tests.length) L.push(`Tests to run: ${f.blast.tests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
     } else {
       L.push('**Blast radius:** _(not in dependency graph — new or leaf file)_');
+    }
+    if (f.methodBlast && (f.methodBlast.directCallers + f.methodBlast.transitiveCallers) > 0) {
+      const mb = f.methodBlast;
+      const total = mb.directCallers + mb.transitiveCallers;
+      L.push(
+        `**Method blast radius:** ${total} function(s) impacted (score ${mb.score}/100, ${mb.tier}) — ` +
+        mb.impactedFunctions.slice(0, 6).map((id) => '`' + id + '`').join(', ') +
+        (total > 6 ? ` +${total - 6} more` : '')
+      );
     }
     if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.slice(0, 8).map((t) => '`' + t + '`').join(', ')}`);
 

--- a/src/review/review-pr.js
+++ b/src/review/review-pr.js
@@ -43,7 +43,7 @@ function isSource(p) {
  * @param {object} [opts]
  * @param {number} [opts.godNodeThreshold=15]
  * @param {number} [opts.scopeThreshold=5]
- * @returns {{ findings: object[], blast: object[], summary: object }}
+ * @returns {{ findings: object[], blast: object[], methodBlast: object|null, summary: object }}
  */
 function reviewPr(changedFiles, cwd, opts = {}) {
   const godThreshold = opts.godNodeThreshold != null ? opts.godNodeThreshold : GOD_NODE_THRESHOLD;
@@ -104,6 +104,27 @@ function reviewPr(changedFiles, cwd, opts = {}) {
     blast.sort((a, b) => b.totalImpact - a.totalImpact);
   }
 
+  // 3b. Method-level blast radius (GR2) — how many FUNCTIONS transitively call
+  // into the change, scored deterministically. Graph optional, like 3.
+  let methodBlast = null;
+  if (srcChanged.length) {
+    try {
+      const { methodBlastRadius } = require('../graph/blast-radius');
+      const mb = methodBlastRadius(srcChanged, cwd, opts.methodBlastOpts || {});
+      if (mb.available) {
+        methodBlast = mb;
+        for (const f of mb.files) {
+          if (f.tier === 'high' || f.tier === 'critical') {
+            findings.push({
+              type: 'method-blast', file: f.file, severity: 'warn',
+              functions: f.directCallers + f.transitiveCallers, score: f.score, tier: f.tier,
+            });
+          }
+        }
+      }
+    } catch (_) { /* call graph optional */ }
+  }
+
   // 4. Scope drift: distinct top-level directories touched.
   const dirs = [...new Set(paths.map((p) => (p.includes('/') ? p.split('/')[0] : '.')))];
   if (dirs.length > scopeThreshold) {
@@ -114,6 +135,7 @@ function reviewPr(changedFiles, cwd, opts = {}) {
   return {
     findings,
     blast,
+    methodBlast,
     summary: {
       filesChanged: files.length,
       sourceChanged: srcChanged.length,

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 19 tools (not 12)', () => {
+test('mcp.md: description mentions 20 tools (not 12)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('19 tools'), 'missing "19 tools" in mcp.md');
+  assert.ok(src.includes('20 tools'), 'missing "20 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -77,9 +77,9 @@ test('version.json: extractors field is derived (>= languages)', () => {
   assert.ok(Number.isInteger(v.extractors) && v.extractors >= v.languages, `extractors=${v.extractors}`);
 });
 
-test('version.json: mcp_tools is 19', () => {
+test('version.json: mcp_tools is 20', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 19);
+  assert.strictEqual(v.mcp_tools, 20);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 19 tools including get_impact', () => {
+test('MCP tools/list: returns 20 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 19, `expected 19 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 20, `expected 20 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/diff-architecture-tools.test.js
+++ b/test/integration/mcp/diff-architecture-tools.test.js
@@ -61,12 +61,12 @@ function seedContext(dir) {
 
 // ── tools/list registration ────────────────────────────────────────────────
 
-test('tools/list registers 19 tools including both new ones', () => {
+test('tools/list registers 20 tools including both new ones', () => {
   withGitProject((dir) => {
     const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, dir);
     const tools = res.find((r) => r.id === 1).result.tools;
     assert.strictEqual(tools.length, TOOLS.length, 'server list matches TOOLS');
-    assert.strictEqual(tools.length, 19, 'exactly 19 tools');
+    assert.strictEqual(tools.length, 20, 'exactly 20 tools');
     assert.ok(tools.some((t) => t.name === 'get_diff_context'), 'get_diff_context registered');
     assert.ok(tools.some((t) => t.name === 'get_architecture_overview'), 'get_architecture_overview registered');
   });

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (19 tools total)', () => {
+test('get_lines is registered (20 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 19, `expected 19 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 20, `expected 20 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -101,12 +101,12 @@ test('initialize returns serverInfo', () => {
 // ─────────────────────────────────────────────────────────────
 // Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 19 tools', () => {
+test('tools/list returns exactly 20 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 19);
+    assert.strictEqual(res.result.tools.length, 20);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -83,12 +83,12 @@ function seedContextFile(dir) {
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 19 tools', () => {
+test('tools/list returns exactly 20 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 19, `Expected 19 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 20, `Expected 20 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 19);
+  assert.strictEqual(tools.length, 20);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/method-blast-radius.test.js
+++ b/test/integration/method-blast-radius.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+/**
+ * Integration tests for method-level blast-radius scoring (GR2, #468).
+ *
+ * Covers: the deterministic scorer (src/graph/blast-radius.js), review-pr
+ * wiring (methodBlast field + method-blast finding), the PR Evidence
+ * markdown line, the get_method_impact MCP handler, and graceful degradation
+ * when no call graph resolves.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+const { methodBlastRadius, tierFor } = require('../../src/graph/blast-radius');
+const { reviewPr } = require('../../src/review/review-pr');
+const { buildPrEvidence, formatPrEvidenceMarkdown } = require('../../src/review/pr-evidence');
+const { getMethodImpact } = require('../../src/mcp/handlers');
+const { TOOLS } = require('../../src/mcp/tools');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+/**
+ * Fixture: src/util.js defines helper(); eight caller files each require it
+ * and call it (direct callers = 8 → score 32 → tier high); src/leaf.js calls
+ * nothing and is called by nothing.
+ */
+function withProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-blast-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'util.js'), [
+      'function helper(x) {',
+      '  return x + 1;',
+      '}',
+      'module.exports = { helper };',
+      '',
+    ].join('\n'));
+    for (let i = 1; i <= 8; i++) {
+      fs.writeFileSync(path.join(dir, 'src', `caller${i}.js`), [
+        "const { helper } = require('./util');",
+        `function useHelper${i}(v) {`,
+        '  return helper(v);',
+        '}',
+        `module.exports = { useHelper${i} };`,
+        '',
+      ].join('\n'));
+    }
+    fs.writeFileSync(path.join(dir, 'src', 'leaf.js'), [
+      'function lonely() {',
+      '  return 42;',
+      '}',
+      'module.exports = { lonely };',
+      '',
+    ].join('\n'));
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── scorer ──────────────────────────────────────────────────────────────────
+
+test('tierFor maps the documented thresholds', () => {
+  assert.strictEqual(tierFor(0), 'none');
+  assert.strictEqual(tierFor(1), 'low');
+  assert.strictEqual(tierFor(10), 'medium');
+  assert.strictEqual(tierFor(30), 'high');
+  assert.strictEqual(tierFor(60), 'critical');
+  assert.strictEqual(tierFor(100), 'critical');
+});
+
+test('methodBlastRadius scores a high-fan-in file and skips the leaf', () => {
+  withProject((dir) => {
+    const r = methodBlastRadius(['src/util.js', 'src/leaf.js'], dir);
+    assert.strictEqual(r.available, true);
+    const util = r.files.find((f) => f.file === 'src/util.js');
+    assert.ok(util, 'util.js missing from result');
+    assert.strictEqual(util.directCallers, 8, `direct=${util.directCallers}`);
+    assert.strictEqual(util.score, 32);
+    assert.strictEqual(util.tier, 'high');
+    const leaf = r.files.find((f) => f.file === 'src/leaf.js');
+    assert.ok(leaf, 'leaf.js missing');
+    assert.strictEqual(leaf.score, 0);
+    assert.strictEqual(leaf.tier, 'none');
+    assert.strictEqual(r.aggregate.tier, 'high');
+  });
+});
+
+test('methodBlastRadius is deterministic (two runs deep-equal)', () => {
+  withProject((dir) => {
+    const a = methodBlastRadius(['src/util.js'], dir);
+    const b = methodBlastRadius(['src/util.js'], dir);
+    assert.deepStrictEqual(a, b);
+  });
+});
+
+test('methodBlastRadius degrades gracefully on an empty dir', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-blast-empty-'));
+  try {
+    const r = methodBlastRadius(['src/nothing.js'], dir);
+    assert.strictEqual(r.available, false);
+    assert.deepStrictEqual(r.files, []);
+    assert.strictEqual(r.aggregate.tier, 'none');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── review-pr wiring ────────────────────────────────────────────────────────
+
+test('reviewPr attaches methodBlast and emits a method-blast finding for high tier', () => {
+  withProject((dir) => {
+    const r = reviewPr(['src/util.js'], dir);
+    assert.ok(r.methodBlast && r.methodBlast.available, 'methodBlast missing');
+    const finding = r.findings.find((f) => f.type === 'method-blast');
+    assert.ok(finding, 'method-blast finding missing');
+    assert.strictEqual(finding.file, 'src/util.js');
+    assert.strictEqual(finding.tier, 'high');
+    assert.strictEqual(finding.functions, 8);
+  });
+});
+
+test('reviewPr emits no method-blast finding for a leaf change', () => {
+  withProject((dir) => {
+    const r = reviewPr(['src/leaf.js'], dir);
+    assert.ok(!r.findings.some((f) => f.type === 'method-blast'), 'unexpected finding');
+  });
+});
+
+// ── PR Evidence markdown ────────────────────────────────────────────────────
+
+test('PR Evidence markdown carries the Method blast radius line (and not for leaf)', () => {
+  withProject((dir) => {
+    const evidence = buildPrEvidence(['src/util.js', 'src/leaf.js'], dir);
+    const md = formatPrEvidenceMarkdown(evidence);
+    assert.ok(md.includes('**Method blast radius:** 8 function(s) impacted (score 32/100, high)'), md.split('\n').find((l) => l.includes('Method blast')));
+    assert.ok(md.includes('method blast radius high'), 'findings line missing');
+    const leafSection = md.split('#### `src/leaf.js`')[1] || '';
+    assert.ok(!leafSection.split('####')[0].includes('Method blast radius'), 'leaf should have no method-blast line');
+  });
+});
+
+// ── MCP tool ────────────────────────────────────────────────────────────────
+
+test('get_method_impact resolves callers of a symbol', () => {
+  withProject((dir) => {
+    const text = getMethodImpact({ symbol: 'helper' }, dir);
+    assert.ok(text.includes('Callers: `helper`'), text.slice(0, 80));
+    assert.ok(text.includes('**Total callers of:** 8'), text);
+    assert.ok(text.includes('src/caller1.js#useHelper1'), text);
+  });
+});
+
+test('get_method_impact direction callees + unknown symbol + missing arg', () => {
+  withProject((dir) => {
+    const callees = getMethodImpact({ symbol: 'useHelper1', direction: 'callees' }, dir);
+    assert.ok(callees.includes('Callees: `useHelper1`') && callees.includes('src/util.js#helper'), callees);
+    const unknown = getMethodImpact({ symbol: 'noSuchFn999' }, dir);
+    assert.ok(unknown.includes('not found in the call-graph'), unknown);
+    assert.strictEqual(getMethodImpact({}, dir), 'Missing required argument: symbol');
+  });
+});
+
+test('get_method_impact is registered as the 20th MCP tool', () => {
+  assert.strictEqual(TOOLS.length, 20, `expected 20 tools, got ${TOOLS.length}`);
+  const tool = TOOLS.find((t) => t.name === 'get_method_impact');
+  assert.ok(tool, 'tool definition missing');
+  assert.deepStrictEqual(tool.inputSchema.required, ['symbol']);
+});
+
+console.log(`\nmethod-blast-radius: ${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 19 tools including query_context', () => {
+test('MCP tools/list: returns 20 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 19, `expected 19 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 20, `expected 20 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "benchmark_id": "sigmap-v8.12-main",
   "languages": 33,
   "extractors": 42,
-  "mcp_tools": 19,
-  "tests": 117,
+  "mcp_tools": 20,
+  "tests": 118,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #468. Implements MASTER_PLAN §7.4 **GR2** — the biggest Phase-2 lever (Graph 7→9). D4 built the method-level call-graph; this PR gives it consumers.

## What
- **`src/graph/blast-radius.js`** — `methodBlastRadius(changedFiles, cwd)`: builds the call graph once, reverse-BFSes each changed file's defined symbols, and returns per-file `{ directCallers, transitiveCallers, testCallers, impactedFunctions, score, tier }` + an aggregate. **Deterministic documented formula**: `min(100, direct×4 + transitive×1)`; tiers none/low/medium/high/critical. Same input → same output (tested with deep-equal).
- **`review-pr`** — result gains `methodBlast`; a `method-blast` finding fires when a file's tier is high/critical. Graph stays optional (try/catch), so repos without a resolvable call graph degrade gracefully.
- **PR Evidence** — per-file `**Method blast radius:** N function(s) impacted (score X/100, tier)` line with top caller ids; reuses review-pr's graph result, no double build.
- **MCP `get_method_impact`** — `{symbol, direction: callers|callees, depth}`; **19 → 20 tools** (tools.js + handlers.js + server dispatch). Errors gracefully on unknown symbols.

## Verified on this repo
`review-pr --base main --markdown` flags `src/graph/builder.js` → *19 functions transitively call into this change (score 37/100, high)* — a real high-fan-in signal the file-level view can't express.

## Tests
10 new (`test/integration/method-blast-radius.test.js`): scorer thresholds, high-fan-in fixture (8 callers → score 32/high), determinism, empty-repo fallback, review-pr wiring both ways, evidence markdown, MCP callers/callees/unknown/missing-arg, 20-tool registration. 9 existing tool-count assertions advanced 19→20; `mcp.md`/README counts synced (guard-enforced). Full suite **112/112 green** + unit pass; version.json `mcp_tools` 20 / tests 118 via check-version-meta. AGENTS.md refresh is a separate commit.

Supply-chain gate: local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 534KB/158 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)