### PR TITLE
feat: Evidence Pack schema v2 — published schema, risk factors, measured tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,16 +35,15 @@ src/extractors/python_ast.py ← ast
 
 ## changes (last 5 commits — 0 seconds ago)
 ```
+src/evidence/pack.js                          +riskFactorsFor  ~parseAnchor  ~buildEvidencePack  ~formatMarkdown
 src/graph/call-graph.js                       +calls  +maskRust  +name  +goDefs
 src/mcp/handlers.js                           +that  +getMethodImpact  ~queryContext  ~squeezeOutput
 src/mcp/server.js                             ~dispatch
 src/mcp/tools.js                              +it
 src/retrieval/ranker.js                       ~scoreFile  ~rank
-src/format/terse.js                           +splitAnchor  +encodeTerseSig  +encodeTerseSigs  +_tokens
 src/graph/blast-radius.js                     +tierFor  +_normRel  +_bfs  +methodBlastRadius
 src/review/pr-evidence.js                     ~buildPrEvidence  ~formatPrEvidenceMarkdown
 src/review/review-pr.js                       ~isSource  ~reviewPr
-src/wiki/generate.js                          +_rel  +_pct  +_identity  +_modules
 ```
 
 ## packages
@@ -179,6 +178,25 @@ code-fence ---
 ### src/config/defaults.js
 ```
 module.exports = { DEFAULTS }  :163-163
+```
+
+### src/evidence/pack.js
+```
+module.exports = { buildEvidencePack, formatJSON, formatMarkdown, parseAnchor, riskLabelFor, riskFactorsFor, findRelatedTests, SCHEMA_VERSION, SCHEMA_URL, TEST_DISCOVERY }  :326-337
+function parseAnchor(sig) → { symbol: string, start:   :64-72
+function riskLabelFor(relPath) → 'generated'|'test'|'migra  :84-86
+function riskFactorsFor(relPath) → string[]  :96-108
+function stemOf(relPath)  :111-114
+function testTargetStem(relPath) → string  :126-132
+function findRelatedTests(relPath, allFiles) → string[]  :143-154
+function reasonFor(signals)  :157-168
+function sigTokens(sigs)  :171-173
+function canonicalize(value) → string  :180-182
+function sortKeys(value)  :184-192
+function buildEvidencePack(query, cwd, opts = {}) → object  :205-281
+function ranked0Empty(query)  :284-286
+function formatJSON(pack)  :289-291
+function formatMarkdown(pack)  :294-324
 ```
 
 ### src/graph/call-graph.js
@@ -519,24 +537,6 @@ function round(x)  :122-124
 module.exports = { scoreUsefulness, computeUsefulnessStats }  :3-3
 function scoreUsefulness(taskResult, rankingScore)  :11-38
 function computeUsefulnessStats(taskResults)  :40-66
