### PR TITLE
feat: line anchors for Kotlin, Swift, PHP, Scala, and Dart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,16 +33,18 @@ Always run `sigmap ask` (or `sigmap --query`) before searching for files relevan
 src/extractors/python_ast.py ← ast
 ```
 
-## changes (last 5 commits — 1 second ago)
+## changes (last 5 commits — 0 seconds ago)
 ```
 src/extractors/csharp.js                      ~extract  ~extractMembers
+src/extractors/dart.js                        ~extract  ~extractMembers
 src/extractors/go.js                          ~extract  ~extractInterfaceMethods
 src/extractors/java.js                        ~extract  ~extractMembers
+src/extractors/kotlin.js                      ~extract  ~extractMembers
+src/extractors/php.js                         ~extract  ~extractMembers
 src/extractors/rust.js                        ~extract  ~extractMethods  ~extractReturnType
+src/extractors/scala.js                       ~extract  ~extractMembers
+src/extractors/swift.js                       ~extract  ~extractMembers  ~extractArrowType
 src/evidence/pack.js                          +riskFactorsFor  ~parseAnchor  ~buildEvidencePack  ~formatMarkdown
-src/graph/call-graph.js                       +buildCallFileGraph  ~buildCallGraph  ~formatCallGraphJSON  ~_resolveSymbol
-src/mcp/handlers.js                           ~queryContext
-src/retrieval/ranker.js                       ~scoreFile  ~rank
 ```
 
 ## packages
@@ -184,6 +186,15 @@ function normalizeParams(params)  :61-64
 function normalizeType(type)  :66-69
 ```
 
+### src/extractors/dart.js
+```
+module.exports = { extract }  :84-84
+function extract(src) → string[]  :12-84
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-77
+function normalizeParams(params)  :79-81
+```
+
 ### src/extractors/go.js
 ```
 module.exports = { extract }  :81-81
@@ -203,6 +214,25 @@ function normalizeParams(params)  :61-64
 function normalizeType(type)  :66-69
 ```
 
+### src/extractors/kotlin.js
+```
+module.exports = { extract }  :90-90
+function extract(src) → string[]  :12-90
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-90
+function normalizeParams(params)  :81-88
+```
+
+### src/extractors/php.js
+```
+module.exports = { extract }  :96-96
+function extract(src) → string[]  :12-96
+function extractBlock(src, startIndex)  :58-67
+function extractMembers(block)  :69-96
+function normalizeParams(params)  :86-89
+function normalizeType(type)  :91-94
+```
+
 ### src/extractors/rust.js
 ```
 module.exports = { extract }  :110-110
@@ -211,6 +241,26 @@ function extractBlock(src, startIndex)  :72-81
 function extractMethods(block)  :83-110
 function normalizeParams(params)  :97-100
 function extractReturnType(afterParen)  :102-110
+```
+
+### src/extractors/scala.js
+```
+module.exports = { extract }  :88-88
+function extract(src) → string[]  :12-88
+function extractBlock(src, startIndex)  :47-56
+function extractMembers(block)  :58-88
+function normalizeParams(params)  :74-81
+function normalizeType(type)  :83-86
+```
+
+### src/extractors/swift.js
+```
+module.exports = { extract }  :97-97
+function extract(src) → string[]  :12-97
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-97
+function normalizeParams(params)  :80-87
+function extractArrowType(str)  :89-97
 ```
 
 ### src/mcp/server.js
@@ -520,15 +570,6 @@ module.exports = { extract }  :69-69
 function extract(src) → string[]  :8-17
 ```
 
-### src/extractors/dart.js
-```
-module.exports = { extract }  :60-60
-function extract(src) → string[]  :8-60
-function extractBlock(src, startIndex)  :34-43
-function extractMembers(block)  :45-53
-function normalizeParams(params)  :55-57
-```
-
 ### src/extractors/deps.js
 ```
 module.exports = { extractPythonDeps, extractTSDeps, extractRDeps, buildReverseDepMap }  :110-110
@@ -589,15 +630,6 @@ function formatReturnHint(type)  :138-140
 function normalizeParams(params)  :142-145
 ```
 
-### src/extractors/kotlin.js
-```
-module.exports = { extract }  :66-66
-function extract(src) → string[]  :8-66
-function extractBlock(src, startIndex)  :34-43
-function extractMembers(block)  :45-66
-function normalizeParams(params)  :57-64
-```
-
 ### src/extractors/line-anchor.js
 ```
 module.exports = { lineAt, anchor, withAnchor }  :52-52
@@ -616,16 +648,6 @@ function extract(src) → string[]  :10-28
 ```
 module.exports = { extract }  :135-135
 function extract(src) → string[]  :10-133
-```
-
-### src/extractors/php.js
-```
-module.exports = { extract }  :71-71
-function extract(src) → string[]  :8-71
-function extractBlock(src, startIndex)  :37-46
-function extractMembers(block)  :48-71
-function normalizeParams(params)  :61-64
-function normalizeType(type)  :66-69
 ```
 
 ### src/extractors/prdiff.js
