### PR TITLE
fix: hermetic grounding benchmark — stop cross-suite context pollution (#480)

### DIFF
--- a/scripts/run-callgraph-boost-benchmark.mjs
+++ b/scripts/run-callgraph-boost-benchmark.mjs
@@ -98,6 +98,7 @@ if (JSON_OUT) {
   console.log(JSON.stringify(result, null, 2));
 } else {
   console.log('Call-graph ranking boost A/B (full rank(); headline BM25 harness untouched)');
+  console.log('  note        : reads each repo\'s context AS-IS — run the retrieval benchmark first for canonical contexts (#480)');
   console.log(`  tasks       : ${tasksA} across ${perRepo.length} repos (${skipped.length} skipped)`);
   console.log(`  arm A hit@5 : ${result.hitAt5A}%  (import graph)`);
   console.log(`  arm B hit@5 : ${result.hitAt5B}%  (+ call graph)`);

--- a/scripts/run-hallucination-benchmark.mjs
+++ b/scripts/run-hallucination-benchmark.mjs
@@ -108,6 +108,59 @@ function indexedNames(repoDir) {
   return names;
 }
 
+// ── Hermeticity (#480) ───────────────────────────────────────────────────────
+// This benchmark regenerates each repo's context with a PLAIN default config,
+// while the retrieval harness generates with per-repo CONFIG_OVERRIDES. Left
+// behind, the plain-config contexts skew any later suite that reads them
+// (the callgraph A/B measured 32.2% instead of ~87%). Snapshot every context
+// artifact before the regen and restore it byte-exactly after measuring, so
+// running this suite leaves the shared benchmark repos untouched.
+
+export const CONTEXT_ARTIFACTS = [
+  '.github/copilot-instructions.md', 'CLAUDE.md', 'AGENTS.md', 'GEMINI.md',
+  '.cursorrules', '.windsurfrules', 'llm.txt', 'llm-full.txt', 'llms.txt',
+  'gen-context.config.json',
+];
+
+export function snapshotArtifacts(repoDir) {
+  const snap = new Map();
+  for (const rel of CONTEXT_ARTIFACTS) {
+    const p = path.join(repoDir, rel);
+    snap.set(rel, fs.existsSync(p) ? fs.readFileSync(p) : null);
+  }
+  return snap;
+}
+
+export function restoreArtifacts(repoDir, snap) {
+  for (const [rel, bytes] of snap) {
+    const p = path.join(repoDir, rel);
+    try {
+      if (bytes === null) {
+        if (fs.existsSync(p)) fs.unlinkSync(p);
+      } else {
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, bytes);
+      }
+    } catch (_) { /* best-effort restore */ }
+  }
+}
+
+/**
+ * Regenerate, measure, and restore — the repo's context artifacts are
+ * byte-identical before and after this call.
+ * @param {string} repoDir
+ * @returns {{ total:number, grounded:number, dark:number, coverage:number }}
+ */
+export function measureGroundingHermetic(repoDir) {
+  const snap = snapshotArtifacts(repoDir);
+  try {
+    spawnSync(process.execPath, [GEN_CTX], { cwd: repoDir, stdio: 'ignore' });
+    return measureGrounding(repoDir);
+  } finally {
+    restoreArtifacts(repoDir, snap);
+  }
+}
+
 /**
  * Grounding coverage for one repo.
  * @returns {{ total:number, grounded:number, dark:number, coverage:number }}
@@ -147,9 +200,8 @@ function main() {
   let tTotal = 0, tGrounded = 0;
   for (const repo of repos) {
     const dir = path.join(REPOS_DIR, repo);
-    // Ensure an index exists (re-generate, like the quality benchmark).
-    spawnSync(process.execPath, [GEN_CTX], { cwd: dir, stdio: 'ignore' });
-    const m = measureGrounding(dir);
+    // Regenerate + measure hermetically: context artifacts restored after (#480).
+    const m = measureGroundingHermetic(dir);
     rows.push({ repo, ...m });
     tTotal += m.total; tGrounded += m.grounded;
     console.log(`  ${repo.padEnd(22)} ${String(m.grounded).padStart(6)}/${String(m.total).padEnd(6)} grounded  ${(m.coverage * 100).toFixed(1)}%`);

--- a/test/integration/benchmark-isolation.test.js
+++ b/test/integration/benchmark-isolation.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Regression test for benchmark cross-suite pollution (#480).
+ *
+ * The grounding benchmark regenerates repo contexts with a plain default
+ * config; left behind, those skew any later context-reading suite. The
+ * hermetic wrapper must leave every context artifact byte-identical —
+ * including deleting files that did not exist before.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => { console.log(`  PASS  ${name}`); passed++; })
+    .catch((err) => { console.log(`  FAIL  ${name}: ${err.message}`); failed++; });
+}
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-iso-'));
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(path.join(dir, 'src', 'app.js'), [
+    'function greet(name) {',
+    '  return `hi ${name}`;',
+    '}',
+    'module.exports = { greet };',
+    '',
+  ].join('\n'));
+  return dir;
+}
+
+(async () => {
+  const mod = await import('../../scripts/run-hallucination-benchmark.mjs');
+
+  await test('measureGroundingHermetic restores a pre-existing context byte-exactly', () => {
+    const dir = makeRepo();
+    try {
+      // Seed a sentinel context + config the way the retrieval harness would.
+      const ctxPath = path.join(dir, '.github', 'copilot-instructions.md');
+      fs.mkdirSync(path.dirname(ctxPath), { recursive: true });
+      const sentinelCtx = '# SENTINEL CONTEXT — must survive the grounding benchmark\n';
+      fs.writeFileSync(ctxPath, sentinelCtx);
+      const cfgPath = path.join(dir, 'gen-context.config.json');
+      const sentinelCfg = JSON.stringify({ srcDirs: ['src'], maxTokens: 123 }, null, 2);
+      fs.writeFileSync(cfgPath, sentinelCfg);
+
+      const m = mod.measureGroundingHermetic(dir);
+      assert.ok(m.total > 0, `expected symbols, got ${m.total}`);
+      assert.strictEqual(fs.readFileSync(ctxPath, 'utf8'), sentinelCtx, 'context artifact not restored');
+      assert.strictEqual(fs.readFileSync(cfgPath, 'utf8'), sentinelCfg, 'config not restored');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await test('measureGroundingHermetic removes artifacts that did not exist before', () => {
+    const dir = makeRepo();
+    try {
+      const ctxPath = path.join(dir, '.github', 'copilot-instructions.md');
+      assert.ok(!fs.existsSync(ctxPath), 'fixture should start without a context');
+      const m = mod.measureGroundingHermetic(dir);
+      assert.ok(m.total > 0);
+      assert.ok(!fs.existsSync(ctxPath), 'regen leftovers not cleaned up');
+      assert.ok(!fs.existsSync(path.join(dir, 'gen-context.config.json')), 'config leftover');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await test('every generated artifact class is covered by the snapshot list', () => {
+    for (const rel of ['.github/copilot-instructions.md', 'CLAUDE.md', 'AGENTS.md', 'gen-context.config.json']) {
+      assert.ok(mod.CONTEXT_ARTIFACTS.includes(rel), `missing ${rel}`);
+    }
+  });
+
+  console.log(`\nbenchmark-isolation: ${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 121,
+  "tests": 122,
   "metrics": {
     "hit_at_5": 0.878,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #480 (found during the full benchmark sweep).

## Root cause
The retrieval harness generates each cached repo's context with per-repo `CONFIG_OVERRIDES` (write config → generate → restore). The grounding benchmark regenerated the **same shared repos with a plain default config** and left the result behind — so any later suite reading contexts as-is saw degraded indexes: the callgraph A/B measured **32.2%** hit@5 (true ~87.8%), and the first retrieval regen after pollution came out one task low (86.7%) before stabilizing.

## Fix
- **`measureGroundingHermetic(dir)`** — snapshots every context artifact (all adapter outputs + `gen-context.config.json`) before its regen and restores them **byte-exactly** after measuring; artifacts that didn't exist before are removed. The benchmark's own measurement is unchanged (aggregate still 14.4%).
- The callgraph A/B now prints that it reads contexts **as-is** and points at the retrieval benchmark for canonical state.

## Verified (the issue's acceptance criteria)
- grounding → A/B back-to-back: **87.8% / 87.8%** — identical to A/B alone (was 32.2%) ✔
- grounding → retrieval first run: **87.8%**, no one-task transient ✔
- 3 regression tests (`test/integration/benchmark-isolation.test.js`): byte-exact restore of a sentinel context+config, cleanup of leftovers on repos that had none, artifact-list coverage ✔

Scripts-only change — the published package is untouched. Full suite **116/116 green** + unit pass; tests meta 122.

Supply-chain gate: local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting · tarball 542KB/158 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)