-```
-
-### src/evidence/pack.js
-```
-module.exports = { buildEvidencePack, formatJSON, formatMarkdown, parseAnchor, riskLabelFor, findRelatedTests, SCHEMA_VERSION }  :293-301
-function parseAnchor(sig) → { symbol: string, start:   :50-58
-function riskLabelFor(relPath) → 'generated'|'test'|'migra  :70-81
-function stemOf(relPath)  :84-87
-function testTargetStem(relPath) → string  :99-105
-function findRelatedTests(relPath, allFiles) → string[]  :116-127
-function reasonFor(signals)  :130-141
-function sigTokens(sigs)  :144-146
-function canonicalize(value) → string  :153-155
-function sortKeys(value)  :157-165
-function buildEvidencePack(query, cwd, opts = {}) → object  :178-249
-function ranked0Empty(query)  :252-254
-function formatJSON(pack)  :257-259
-function formatMarkdown(pack)  :262-291
 ```
 
 ### src/extractors/coverage.js

--- a/docs-vp/public/schemas/evidence-pack-2.json
+++ b/docs-vp/public/schemas/evidence-pack-2.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://sigmap.io/schemas/evidence-pack-2.json",
+  "title": "SigMap Evidence Pack v2",
+  "description": "Deterministic, machine-consumable signature-and-evidence map produced by `sigmap evidence`. Byte-stable for a fixed repository tree; grounding.contextHash is a sha256 over the canonicalized pack. Additive over schema v1: schemaUrl, generator, files[].riskFactors, testDiscovery.",
+  "type": "object",
+  "required": ["schemaVersion", "schemaUrl", "generator", "query", "intent", "files", "tokenBudget", "droppedFiles", "testDiscovery", "grounding"],
+  "properties": {
+    "schemaVersion": { "const": "2.0" },
+    "schemaUrl": { "const": "https://sigmap.io/schemas/evidence-pack-2.json" },
+    "generator": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "const": "sigmap" },
+        "version": { "type": ["string", "null"], "description": "SigMap version that built the pack; null when built via the library API without one." }
+      }
+    },
+    "query": { "type": "string" },
+    "intent": { "type": "string", "description": "Detected query intent (search, debug, explain, refactor, review, test, ...)." },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "symbols", "reason", "confidence", "sourceLines", "relatedTests", "riskLabel", "riskFactors"],
+        "properties": {
+          "path": { "type": "string", "description": "Repository-relative path, forward slashes." },
+          "symbols": { "type": "array", "items": { "type": "string" }, "description": "Secret-redacted signature lines (anchors stripped into sourceLines)." },
+          "reason": { "type": "string", "description": "Human-readable ranking rationale derived from the scorer signals." },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1, "description": "Score normalized against the top-ranked file." },
+          "sourceLines": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["symbol", "start", "end"],
+              "properties": {
+                "symbol": { "type": "string" },
+                "start": { "type": "integer", "minimum": 1 },
+                "end": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "description": "1-based line anchors for symbols that carry a `:start-end` anchor — fetch exact lines instead of whole files."
+          },
+          "relatedTests": { "type": "array", "items": { "type": "string" }, "description": "Impl→test discovery via the measured stem-affix method (see testDiscovery)." },
+          "riskLabel": { "$ref": "#/definitions/riskCategory", "description": "Dominant risk (first of riskFactors) — v1 compatibility." },
+          "riskFactors": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/riskCategory" },
+            "description": "Every matched risk category in strict precedence order (v2). A migration touching payments carries both."
+          }
+        }
+      }
+    },
+    "tokenBudget": {
+      "type": "object",
+      "required": ["limit", "used", "remaining"],
+      "properties": {
+        "limit": { "type": "integer" },
+        "used": { "type": "integer" },
+        "remaining": { "type": "integer" }
+      }
+    },
+    "droppedFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "reason"],
+        "properties": { "path": { "type": "string" }, "reason": { "type": "string" } }
+      }
+    },
+    "testDiscovery": {
+      "type": "object",
+      "required": ["method", "measured", "benchmark"],
+      "description": "Provenance for relatedTests: the discovery method and its measured accuracy on the public benchmark (guard-tested against benchmarks/reports/test-discovery.json).",
+      "properties": {
+        "method": { "const": "stem-affix-match" },
+        "measured": {
+          "type": "object",
+          "required": ["f1", "precision", "recall", "pairs", "repos"],
+          "properties": {
+            "f1": { "type": "number" },
+            "precision": { "type": "number" },
+            "recall": { "type": "number" },
+            "pairs": { "type": "integer" },
+            "repos": { "type": "integer" }
+          }
+        },
+        "benchmark": { "type": "string" }
+      }
+    },
+    "grounding": {
+      "type": "object",
+      "required": ["symbolCount", "anchoredSymbols", "anchorCoverage", "contextHash", "deterministic"],
+      "properties": {
+        "symbolCount": { "type": "integer" },
+        "anchoredSymbols": { "type": "integer" },
+        "anchorCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
+        "contextHash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "deterministic": { "const": true }
+      }
+    }
+  },
+  "definitions": {
+    "riskCategory": {
+      "enum": ["generated", "test", "migration", "payment", "auth", "security", "config", "public-api", "source"]
+    }
+  }
+}

--- a/gen-context.js
+++ b/gen-context.js
@@ -4733,12 +4733,15 @@ __factories["./src/eval/usefulness-scorer"] = function(module, exports) {
 __factories["./src/evidence/pack"] = function(module, exports) {
   
   /**
-   * Evidence Pack v1 (v8.0 E1).
+   * Evidence Pack v2 (v8.0 E1; schema v2 adds a published schema URL, per-file
+   * multi-factor risk labels, measured test-discovery provenance, and generator
+   * identity — all additive over v1).
    *
    * A deterministic, machine-consumable signature-and-evidence map. Replaces the
    * "paste this into your prompt" workflow with a byte-stable JSON artifact that
    * an agent or CI can ingest directly — every entry anchored to a real file,
-   * symbol, and line range.
+   * symbol, and line range. The published schema lives at
+   * docs-vp/public/schemas/evidence-pack-2.json (sigmap.io/schemas/).
    *
    * Composed entirely from shipped zero-dep modules:
    *   - retrieval/ranker        → ranked files, scores, signals
@@ -4758,9 +4761,20 @@ __factories["./src/evidence/pack"] = function(module, exports) {
   const { buildSigIndex, rank, detectIntent } = __require('./src/retrieval/ranker');
   const { scan } = __require('./src/security/scanner');
 
-  const SCHEMA_VERSION = '1.0';
+  const SCHEMA_VERSION = '2.0';
+  const SCHEMA_URL = 'https://sigmap.io/schemas/evidence-pack-2.json';
   const DEFAULT_BUDGET = 6000;
   const DEFAULT_TOP = 12;
+
+  // Measured accuracy of the stem-affix test-discovery method (C2). Constants
+  // are sourced from the committed benchmarks/reports/test-discovery.json and
+  // guarded by a test that fails on drift — re-run `npm run
+  // benchmark:test-discovery` and update together, never hand-invent.
+  const TEST_DISCOVERY = {
+    method: 'stem-affix-match',
+    measured: { f1: 0.98, precision: 0.971, recall: 0.988, pairs: 3701, repos: 28 },
+    benchmark: 'npm run benchmark:test-discovery',
+  };
 
   const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
   const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
@@ -4800,16 +4814,29 @@ __factories["./src/evidence/pack"] = function(module, exports) {
    * @returns {'generated'|'test'|'migration'|'payment'|'auth'|'security'|'config'|'public-api'|'source'}
    */
   function riskLabelFor(relPath) {
+    return riskFactorsFor(relPath)[0];
+  }
+
+  /**
+   * Every risk category a file matches, in the same strict precedence order
+   * riskLabelFor uses (schema v2). Where v1 collapsed a migration touching
+   * payments to `migration`, the factors list carries both. Always non-empty:
+   * a file matching nothing is `['source']`.
+   * @param {string} relPath
+   * @returns {string[]}
+   */
+  function riskFactorsFor(relPath) {
     const p = relPath.replace(/\\/g, '/');
-    if (GENERATED_RE.test(p)) return 'generated';
-    if (TEST_RE.test(p)) return 'test';
-    if (MIGRATION_RE.test(p)) return 'migration';
-    if (PAYMENT_RE.test(p)) return 'payment';
-    if (AUTH_RE.test(p)) return 'auth';
-    if (SECURITY_RE.test(p)) return 'security';
-    if (CONFIG_RE.test(p)) return 'config';
-    if (PUBLIC_API_RE.test(p)) return 'public-api';
-    return 'source';
+    const factors = [];
+    if (GENERATED_RE.test(p)) factors.push('generated');
+    if (TEST_RE.test(p)) factors.push('test');
+    if (MIGRATION_RE.test(p)) factors.push('migration');
+    if (PAYMENT_RE.test(p)) factors.push('payment');
+    if (AUTH_RE.test(p)) factors.push('auth');
+    if (SECURITY_RE.test(p)) factors.push('security');
+    if (CONFIG_RE.test(p)) factors.push('config');
+    if (PUBLIC_API_RE.test(p)) factors.push('public-api');
+    return factors.length ? factors : ['source'];
   }
 
   /** Filename stem (basename minus the first extension chain). */
@@ -4941,6 +4968,7 @@ __factories["./src/evidence/pack"] = function(module, exports) {
         if (start !== null) sourceLines.push({ symbol, start, end });
       }
 
+      const riskFactors = riskFactorsFor(r.file);
       files.push({
         path: r.file,
         symbols,
@@ -4948,7 +4976,8 @@ __factories["./src/evidence/pack"] = function(module, exports) {
         confidence: maxScore > 0 ? Math.round((r.score / maxScore) * 100) / 100 : 0,
         sourceLines,
         relatedTests: findRelatedTests(r.file, allFiles),
-        riskLabel: riskLabelFor(r.file),
+        riskLabel: riskFactors[0],
+        riskFactors,
       });
     }
 
@@ -4957,11 +4986,14 @@ __factories["./src/evidence/pack"] = function(module, exports) {
 
     const pack = {
       schemaVersion: SCHEMA_VERSION,
+      schemaUrl: SCHEMA_URL,
+      generator: { name: 'sigmap', version: typeof opts.version === 'string' ? opts.version : null },
       query,
       intent,
       files,
       tokenBudget: { limit: budget, used, remaining: Math.max(0, budget - used) },
       droppedFiles,
+      testDiscovery: TEST_DISCOVERY,
       grounding: {
         symbolCount,
         anchoredSymbols,
@@ -5003,7 +5035,8 @@ __factories["./src/evidence/pack"] = function(module, exports) {
     L.push('');
 
     for (const f of pack.files) {
-      L.push(`## \`${f.path}\`  _(${f.riskLabel}, confidence ${f.confidence})_`);
+      const risk = (f.riskFactors && f.riskFactors.length > 1) ? f.riskFactors.join(' + ') : f.riskLabel;
+      L.push(`## \`${f.path}\`  _(${risk}, confidence ${f.confidence})_`);
       L.push(`_${f.reason}_`);
       if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.map((t) => `\`${t}\``).join(', ')}`);
       L.push('');
@@ -5028,8 +5061,11 @@ __factories["./src/evidence/pack"] = function(module, exports) {
     formatMarkdown,
     parseAnchor,
     riskLabelFor,
+    riskFactorsFor,
     findRelatedTests,
     SCHEMA_VERSION,
+    SCHEMA_URL,
+    TEST_DISCOVERY,
   };
   
 };
@@ -21905,7 +21941,7 @@ function main() {
 
     const { buildEvidencePack, formatJSON, formatMarkdown } = requireSourceOrBundled('./src/evidence/pack');
 
-    const opts = {};
+    const opts = { version: VERSION };
     const topIdx = args.indexOf('--top');
     if (topIdx !== -1 && args[topIdx + 1]) opts.top = parseInt(args[topIdx + 1], 10);
     const budgetIdx = args.indexOf('--budget');

--- a/src/evidence/pack.js
+++ b/src/evidence/pack.js
@@ -1,12 +1,15 @@
 'use strict';
 
 /**
- * Evidence Pack v1 (v8.0 E1).
+ * Evidence Pack v2 (v8.0 E1; schema v2 adds a published schema URL, per-file
+ * multi-factor risk labels, measured test-discovery provenance, and generator
+ * identity — all additive over v1).
  *
  * A deterministic, machine-consumable signature-and-evidence map. Replaces the
  * "paste this into your prompt" workflow with a byte-stable JSON artifact that
  * an agent or CI can ingest directly — every entry anchored to a real file,
- * symbol, and line range.
+ * symbol, and line range. The published schema lives at
+ * docs-vp/public/schemas/evidence-pack-2.json (sigmap.io/schemas/).
  *
  * Composed entirely from shipped zero-dep modules:
  *   - retrieval/ranker        → ranked files, scores, signals
@@ -26,9 +29,20 @@ const crypto = require('crypto');
 const { buildSigIndex, rank, detectIntent } = require('../retrieval/ranker');
 const { scan } = require('../security/scanner');
 
-const SCHEMA_VERSION = '1.0';
+const SCHEMA_VERSION = '2.0';
+const SCHEMA_URL = 'https://sigmap.io/schemas/evidence-pack-2.json';
 const DEFAULT_BUDGET = 6000;
 const DEFAULT_TOP = 12;
+
+// Measured accuracy of the stem-affix test-discovery method (C2). Constants
+// are sourced from the committed benchmarks/reports/test-discovery.json and
+// guarded by a test that fails on drift — re-run `npm run
+// benchmark:test-discovery` and update together, never hand-invent.
+const TEST_DISCOVERY = {
+  method: 'stem-affix-match',
+  measured: { f1: 0.98, precision: 0.971, recall: 0.988, pairs: 3701, repos: 28 },
+  benchmark: 'npm run benchmark:test-discovery',
+};
 
 const GENERATED_RE = /(^|\/)(dist|build|out|vendor|node_modules)\/|\.(generated|min|bundle)\.|\.(pb|_pb)\.|\.pb\.go$|_pb2\.py$/;
 const TEST_RE = /(^|\/)(tests?|__tests__|spec|specs)\/|\.(test|spec)\.[a-z]+$|(^|\/)test_[^/]+\.py$|_test\.(go|py|rb)$/;
@@ -68,16 +82,29 @@ function parseAnchor(sig) {
  * @returns {'generated'|'test'|'migration'|'payment'|'auth'|'security'|'config'|'public-api'|'source'}
  */
 function riskLabelFor(relPath) {
+  return riskFactorsFor(relPath)[0];
+}
+
+/**
+ * Every risk category a file matches, in the same strict precedence order
+ * riskLabelFor uses (schema v2). Where v1 collapsed a migration touching
+ * payments to `migration`, the factors list carries both. Always non-empty:
+ * a file matching nothing is `['source']`.
+ * @param {string} relPath
+ * @returns {string[]}
+ */
+function riskFactorsFor(relPath) {
   const p = relPath.replace(/\\/g, '/');
-  if (GENERATED_RE.test(p)) return 'generated';
-  if (TEST_RE.test(p)) return 'test';
-  if (MIGRATION_RE.test(p)) return 'migration';
-  if (PAYMENT_RE.test(p)) return 'payment';
-  if (AUTH_RE.test(p)) return 'auth';
-  if (SECURITY_RE.test(p)) return 'security';
-  if (CONFIG_RE.test(p)) return 'config';
-  if (PUBLIC_API_RE.test(p)) return 'public-api';
-  return 'source';
+  const factors = [];
+  if (GENERATED_RE.test(p)) factors.push('generated');
+  if (TEST_RE.test(p)) factors.push('test');
+  if (MIGRATION_RE.test(p)) factors.push('migration');
+  if (PAYMENT_RE.test(p)) factors.push('payment');
+  if (AUTH_RE.test(p)) factors.push('auth');
+  if (SECURITY_RE.test(p)) factors.push('security');
+  if (CONFIG_RE.test(p)) factors.push('config');
+  if (PUBLIC_API_RE.test(p)) factors.push('public-api');
+  return factors.length ? factors : ['source'];
 }
 
 /** Filename stem (basename minus the first extension chain). */
@@ -209,6 +236,7 @@ function buildEvidencePack(query, cwd, opts = {}) {
       if (start !== null) sourceLines.push({ symbol, start, end });
     }
 
+    const riskFactors = riskFactorsFor(r.file);
     files.push({
       path: r.file,
       symbols,
@@ -216,7 +244,8 @@ function buildEvidencePack(query, cwd, opts = {}) {
       confidence: maxScore > 0 ? Math.round((r.score / maxScore) * 100) / 100 : 0,
       sourceLines,
       relatedTests: findRelatedTests(r.file, allFiles),
-      riskLabel: riskLabelFor(r.file),
+      riskLabel: riskFactors[0],
+      riskFactors,
     });
   }
 
@@ -225,11 +254,14 @@ function buildEvidencePack(query, cwd, opts = {}) {
 
   const pack = {
     schemaVersion: SCHEMA_VERSION,
+    schemaUrl: SCHEMA_URL,
+    generator: { name: 'sigmap', version: typeof opts.version === 'string' ? opts.version : null },
     query,
     intent,
     files,
     tokenBudget: { limit: budget, used, remaining: Math.max(0, budget - used) },
     droppedFiles,
+    testDiscovery: TEST_DISCOVERY,
     grounding: {
       symbolCount,
       anchoredSymbols,
@@ -271,7 +303,8 @@ function formatMarkdown(pack) {
   L.push('');
 
   for (const f of pack.files) {
-    L.push(`## \`${f.path}\`  _(${f.riskLabel}, confidence ${f.confidence})_`);
+    const risk = (f.riskFactors && f.riskFactors.length > 1) ? f.riskFactors.join(' + ') : f.riskLabel;
+    L.push(`## \`${f.path}\`  _(${risk}, confidence ${f.confidence})_`);
     L.push(`_${f.reason}_`);
     if (f.relatedTests.length) L.push(`Related tests: ${f.relatedTests.map((t) => `\`${t}\``).join(', ')}`);
     L.push('');
@@ -296,6 +329,9 @@ module.exports = {
   formatMarkdown,
   parseAnchor,
   riskLabelFor,
+  riskFactorsFor,
   findRelatedTests,
   SCHEMA_VERSION,
+  SCHEMA_URL,
+  TEST_DISCOVERY,
 };

--- a/test/integration/evidence-pack-v2.test.js
+++ b/test/integration/evidence-pack-v2.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Integration tests for Evidence Pack schema v2 (#477).
+ *
+ * Covers: multi-factor risk labels (riskFactorsFor + files[].riskFactors),
+ * the measured test-discovery provenance block and its guard against the
+ * committed benchmark report, generator identity, structural conformance to
+ * the published JSON Schema, and byte-stable determinism.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+const {
+  buildEvidencePack, riskFactorsFor, riskLabelFor,
+  SCHEMA_VERSION, SCHEMA_URL, TEST_DISCOVERY,
+} = require('../../src/evidence/pack');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function fixtureIndex() {
+  return new Map([
+    ['src/auth/login.js', ['function login(user, pass)  :1-9', 'function logout()  :11-14']],
+    ['db/migrate/20240101_add_payments.rb', ['def change  :1-6']],
+    ['src/util.js', ['function helper(x)  :1-3']],
+    ['test/login.test.js', ['function run()  :1-5']],
+  ]);
+}
+
+function buildPack(opts) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-ev2-'));
+  try {
+    return buildEvidencePack('login auth flow', dir, Object.assign({ sigIndex: fixtureIndex() }, opts));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── risk factors ────────────────────────────────────────────────────────────
+
+test('riskFactorsFor returns every matched category in precedence order', () => {
+  const factors = riskFactorsFor('db/migrate/20240101_add_payments.rb');
+  assert.ok(factors.includes('migration') && factors.includes('payment'), JSON.stringify(factors));
+  assert.strictEqual(factors[0], 'migration', 'precedence violated');
+  assert.deepStrictEqual(riskFactorsFor('src/plain/thing.js'), ['source']);
+});
+
+test('riskLabelFor still equals the first factor (v1 compatibility)', () => {
+  for (const p of ['db/migrate/20240101_add_payments.rb', 'src/auth/login.js', 'src/util.js', 'test/login.test.js']) {
+    assert.strictEqual(riskLabelFor(p), riskFactorsFor(p)[0], p);
+  }
+});
+
+test('pack files carry riskFactors with riskLabel as the first entry', () => {
+  const pack = buildPack();
+  const mig = pack.files.find((f) => f.path.includes('migrate'));
+  if (mig) {
+    assert.ok(Array.isArray(mig.riskFactors) && mig.riskFactors.length >= 2, JSON.stringify(mig.riskFactors));
+    assert.strictEqual(mig.riskLabel, mig.riskFactors[0]);
+  }
+  for (const f of pack.files) {
+    assert.ok(Array.isArray(f.riskFactors) && f.riskFactors.length >= 1, f.path);
+    assert.strictEqual(f.riskLabel, f.riskFactors[0], f.path);
+  }
+});
+
+// ── measured test-discovery provenance ──────────────────────────────────────
+
+test('TEST_DISCOVERY constants match the committed benchmark report (guard)', () => {
+  const report = JSON.parse(fs.readFileSync(path.join(ROOT, 'benchmarks/reports/test-discovery.json'), 'utf8'));
+  assert.strictEqual(TEST_DISCOVERY.measured.f1, report.metrics.f1, 'f1 drifted — update TEST_DISCOVERY in src/evidence/pack.js');
+  assert.strictEqual(TEST_DISCOVERY.measured.precision, report.metrics.precision, 'precision drifted');
+  assert.strictEqual(TEST_DISCOVERY.measured.recall, report.metrics.recall, 'recall drifted');
+  assert.strictEqual(TEST_DISCOVERY.measured.pairs, report.pairs, 'pairs drifted');
+  assert.strictEqual(TEST_DISCOVERY.measured.repos, report.repos, 'repos drifted');
+});
+
+test('pack carries the testDiscovery provenance block', () => {
+  const pack = buildPack();
+  assert.strictEqual(pack.testDiscovery.method, 'stem-affix-match');
+  assert.strictEqual(pack.testDiscovery.measured.f1, TEST_DISCOVERY.measured.f1);
+  assert.ok(pack.testDiscovery.benchmark.includes('benchmark:test-discovery'));
+});
+
+// ── generator + schema ──────────────────────────────────────────────────────
+
+test('generator carries the injected version, null without one', () => {
+  assert.deepStrictEqual(buildPack({ version: '9.9.9' }).generator, { name: 'sigmap', version: '9.9.9' });
+  assert.deepStrictEqual(buildPack().generator, { name: 'sigmap', version: null });
+});
+
+test('published schema exists and the pack structurally conforms', () => {
+  const schema = JSON.parse(fs.readFileSync(path.join(ROOT, 'docs-vp/public/schemas/evidence-pack-2.json'), 'utf8'));
+  assert.strictEqual(schema.$id, SCHEMA_URL);
+  assert.strictEqual(schema.properties.schemaVersion.const, SCHEMA_VERSION);
+  const pack = buildPack({ version: '1.2.3' });
+  assert.strictEqual(pack.schemaVersion, '2.0');
+  assert.strictEqual(pack.schemaUrl, SCHEMA_URL);
+  for (const key of schema.required) {
+    assert.ok(key in pack, `pack missing required key: ${key}`);
+  }
+  const fileRequired = schema.properties.files.items.required;
+  for (const f of pack.files) {
+    for (const key of fileRequired) assert.ok(key in f, `file entry missing: ${key}`);
+    for (const r of f.riskFactors) assert.ok(schema.definitions.riskCategory.enum.includes(r), `unknown risk: ${r}`);
+  }
+  assert.ok(/^sha256:[0-9a-f]{64}$/.test(pack.grounding.contextHash));
+});
+
+test('pack is byte-stable: two builds are deep-equal with identical hashes', () => {
+  const a = buildPack({ version: '1.2.3' });
+  const b = buildPack({ version: '1.2.3' });
+  assert.deepStrictEqual(a, b);
+  assert.strictEqual(a.grounding.contextHash, b.grounding.contextHash);
+});
+
+console.log(`\nevidence-pack-v2: ${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/test/integration/evidence-pack.test.js
+++ b/test/integration/evidence-pack.test.js
@@ -158,7 +158,7 @@ test('evidence JSON has the v1 schema shape', () => {
   withTempProject((dir) => {
     writeContextFile(dir);
     const p = JSON.parse(runEvidence(dir, ['render widget']));
-    assert.strictEqual(p.schemaVersion, '1.0');
+    assert.strictEqual(p.schemaVersion, '2.0');
     assert.strictEqual(p.query, 'render widget');
     assert.ok(typeof p.intent === 'string');
     assert.ok(Array.isArray(p.files));
@@ -217,7 +217,7 @@ test('--markdown emits the Markdown handoff rendering', () => {
     writeContextFile(dir);
     const md = runEvidence(dir, ['render widget', '--markdown']);
     assert.ok(md.startsWith('# Evidence Pack'), 'markdown should start with the pack heading');
-    assert.ok(md.includes('**Schema:** v1.0'));
+    assert.ok(md.includes('**Schema:** v2.0'));
     assert.ok(md.includes('src/widget.js'));
   });
 });
@@ -253,7 +253,7 @@ test('writes the .context/evidence-pack.json artifact', () => {
     const artifact = path.join(dir, '.context', 'evidence-pack.json');
     assert.ok(fs.existsSync(artifact), 'artifact file should be written');
     const p = JSON.parse(fs.readFileSync(artifact, 'utf8'));
-    assert.strictEqual(p.schemaVersion, '1.0');
+    assert.strictEqual(p.schemaVersion, '2.0');
   });
 });
 

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 120,
+  "tests": 121,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #477. The last Machine-lever item from MASTER_PLAN §7.4: **Evidence Pack schema v2 — published/versioned, richer risk labels, measured related-tests.** Everything is additive over v1.

## What
- **Published schema:** `schemaVersion: '2.0'` + `schemaUrl` → a real draft-07 JSON Schema at `docs-vp/public/schemas/evidence-pack-2.json` (served at `sigmap.io/schemas/evidence-pack-2.json`). CI and agents can now *validate* a pack, not just parse it.
- **Multi-factor risk:** `riskFactorsFor()` returns every matched category in precedence order; `files[].riskFactors` exposes them (a migration touching payments carries `['migration','payment']`) while `riskLabel` stays the first factor — v1 consumers unaffected.
- **Measured relatedTests:** the pack now says *how good its own test discovery is* — `testDiscovery: { method: 'stem-affix-match', measured: { f1: 0.98, precision: 0.971, recall: 0.988, pairs: 3701, repos: 28 }, benchmark }`. Constants are sourced from the committed benchmark report and **guard-tested against it** — they fail the suite if they ever drift (the H1 honesty pattern).
- **Provenance:** `generator: { name: 'sigmap', version }` (CLI injects; null via library API).

## Determinism
No clocks anywhere; two builds are deep-equal with identical `contextHash` (tested). The markdown handoff shows multi-factor risk.

## Tests
8 new (`test/integration/evidence-pack-v2.test.js`): factor precedence, v1-compat of riskLabel, the report guard, provenance block, generator, structural conformance against the published schema, byte-stability. 3 existing v1 assertions advanced to 2.0 — **15/15 evidence tests + full suite 115/115 green**; tests meta 121. AGENTS.md refresh separated.

Supply-chain gate: local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 542KB/158 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)