@@ -709,16 +731,6 @@ function normalizeParams(params)  :40-43
 function extractReturnHint(stripped, index)  :45-52
 ```
 
-### src/extractors/scala.js
-```
-module.exports = { extract }  :76-76
-function extract(src) → string[]  :8-76
-function extractBlock(src, startIndex)  :39-48
-function extractMembers(block)  :50-76
-function normalizeParams(params)  :62-69
-function normalizeType(type)  :71-74
-```
-
 ### src/extractors/shell.js
 ```
 module.exports = { extract }  :43-43
@@ -739,16 +751,6 @@ module.exports = { extract }  :58-58
 function extract(src) → string[]  :8-58
 function normalizeParams(params)  :48-51
 function normalizeType(type)  :53-56
-```
-
-### src/extractors/swift.js
-```
-module.exports = { extract }  :73-73
-function extract(src) → string[]  :8-73
-function extractBlock(src, startIndex)  :34-43
-function extractMembers(block)  :45-73
-function normalizeParams(params)  :56-63
-function extractArrowType(str)  :65-73
 ```
 
 ### src/extractors/terraform.js

--- a/gen-context.js
+++ b/gen-context.js
@@ -5377,8 +5377,12 @@ __factories["./src/extractors/css"] = function(module, exports) {
 // ── ./src/extractors/dart ──
 __factories["./src/extractors/dart"] = function(module, exports) {
   
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from Dart source code.
+   * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+   * strip below is newline-preserving so anchor lines match the original file.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
@@ -5388,21 +5392,37 @@ __factories["./src/extractors/dart"] = function(module, exports) {
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+      .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+    // Anchor range: scan past same-line trivia (`async`, `=>` stops) to a body `{`.
+    const rangeFor = (declIdx, afterIdx) => {
+      let k = afterIdx;
+      while (k < stripped.length && /[ \tA-Za-z0-9_]/.test(stripped[k])) k++;
+      if (stripped[k] === '{') {
+        const end = k + 1 + extractBlock(stripped, k + 1).length;
+        return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+      }
+      const line = lineAt(stripped, declIdx);
+      return [line, line];
+    };
 
     // Classes and abstract classes
     for (const m of stripped.matchAll(/^(?:abstract\s+)?class\s+(\w+)(?:<[^{]*>)?(?:\s+extends\s+[\w<>, ]+)?(?:\s+(?:implements|with|on)\s+[\w<>, ]+)?\s*\{/gm)) {
       const abs = m[0].trimStart().startsWith('abstract') ? 'abstract ' : '';
-      sigs.push(`${abs}class ${m[1]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      sigs.push(withAnchor(`${abs}class ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      for (const meth of extractMembers(block)) {
+        sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+      }
     }
 
     // Top-level functions — capture return type (prefix before name) and show as suffix
     for (const m of stripped.matchAll(/^((?:Future<[\w<>?,\s]*>|[\w<>?]+))\s+(\w+)\s*\(([^)]*)\)/gm)) {
       if (m[2].startsWith('_')) continue;
-      const retStr = (m[1] && m[1] !== 'void') ? ` \u2192 ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
-      sigs.push(`${m[2]}(${normalizeParams(m[3])})${retStr}`);
+      const retStr = (m[1] && m[1] !== 'void') ? ` → ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
+      const [s, e] = rangeFor(m.index, m.index + m[0].length);
+      sigs.push(withAnchor(`${m[2]}(${normalizeParams(m[3])})${retStr}`, s, e));
     }
 
     return sigs.slice(0, 25);
@@ -5423,8 +5443,12 @@ __factories["./src/extractors/dart"] = function(module, exports) {
     const members = [];
     for (const m of block.matchAll(/^\s+(?:@override\s+)?(?:@\w+\s+)*((?:Future<[\w<>?,\s]*>|[\w<>?]+))\s+(\w+)\s*\(([^)]*)\)/gm)) {
       if (m[2].startsWith('_')) continue;
-      const retStr = (m[1] && m[1] !== 'void') ? ` \u2192 ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
-      members.push(`${m[2]}(${normalizeParams(m[3])})${retStr}`);
+      const retStr = (m[1] && m[1] !== 'void') ? ` → ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
+      members.push({
+        text: `${m[2]}(${normalizeParams(m[3])})${retStr}`,
+        declIdx: m.index + (m[0].length - m[0].trimStart().length),
+        endIdx: m.index + m[0].length,
+      });
     }
     return members.slice(0, 8);
   }
@@ -6314,8 +6338,12 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
 // ── ./src/extractors/kotlin ──
 __factories["./src/extractors/kotlin"] = function(module, exports) {
   
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from Kotlin source code.
+   * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+   * strip below is newline-preserving so anchor lines match the original file.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
@@ -6325,21 +6353,37 @@ __factories["./src/extractors/kotlin"] = function(module, exports) {
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+      .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+    // Anchor range: scan past same-line modifiers to a body `{` (range) else single line.
+    const rangeFor = (declIdx, afterIdx) => {
+      let k = afterIdx;
+      while (k < stripped.length && /[ \tA-Za-z0-9_]/.test(stripped[k])) k++;
+      if (stripped[k] === '{') {
+        const end = k + 1 + extractBlock(stripped, k + 1).length;
+        return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+      }
+      const line = lineAt(stripped, declIdx);
+      return [line, line];
+    };
 
     // Classes, objects, interfaces
     for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:data\s+|sealed\s+|abstract\s+|open\s+)?(class|object|interface)\s+(\w+)(?:[^{]*)\{/gm)) {
-      sigs.push(`${m[1]} ${m[2]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      for (const meth of extractMembers(block)) {
+        sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+      }
     }
 
     // Top-level functions — capture `: RetType` after params
     for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:suspend\s+)?fun\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*([^\n{=]+))?/gm)) {
       const suspend = m[0].includes('suspend') ? 'suspend ' : '';
       const retType = m[3] ? m[3].trim().replace(/\s+/g, ' ') : '';
-      const retStr = retType ? ` \u2192 ${retType.slice(0, 25)}` : '';
-      sigs.push(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const retStr = retType ? ` → ${retType.slice(0, 25)}` : '';
+      const [s, e] = rangeFor(m.index, m.index + m[0].length);
+      sigs.push(withAnchor(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
     }
 
     return sigs.slice(0, 25);
@@ -6362,8 +6406,12 @@ __factories["./src/extractors/kotlin"] = function(module, exports) {
       if (m[1].startsWith('_')) continue;
       const suspend = m[0].includes('suspend') ? 'suspend ' : '';
       const retType = m[3] ? m[3].trim().replace(/\s+/g, ' ') : '';
-      const retStr = retType ? ` \u2192 ${retType.slice(0, 25)}` : '';
-      members.push(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const retStr = retType ? ` → ${retType.slice(0, 25)}` : '';
+      members.push({
+        text: `${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+        declIdx: m.index + (m[0].length - m[0].trimStart().length),
+        endIdx: m.index + m[0].length,
+      });
     }
     return members.slice(0, 8);
   }
@@ -6613,8 +6661,12 @@ __factories["./src/extractors/patterns"] = function(module, exports) {
 // ── ./src/extractors/php ──
 __factories["./src/extractors/php"] = function(module, exports) {
   
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from PHP source code.
+   * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+   * strips below are newline-preserving so anchor lines match the original file.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
@@ -6625,23 +6677,40 @@ __factories["./src/extractors/php"] = function(module, exports) {
     const stripped = src
       .replace(/\/\/.*$/gm, '')
       .replace(/#.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+      .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+    // Anchor range: scan past same-line trivia to a body `{` (range) else single line.
+    const rangeFor = (declIdx, afterIdx) => {
+      let k = afterIdx;
+      while (k < stripped.length && /[ \tA-Za-z0-9_:?\\]/.test(stripped[k])) k++;
+      if (stripped[k] === '{' || (stripped[k] === '\n' && stripped[k + 1] === '{')) {
+        const open = stripped[k] === '{' ? k : k + 1;
+        const end = open + 1 + extractBlock(stripped, open + 1).length;
+        return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+      }
+      const line = lineAt(stripped, declIdx);
+      return [line, line];
+    };
 
     // Classes and interfaces
     const typeRe = /^(?:abstract\s+)?(?:class|interface|trait)\s+(\w+)(?:\s+extends\s+\w+)?(?:\s+implements\s+[\w, ]+)?\s*\{/gm;
     for (const m of stripped.matchAll(typeRe)) {
       const kind = m[0].trimStart().startsWith('interface') ? 'interface' :
         m[0].trimStart().startsWith('trait') ? 'trait' : 'class';
-      sigs.push(`${kind} ${m[1]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      sigs.push(withAnchor(`${kind} ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      for (const meth of extractMembers(block)) {
+        sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+      }
     }
 
     // Top-level functions
     for (const m of stripped.matchAll(/^function\s+(\w+)\s*\(([^)]*)\)\s*(?::\s*([^\n{]+))?/gm)) {
       const ret = normalizeType(m[3]);
       const retStr = ret ? ` → ${ret}` : '';
-      sigs.push(`function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const [s, e] = rangeFor(m.index, m.index + m[0].length);
+      sigs.push(withAnchor(`function ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
     }
 
     return sigs.slice(0, 25);
@@ -6666,7 +6735,11 @@ __factories["./src/extractors/php"] = function(module, exports) {
       const isStatic = m[0].includes('static ') ? 'static ' : '';
       const ret = normalizeType(m[3]);
       const retStr = ret ? ` → ${ret}` : '';
-      members.push(`${isStatic}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      members.push({
+        text: `${isStatic}function ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+        declIdx: m.index + (m[0].length - m[0].trimStart().length),
+        endIdx: m.index + m[0].length,
+      });
     }
     return members.slice(0, 8);
   }
@@ -7666,8 +7739,12 @@ __factories["./src/extractors/rust"] = function(module, exports) {
 // ── ./src/extractors/scala ──
 __factories["./src/extractors/scala"] = function(module, exports) {
   
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from Scala source code.
+   * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+   * strip below is newline-preserving so anchor lines match the original file.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
@@ -7677,7 +7754,7 @@ __factories["./src/extractors/scala"] = function(module, exports) {
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+      .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
 
     // Classes, traits, objects
     const typeRe = /^(?:case\s+)?(?:class|trait|object)\s+(\w+)(?:\[[\w, ]+\])?(?:[^{]*)\{/gm;
@@ -7685,9 +7762,12 @@ __factories["./src/extractors/scala"] = function(module, exports) {
       const kind = m[0].trimStart().startsWith('case class') ? 'case class' :
         m[0].trimStart().startsWith('trait') ? 'trait' :
         m[0].trimStart().startsWith('object') ? 'object' : 'class';
-      sigs.push(`${kind} ${m[1]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const fn of extractMembers(block)) sigs.push(`  ${fn}`);
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      sigs.push(withAnchor(`${kind} ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      for (const fn of extractMembers(block)) {
+        sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+      }
     }
 
     // Top-level defs
@@ -7696,7 +7776,8 @@ __factories["./src/extractors/scala"] = function(module, exports) {
       const params = m[2] ? `(${normalizeParams(m[2])})` : '';
       const ret = normalizeType(m[3]);
       const retStr = ret ? ` → ${ret}` : '';
-      sigs.push(`def ${m[1]}${params}${retStr}`);
+      const line = lineAt(stripped, m.index);
+      sigs.push(withAnchor(`def ${m[1]}${params}${retStr}`, line, line));
     }
 
     return sigs.slice(0, 25);
@@ -7720,7 +7801,11 @@ __factories["./src/extractors/scala"] = function(module, exports) {
       const params = m[2] ? `(${normalizeParams(m[2])})` : '';
       const ret = normalizeType(m[3]);
       const retStr = ret ? ` → ${ret}` : '';
-      members.push(`def ${m[1]}${params}${retStr}`);
+      members.push({
+        text: `def ${m[1]}${params}${retStr}`,
+        declIdx: m.index + (m[0].length - m[0].trimStart().length),
+        endIdx: m.index + m[0].length,
+      });
     }
     return members.slice(0, 8);
   }
@@ -7952,8 +8037,12 @@ __factories["./src/extractors/svelte"] = function(module, exports) {
 // ── ./src/extractors/swift ──
 __factories["./src/extractors/swift"] = function(module, exports) {
   
+  const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+
   /**
    * Extract signatures from Swift source code.
+   * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+   * strip below is newline-preserving so anchor lines match the original file.
    * @param {string} src - Raw file content
    * @returns {string[]} Array of signature strings
    */
@@ -7963,21 +8052,37 @@ __factories["./src/extractors/swift"] = function(module, exports) {
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+      .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+    // Anchor range: scan past same-line modifiers to a body `{` (range) else single line.
+    const rangeFor = (declIdx, afterIdx) => {
+      let k = afterIdx;
+      while (k < stripped.length && /[ \tA-Za-z0-9_>-]/.test(stripped[k])) k++;
+      if (stripped[k] === '{') {
+        const end = k + 1 + extractBlock(stripped, k + 1).length;
+        return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+      }
+      const line = lineAt(stripped, declIdx);
+      return [line, line];
+    };
 
     // Classes, structs, protocols, enums
     const typeRe = /^(?:public\s+|internal\s+|open\s+)?(?:final\s+)?(class|struct|protocol|enum|actor)\s+(\w+)(?:<[^{]*>)?(?:\s*:\s*[\w, <>.]+)?\s*\{/gm;
     for (const m of stripped.matchAll(typeRe)) {
-      sigs.push(`${m[1]} ${m[2]}`);
-      const block = extractBlock(stripped, m.index + m[0].length);
-      for (const fn of extractMembers(block)) sigs.push(`  ${fn}`);
+      const bodyStart = m.index + m[0].length;
+      const block = extractBlock(stripped, bodyStart);
+      sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      for (const fn of extractMembers(block)) {
+        sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+      }
     }
 
     // Top-level public functions — capture everything after ) to end of line for arrow type
     for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:static\s+)?(?:async\s+)?func\s+(\w+)(?:<[^(]*>)?\s*\(([^)]*)\)([^{\n]*)/gm)) {
       const asyncKw = m[0].includes('async') ? 'async ' : '';
       const retStr = extractArrowType(m[3]);
-      sigs.push(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      const [s, e] = rangeFor(m.index, m.index + m[0].length);
+      sigs.push(withAnchor(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
     }
 
     return sigs.slice(0, 25);
@@ -8000,7 +8105,11 @@ __factories["./src/extractors/swift"] = function(module, exports) {
       if (m[1].startsWith('_')) continue;
       const asyncKw = m[0].includes('async') ? 'async ' : '';
       const retStr = extractArrowType(m[3]);
-      members.push(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      members.push({
+        text: `${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+        declIdx: m.index + (m[0].length - m[0].trimStart().length),
+        endIdx: m.index + m[0].length,
+      });
     }
     return members.slice(0, 8);
   }
@@ -8019,7 +8128,7 @@ __factories["./src/extractors/swift"] = function(module, exports) {
     const m = str.match(/->\s*([^\n{]+)/);
     if (!m) return '';
     const rt = m[1].trim().replace(/\s+/g, ' ');
-    return ` \u2192 ${rt.length > 25 ? rt.slice(0, 22) + '...' : rt}`;
+    return ` → ${rt.length > 25 ? rt.slice(0, 22) + '...' : rt}`;
   }
 
   module.exports = { extract };

--- a/src/extractors/dart.js
+++ b/src/extractors/dart.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from Dart source code.
+ * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+ * strip below is newline-preserving so anchor lines match the original file.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
@@ -11,21 +15,37 @@ function extract(src) {
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+  // Anchor range: scan past same-line trivia (`async`, `=>` stops) to a body `{`.
+  const rangeFor = (declIdx, afterIdx) => {
+    let k = afterIdx;
+    while (k < stripped.length && /[ \tA-Za-z0-9_]/.test(stripped[k])) k++;
+    if (stripped[k] === '{') {
+      const end = k + 1 + extractBlock(stripped, k + 1).length;
+      return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+    }
+    const line = lineAt(stripped, declIdx);
+    return [line, line];
+  };
 
   // Classes and abstract classes
   for (const m of stripped.matchAll(/^(?:abstract\s+)?class\s+(\w+)(?:<[^{]*>)?(?:\s+extends\s+[\w<>, ]+)?(?:\s+(?:implements|with|on)\s+[\w<>, ]+)?\s*\{/gm)) {
     const abs = m[0].trimStart().startsWith('abstract') ? 'abstract ' : '';
-    sigs.push(`${abs}class ${m[1]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+    const bodyStart = m.index + m[0].length;
+    const block = extractBlock(stripped, bodyStart);
+    sigs.push(withAnchor(`${abs}class ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    for (const meth of extractMembers(block)) {
+      sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+    }
   }
 
   // Top-level functions — capture return type (prefix before name) and show as suffix
   for (const m of stripped.matchAll(/^((?:Future<[\w<>?,\s]*>|[\w<>?]+))\s+(\w+)\s*\(([^)]*)\)/gm)) {
     if (m[2].startsWith('_')) continue;
-    const retStr = (m[1] && m[1] !== 'void') ? ` \u2192 ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
-    sigs.push(`${m[2]}(${normalizeParams(m[3])})${retStr}`);
+    const retStr = (m[1] && m[1] !== 'void') ? ` → ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
+    const [s, e] = rangeFor(m.index, m.index + m[0].length);
+    sigs.push(withAnchor(`${m[2]}(${normalizeParams(m[3])})${retStr}`, s, e));
   }
 
   return sigs.slice(0, 25);
@@ -46,8 +66,12 @@ function extractMembers(block) {
   const members = [];
   for (const m of block.matchAll(/^\s+(?:@override\s+)?(?:@\w+\s+)*((?:Future<[\w<>?,\s]*>|[\w<>?]+))\s+(\w+)\s*\(([^)]*)\)/gm)) {
     if (m[2].startsWith('_')) continue;
-    const retStr = (m[1] && m[1] !== 'void') ? ` \u2192 ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
-    members.push(`${m[2]}(${normalizeParams(m[3])})${retStr}`);
+    const retStr = (m[1] && m[1] !== 'void') ? ` → ${m[1].replace(/\s+/g, '').slice(0, 25)}` : '';
+    members.push({
+      text: `${m[2]}(${normalizeParams(m[3])})${retStr}`,
+      declIdx: m.index + (m[0].length - m[0].trimStart().length),
+      endIdx: m.index + m[0].length,
+    });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/kotlin.js
+++ b/src/extractors/kotlin.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from Kotlin source code.
+ * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+ * strip below is newline-preserving so anchor lines match the original file.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
@@ -11,21 +15,37 @@ function extract(src) {
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+  // Anchor range: scan past same-line modifiers to a body `{` (range) else single line.
+  const rangeFor = (declIdx, afterIdx) => {
+    let k = afterIdx;
+    while (k < stripped.length && /[ \tA-Za-z0-9_]/.test(stripped[k])) k++;
+    if (stripped[k] === '{') {
+      const end = k + 1 + extractBlock(stripped, k + 1).length;
+      return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+    }
+    const line = lineAt(stripped, declIdx);
+    return [line, line];
+  };
 
   // Classes, objects, interfaces
   for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:data\s+|sealed\s+|abstract\s+|open\s+)?(class|object|interface)\s+(\w+)(?:[^{]*)\{/gm)) {
-    sigs.push(`${m[1]} ${m[2]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+    const bodyStart = m.index + m[0].length;
+    const block = extractBlock(stripped, bodyStart);
+    sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    for (const meth of extractMembers(block)) {
+      sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+    }
   }
 
   // Top-level functions — capture `: RetType` after params
   for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:suspend\s+)?fun\s+(\w+)\s*(?:<[^(]*>)?\s*\(([^)]*)\)(?:\s*:\s*([^\n{=]+))?/gm)) {
     const suspend = m[0].includes('suspend') ? 'suspend ' : '';
     const retType = m[3] ? m[3].trim().replace(/\s+/g, ' ') : '';
-    const retStr = retType ? ` \u2192 ${retType.slice(0, 25)}` : '';
-    sigs.push(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    const retStr = retType ? ` → ${retType.slice(0, 25)}` : '';
+    const [s, e] = rangeFor(m.index, m.index + m[0].length);
+    sigs.push(withAnchor(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
   }
 
   return sigs.slice(0, 25);
@@ -48,8 +68,12 @@ function extractMembers(block) {
     if (m[1].startsWith('_')) continue;
     const suspend = m[0].includes('suspend') ? 'suspend ' : '';
     const retType = m[3] ? m[3].trim().replace(/\s+/g, ' ') : '';
-    const retStr = retType ? ` \u2192 ${retType.slice(0, 25)}` : '';
-    members.push(`${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    const retStr = retType ? ` → ${retType.slice(0, 25)}` : '';
+    members.push({
+      text: `${suspend}fun ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+      declIdx: m.index + (m[0].length - m[0].trimStart().length),
+      endIdx: m.index + m[0].length,
+    });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/php.js
+++ b/src/extractors/php.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from PHP source code.
+ * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+ * strips below are newline-preserving so anchor lines match the original file.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
@@ -12,23 +16,40 @@ function extract(src) {
   const stripped = src
     .replace(/\/\/.*$/gm, '')
     .replace(/#.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+  // Anchor range: scan past same-line trivia to a body `{` (range) else single line.
+  const rangeFor = (declIdx, afterIdx) => {
+    let k = afterIdx;
+    while (k < stripped.length && /[ \tA-Za-z0-9_:?\\]/.test(stripped[k])) k++;
+    if (stripped[k] === '{' || (stripped[k] === '\n' && stripped[k + 1] === '{')) {
+      const open = stripped[k] === '{' ? k : k + 1;
+      const end = open + 1 + extractBlock(stripped, open + 1).length;
+      return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+    }
+    const line = lineAt(stripped, declIdx);
+    return [line, line];
+  };
 
   // Classes and interfaces
   const typeRe = /^(?:abstract\s+)?(?:class|interface|trait)\s+(\w+)(?:\s+extends\s+\w+)?(?:\s+implements\s+[\w, ]+)?\s*\{/gm;
   for (const m of stripped.matchAll(typeRe)) {
     const kind = m[0].trimStart().startsWith('interface') ? 'interface' :
       m[0].trimStart().startsWith('trait') ? 'trait' : 'class';
-    sigs.push(`${kind} ${m[1]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const meth of extractMembers(block)) sigs.push(`  ${meth}`);
+    const bodyStart = m.index + m[0].length;
+    const block = extractBlock(stripped, bodyStart);
+    sigs.push(withAnchor(`${kind} ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    for (const meth of extractMembers(block)) {
+      sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+    }
   }
 
   // Top-level functions
   for (const m of stripped.matchAll(/^function\s+(\w+)\s*\(([^)]*)\)\s*(?::\s*([^\n{]+))?/gm)) {
     const ret = normalizeType(m[3]);
     const retStr = ret ? ` → ${ret}` : '';
-    sigs.push(`function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    const [s, e] = rangeFor(m.index, m.index + m[0].length);
+    sigs.push(withAnchor(`function ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
   }
 
   return sigs.slice(0, 25);
@@ -53,7 +74,11 @@ function extractMembers(block) {
     const isStatic = m[0].includes('static ') ? 'static ' : '';
     const ret = normalizeType(m[3]);
     const retStr = ret ? ` → ${ret}` : '';
-    members.push(`${isStatic}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({
+      text: `${isStatic}function ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+      declIdx: m.index + (m[0].length - m[0].trimStart().length),
+      endIdx: m.index + m[0].length,
+    });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/scala.js
+++ b/src/extractors/scala.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from Scala source code.
+ * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+ * strip below is newline-preserving so anchor lines match the original file.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
@@ -11,7 +15,7 @@ function extract(src) {
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
 
   // Classes, traits, objects
   const typeRe = /^(?:case\s+)?(?:class|trait|object)\s+(\w+)(?:\[[\w, ]+\])?(?:[^{]*)\{/gm;
@@ -19,9 +23,12 @@ function extract(src) {
     const kind = m[0].trimStart().startsWith('case class') ? 'case class' :
       m[0].trimStart().startsWith('trait') ? 'trait' :
       m[0].trimStart().startsWith('object') ? 'object' : 'class';
-    sigs.push(`${kind} ${m[1]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const fn of extractMembers(block)) sigs.push(`  ${fn}`);
+    const bodyStart = m.index + m[0].length;
+    const block = extractBlock(stripped, bodyStart);
+    sigs.push(withAnchor(`${kind} ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    for (const fn of extractMembers(block)) {
+      sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+    }
   }
 
   // Top-level defs
@@ -30,7 +37,8 @@ function extract(src) {
     const params = m[2] ? `(${normalizeParams(m[2])})` : '';
     const ret = normalizeType(m[3]);
     const retStr = ret ? ` → ${ret}` : '';
-    sigs.push(`def ${m[1]}${params}${retStr}`);
+    const line = lineAt(stripped, m.index);
+    sigs.push(withAnchor(`def ${m[1]}${params}${retStr}`, line, line));
   }
 
   return sigs.slice(0, 25);
@@ -54,7 +62,11 @@ function extractMembers(block) {
     const params = m[2] ? `(${normalizeParams(m[2])})` : '';
     const ret = normalizeType(m[3]);
     const retStr = ret ? ` → ${ret}` : '';
-    members.push(`def ${m[1]}${params}${retStr}`);
+    members.push({
+      text: `def ${m[1]}${params}${retStr}`,
+      declIdx: m.index + (m[0].length - m[0].trimStart().length),
+      endIdx: m.index + m[0].length,
+    });
   }
   return members.slice(0, 8);
 }

--- a/src/extractors/swift.js
+++ b/src/extractors/swift.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const { lineAt, withAnchor } = require('./line-anchor');
+
 /**
  * Extract signatures from Swift source code.
+ * Signatures carry `:start-end` line anchors (Surgical Context); the comment
+ * strip below is newline-preserving so anchor lines match the original file.
  * @param {string} src - Raw file content
  * @returns {string[]} Array of signature strings
  */
@@ -11,21 +15,37 @@ function extract(src) {
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (s) => s.replace(/[^\n]/g, ' '));
+
+  // Anchor range: scan past same-line modifiers to a body `{` (range) else single line.
+  const rangeFor = (declIdx, afterIdx) => {
+    let k = afterIdx;
+    while (k < stripped.length && /[ \tA-Za-z0-9_>-]/.test(stripped[k])) k++;
+    if (stripped[k] === '{') {
+      const end = k + 1 + extractBlock(stripped, k + 1).length;
+      return [lineAt(stripped, declIdx), lineAt(stripped, end)];
+    }
+    const line = lineAt(stripped, declIdx);
+    return [line, line];
+  };
 
   // Classes, structs, protocols, enums
   const typeRe = /^(?:public\s+|internal\s+|open\s+)?(?:final\s+)?(class|struct|protocol|enum|actor)\s+(\w+)(?:<[^{]*>)?(?:\s*:\s*[\w, <>.]+)?\s*\{/gm;
   for (const m of stripped.matchAll(typeRe)) {
-    sigs.push(`${m[1]} ${m[2]}`);
-    const block = extractBlock(stripped, m.index + m[0].length);
-    for (const fn of extractMembers(block)) sigs.push(`  ${fn}`);
+    const bodyStart = m.index + m[0].length;
+    const block = extractBlock(stripped, bodyStart);
+    sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    for (const fn of extractMembers(block)) {
+      sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+    }
   }
 
   // Top-level public functions — capture everything after ) to end of line for arrow type
   for (const m of stripped.matchAll(/^(?:public\s+|internal\s+)?(?:static\s+)?(?:async\s+)?func\s+(\w+)(?:<[^(]*>)?\s*\(([^)]*)\)([^{\n]*)/gm)) {
     const asyncKw = m[0].includes('async') ? 'async ' : '';
     const retStr = extractArrowType(m[3]);
-    sigs.push(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    const [s, e] = rangeFor(m.index, m.index + m[0].length);
+    sigs.push(withAnchor(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
   }
 
   return sigs.slice(0, 25);
@@ -48,7 +68,11 @@ function extractMembers(block) {
     if (m[1].startsWith('_')) continue;
     const asyncKw = m[0].includes('async') ? 'async ' : '';
     const retStr = extractArrowType(m[3]);
-    members.push(`${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    members.push({
+      text: `${asyncKw}func ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+      declIdx: m.index + (m[0].length - m[0].trimStart().length),
+      endIdx: m.index + m[0].length,
+    });
   }
   return members.slice(0, 8);
 }
@@ -67,7 +91,7 @@ function extractArrowType(str) {
   const m = str.match(/->\s*([^\n{]+)/);
   if (!m) return '';
   const rt = m[1].trim().replace(/\s+/g, ' ');
-  return ` \u2192 ${rt.length > 25 ? rt.slice(0, 22) + '...' : rt}`;
+  return ` → ${rt.length > 25 ? rt.slice(0, 22) + '...' : rt}`;
 }
 
 module.exports = { extract };

--- a/test/expected/dart.txt
+++ b/test/expected/dart.txt
@@ -1,8 +1,8 @@
-abstract class Repository
-  findById(String id) → T?
-  save(T entity) → Future<T>
-class UserService
-  getUser(String id) → User?
-  createUser(CreateUserDto data) → Future<User>
-class User
-hashPassword(String password) → String
+abstract class Repository  :2-5
+  findById(String id) → T?  :3-3
+  save(T entity) → Future<T>  :4-4
+class UserService  :7-18
+  getUser(String id) → User?  :12-12
+  createUser(CreateUserDto data) → Future<User>  :14-14
+class User  :20-24
+hashPassword(String password) → String  :26-26

--- a/test/expected/kotlin.txt
+++ b/test/expected/kotlin.txt
@@ -1,7 +1,7 @@
-class User
-  fun getUser(id) → User?
-  suspend fun createUser(dto) → User
-interface Repository
-  fun findById(id) → T?
-  suspend fun save(entity) → T
-fun formatUser(user) → String
+class User  :4-14
+  fun getUser(id) → User?  :7-7
+  suspend fun createUser(dto) → User  :9-9
+interface Repository  :16-19
+  fun findById(id) → T?  :17-17
+  suspend fun save(entity) → T  :18-18
+fun formatUser(user) → String  :21-21

--- a/test/expected/php.txt
+++ b/test/expected/php.txt
@@ -1,8 +1,8 @@
-class UserService
-  function getUser(string $id) → ?User
-  function createUser(array $data) → User
-  function validateUser(User $user) → bool
-interface Repository
-  function findById(string $id) → mixed
-  function save(mixed $entity) → mixed
-function hashPassword(string $password) → string
+class UserService  :5-28
+  function getUser(string $id) → ?User  :14-14
+  function createUser(array $data) → User  :19-19
+  function validateUser(User $user) → bool  :24-24
+interface Repository  :30-34
+  function findById(string $id) → mixed  :32-32
+  function save(mixed $entity) → mixed  :33-33
+function hashPassword(string $password) → string  :36-39

--- a/test/expected/scala.txt
+++ b/test/expected/scala.txt
@@ -1,9 +1,9 @@
-case class User
-  def findById(id) → Option[T]
-  def save(entity) → T
-class UserService
-  def getUser(id) → Option[User]
-  def createUser(dto) → User
-object UserService
-  def apply(repo) → UserService
-def hashPassword(password) → String
+case class User  :4-9
+  def findById(id) → Option[T]  :7-7
+  def save(entity) → T  :8-8
+class UserService  :11-18
+  def getUser(id) → Option[User]  :12-12
+  def createUser(dto) → User  :14-14
+object UserService  :20-22
+  def apply(repo) → UserService  :21-21
+def hashPassword(password) → String  :24-24

--- a/test/expected/swift.txt
+++ b/test/expected/swift.txt
@@ -1,9 +1,9 @@
-protocol Repository
-  func findById(_ id) → User?
-  func save(_ user)
-class UserService
-  func getUser(id) → User?
-  async func createUser(data) → User
-struct User
-enum UserRole
-func hashPassword(_ password) → String
+protocol Repository  :4-7
+  func findById(_ id) → User?  :5-5
+  func save(_ user)  :6-6
+class UserService  :9-25
+  func getUser(id) → User?  :16-16
+  async func createUser(data) → User  :20-20
+struct User  :27-30
+enum UserRole  :32-34
+func hashPassword(_ password) → String  :36-38

--- a/test/integration/extractor-anchors.test.js
+++ b/test/integration/extractor-anchors.test.js
@@ -113,6 +113,33 @@ test('C#: class + member anchors correct despite a leading block comment', () =>
   assert.ok(sigs.find((s) => s.startsWith('class Svc')).endsWith(':4-9'), sigs.join('|'));
 });
 
+test('Kotlin/Swift/PHP/Scala/Dart: every fixture sig anchored; block-comment lines correct', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const header = '/*\n * multi-line\n * header\n */\n';
+  const cases = [
+    ['kotlin', header + 'class Foo {\n  fun bar(x: Int): Int {\n    return x\n  }\n}\n', 'class Foo', ':5-9'],
+    ['swift', header + 'struct Foo {\n  func bar(x: Int) -> Int {\n    return x\n  }\n}\n', 'struct Foo', ':5-9'],
+    ['php', header + 'class Foo {\n  public function bar(int $x): int {\n    return $x;\n  }\n}\n', 'class Foo', ':5-9'],
+    ['scala', header + 'class Foo {\n  def bar(x: Int): Int = x\n}\n', 'class Foo', ':5-7'],
+    ['dart', header + 'class Foo {\n  int bar(int x) {\n    return x;\n  }\n}\n', 'class Foo', ':5-9'],
+  ];
+  for (const [lang, src, decl, anchor] of cases) {
+    const { extract } = require('../../src/extractors/' + lang);
+    const sigs = extract(src);
+    assert.ok(sigs.length > 0 && sigs.every((s) => /\s{2}:\d+-\d+$/.test(s)), lang + ': ' + sigs.join('|'));
+    const typeSig = sigs.find((s) => s.startsWith(decl));
+    assert.ok(typeSig && typeSig.endsWith(anchor), lang + ': ' + typeSig);
+  }
+  // fixture files: 100% anchored for all five
+  const map = { kotlin: 'kotlin.kt', swift: 'swift.swift', php: 'php.php', scala: 'scala.scala', dart: 'dart.dart' };
+  for (const [lang, f] of Object.entries(map)) {
+    const { extract } = require('../../src/extractors/' + lang);
+    const sigs = extract(fs.readFileSync(path.join(__dirname, '../fixtures', f), 'utf8'));
+    assert.ok(sigs.length > 0 && sigs.every((s) => /\s{2}:\d+-\d+$/.test(s)), lang + ' fixture not fully anchored');
+  }
+});
+
 test('parseAnchor round-trips the emitted anchors', () => {
   for (const sig of [...goX.extract(GO_SRC), ...javaX.extract(JAVA_SRC), ...rustX.extract(RUST_SRC), ...csX.extract(CS_SRC)]) {
     const { symbol, start, end } = parseAnchor(sig);


### PR DESCRIPTION
Closes #486. Completes the anchors sweep started in v8.17 (#483) — same recipe applied to the remaining five brace languages: newline-preserving comment strips, brace-matched `:start-end` ranges on types, `:n-n` members, body-scan ranging for top-level functions (expression bodies and PSR next-line braces degrade to single-line anchors).

All five fixture files anchor **100%**; `parseAnchor` round-trips; per-language block-comment line-fidelity regression covered. 5 expected fixtures regenerated (anchors only). Full suite **117/117 + unit green**.

Supply-chain gate: extractors-only change; audit unchanged from v8.17 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)