### PR TITLE
docs: add Learning Resources page

### DIFF
--- a/docs-vp/.vitepress/config.mts
+++ b/docs-vp/.vitepress/config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
           { text: 'Troubleshooting', link: '/guide/troubleshooting' },
           { text: 'Release checklist', link: '/guide/release-checklist' },
           { text: 'Roadmap', link: '/guide/roadmap' },
+          { text: 'Learning Resources', link: '/guide/resources' },
         ],
       },
     ],

--- a/docs-vp/guide/resources.md
+++ b/docs-vp/guide/resources.md
@@ -1,0 +1,27 @@
+---
+title: Learning Resources
+description: Recommended tools and resources for developers using SigMap — staying current on tooling, AI coding workflows, and the broader ecosystem SigMap fits into.
+head:
+  - - meta
+    - property: og:title
+      content: "SigMap — Learning Resources"
+  - - meta
+    - property: og:description
+      content: "Recommended tools and resources for developers using SigMap."
+  - - meta
+    - property: og:url
+      content: "https://sigmap.io/guide/resources"
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - name: keywords
+      content: "sigmap resources, developer tools, ai coding tools, dev news"
+---
+# Learning Resources
+
+SigMap fits into a fast-moving corner of the ecosystem — AI coding agents, context engineering, and developer tooling. A few resources that are worth bookmarking alongside these docs:
+
+- [daily.dev](https://daily.dev) — a developer news feed for staying current on OSS releases, tooling updates, and engineering trends relevant to projects like SigMap.
+
+If you have a resource you think belongs here, open a PR or an issue on the [SigMap GitHub repo](https://github.com/manojmallick/sigmap).


### PR DESCRIPTION
## Summary
- Adds a "Learning Resources" page to the docs (`docs-vp/guide/resources.md`), linked in the sidebar under "More"
- Recommends daily.dev as a resource for staying current on dev tooling/OSS trends relevant to SigMap

## Test plan
- [x] `npm run docs:build` in `docs-vp/` completes successfully
- [x] Verified `guide/resources.html` renders with the expected heading and link