### PR TITLE
feat(benchmark): honest grep-agent baseline; retire random-baseline lift

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ That map is exactly what agentic grep is worst at: reproducible, auditable conte
 
 **Proof it pays off** (full benchmark below):
 <!--SM:whyMetrics-->
-- **86.7% hit@5** — right file found in top 5 results (vs 13.6% baseline)
+- **86.7% hit@5** — right file in top 5 results (vs 42.7% single-shot grep baseline — 2.02× lift)
 - **96.9% token reduction** — average across 21 real repos
-- **68.9% task success rate** — up from 10% without context
-- **1.44 prompts per task** — down from 2.84 (49.2% fewer retries)
+- **68.9% task-success proxy** — modeled from retrieval tiers, not measured LLM sessions
+- **1.44 prompts per task** — down from 2.84 (49.2% fewer retries, modeled)
 <!--/SM:whyMetrics-->
 - **<!--SM:languages-->33<!--/SM:languages--> languages supported** — TypeScript, Python, Go, Rust, Java, R, and more
 - **No vendor lock-in** — works with any AI assistant or local LLM
@@ -125,10 +125,10 @@ Ask → Rank → Context → Validate → Judge → Learn
 Benchmark : sigmap-v8.18-main (21 repositories, including R language)
 Date      : 2026-07-12
 
-Hit@5          : 86.7%   (baseline 13.6%  — 6.4× lift)
+Hit@5          : 86.7%   (grep-agent baseline 42.7%  — 2.02× lift)
 Token reduction: 96.9%   (across 21 repos)
-Prompt reduction : 49.2% (2.84 → 1.44 prompts per task)
-Task success   : 68.9%   (baseline 10%)
+Prompt reduction : 49.2% (2.84 → 1.44 prompts per task, modeled)
+Task success   : 68.9%   (proxy — modeled from retrieval tiers)
 Repos tested   : 21 (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift, Ruby, PHP, Scala, Kotlin, and more)
 ```
 <!--/SM:benchmarkBlock-->

--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -1,7 +1,7 @@
 {
   "benchmark_id": "sigmap-v8.18-main",
   "benchmark_date": "2026-07-12",
-  "source": "benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction}.json",
+  "source": "benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction,honest-baseline}.json",
   "repos_token": 21,
   "repos_retrieval": 18,
   "metrics": {
@@ -13,7 +13,9 @@
     "prompts_per_task": 1.44,
     "baseline_prompts_per_task": 2.84,
     "prompt_reduction_pct": 49.2,
-    "graph_boosted_hit_at_5": 0.867
+    "graph_boosted_hit_at_5": 0.867,
+    "grep_baseline_hit_at_5": 0.427,
+    "grep_lift": 2.02
   },
   "test_discovery": {
     "repos": 28,

--- a/benchmarks/reports/honest-baseline.json
+++ b/benchmarks/reports/honest-baseline.json
@@ -1,0 +1,141 @@
+{
+  "generated": "2026-07-19T08:34:08.303Z",
+  "methodology": {
+    "corpus": "benchmarks/tasks/*.jsonl",
+    "scorer": "src/eval/scorer.js hitAtK/reciprocalRank, k=5",
+    "sigmap": "src/eval/runner.js buildSigIndex + rank over committed context output",
+    "baseline": "internal single-shot grep-agent: whole-repo term scan, ranked by distinct-term coverage then occurrences; skips VCS/vendor dirs + top-level .gitignore dirs; files ≤1MB, non-binary",
+    "note": "Single-shot floor for agentic grep — a live agent iterates above this at the cost of extra turns and tokens."
+  },
+  "summary": {
+    "tasks": 110,
+    "repos": 19,
+    "sigmap": {
+      "hitAt5": 0.864,
+      "mrr": 0.78
+    },
+    "grepBaseline": {
+      "hitAt5": 0.427,
+      "mrr": 0.228
+    },
+    "lift": 2.02,
+    "deltaPts": 43.6
+  },
+  "repos": [
+    {
+      "repo": "abseil-cpp",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.8
+    },
+    {
+      "repo": "akka",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.4
+    },
+    {
+      "repo": "axios",
+      "tasks": 5,
+      "sigmapHitAt5": 0.8,
+      "grepHitAt5": 0
+    },
+    {
+      "repo": "express",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 1
+    },
+    {
+      "repo": "fastapi",
+      "tasks": 5,
+      "sigmapHitAt5": 0.8,
+      "grepHitAt5": 0.8
+    },
+    {
+      "repo": "fastify",
+      "tasks": 5,
+      "sigmapHitAt5": 0.8,
+      "grepHitAt5": 0.6
+    },
+    {
+      "repo": "flask",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.8
+    },
+    {
+      "repo": "gin",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.8
+    },
+    {
+      "repo": "laravel",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.8
+    },
+    {
+      "repo": "okhttp",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.4
+    },
+    {
+      "repo": "rails",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.2
+    },
+    {
+      "repo": "retrieval",
+      "tasks": 20,
+      "sigmapHitAt5": 0.85,
+      "grepHitAt5": 0.1
+    },
+    {
+      "repo": "riverpod",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.4
+    },
+    {
+      "repo": "rust-analyzer",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.2
+    },
+    {
+      "repo": "serilog",
+      "tasks": 5,
+      "sigmapHitAt5": 0.2,
+      "grepHitAt5": 0
+    },
+    {
+      "repo": "spring-petclinic",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.4
+    },
+    {
+      "repo": "svelte",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.6
+    },
+    {
+      "repo": "vapor",
+      "tasks": 5,
+      "sigmapHitAt5": 0,
+      "grepHitAt5": 0.4
+    },
+    {
+      "repo": "vue-core",
+      "tasks": 5,
+      "sigmapHitAt5": 1,
+      "grepHitAt5": 0.4
+    }
+  ],
+  "skipped": []
+}

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -21,9 +21,9 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
 | Metric | Without SigMap | With SigMap |
 |--------|----------------|-------------|
-| Retrieval hit@5 | 13.6% (random) | 86.7% (6.4× lift) |
+| Retrieval hit@5 | 42.7% (single-shot grep) | 86.7% (2.02× lift) |
 | Token reduction | — | 96.9% average |
-| Task success proxy | 10% | 68.9% |
+| Task-success proxy (modeled) | — | 68.9% |
 | Prompts per task | 2.84 | 1.44 (49.2% fewer) |
 | Supported languages | — | 33 |
 | MCP tools | — | 20 |

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -25,10 +25,10 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
 ## Core metrics (benchmark: sigmap-v8.18-main, 2026-07-12)
 
-- hit@5 retrieval: 86.7% vs 13.6% random baseline (6.4× lift)
+- hit@5 retrieval: 86.7% vs 42.7% single-shot grep baseline (2.02× lift)
 - Token reduction: 96.9% average across benchmark repos
-- Task success: 68.9% vs 10% without SigMap
-- Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer)
+- Task-success proxy: 68.9% (modeled from retrieval tiers, not measured LLM sessions)
+- Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer, modeled)
 - Languages: 33 supported · MCP tools: 20
 - Dependencies: zero npm runtime dependencies · fully offline
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -21,9 +21,9 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
 | Metric | Without SigMap | With SigMap |
 |--------|----------------|-------------|
-| Retrieval hit@5 | 13.6% (random) | 86.7% (6.4× lift) |
+| Retrieval hit@5 | 42.7% (single-shot grep) | 86.7% (2.02× lift) |
 | Token reduction | — | 96.9% average |
-| Task success proxy | 10% | 68.9% |
+| Task-success proxy (modeled) | — | 68.9% |
 | Prompts per task | 2.84 | 1.44 (49.2% fewer) |
 | Supported languages | — | 33 |
 | MCP tools | — | 20 |

--- a/llms.txt
+++ b/llms.txt
@@ -25,10 +25,10 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 
 ## Core metrics (benchmark: sigmap-v8.18-main, 2026-07-12)
 
-- hit@5 retrieval: 86.7% vs 13.6% random baseline (6.4× lift)
+- hit@5 retrieval: 86.7% vs 42.7% single-shot grep baseline (2.02× lift)
 - Token reduction: 96.9% average across benchmark repos
-- Task success: 68.9% vs 10% without SigMap
-- Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer)
+- Task-success proxy: 68.9% (modeled from retrieval tiers, not measured LLM sessions)
+- Prompts per task: 1.44 vs 2.84 baseline (49.2% fewer, modeled)
 - Languages: 33 supported · MCP tools: 20
 - Dependencies: zero npm runtime dependencies · fully offline
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check:metrics": "node scripts/gen-benchmark-latest.mjs --check && node scripts/check-version-meta.mjs && node scripts/sync-metrics.mjs --check",
     "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/build-bundle.mjs --check && node scripts/gen-benchmark-latest.mjs --check && node scripts/check-version-meta.mjs && node scripts/sync-metrics.mjs --check && node scripts/generate-llms.mjs",
     "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs",
+    "benchmark:honest": "node scripts/run-honest-benchmark.mjs --save",
     "benchmark:llm-ablation": "node scripts/run-llm-ablation.mjs"
   },
   "files": [

--- a/scripts/gen-benchmark-latest.mjs
+++ b/scripts/gen-benchmark-latest.mjs
@@ -58,7 +58,7 @@ export function computeLatest(root = ROOT) {
   const out = {
     benchmark_id: `sigmap-v${maj}.${min}-main`,
     benchmark_date,
-    source: 'benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction}.json',
+    source: 'benchmarks/reports/{benchmark-matrix,task-benchmark,token-reduction,honest-baseline}.json',
     repos_token: matrix.reposToken,
     repos_retrieval: matrix.reposRetrieval,
     metrics: {
@@ -73,6 +73,16 @@ export function computeLatest(root = ROOT) {
       graph_boosted_hit_at_5: round(matrix.avgHitAt5Pct / 100, 3),
     },
   };
+
+  // Honest grep-agent baseline (v8.19 A1) — optional, present once
+  // scripts/run-honest-benchmark.mjs --save has run. These are the only
+  // baseline numbers surfaced on human-facing pages; the random baseline
+  // stays above as data but is no longer quoted.
+  const honest = readReportOptional(root, 'honest-baseline.json');
+  if (honest && honest.summary) {
+    out.metrics.grep_baseline_hit_at_5 = round(honest.summary.grepBaseline.hitAt5, 3);
+    out.metrics.grep_lift = round(honest.summary.lift, 2);
+  }
 
   // Test-discovery (v8.5 C2) — optional, present once the benchmark has run.
   // Kept top-level (not under `metrics`) so version.json's metrics mirror is

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -72,10 +72,12 @@ function metricsBullets(d) {
   return [
     `## Core metrics (benchmark: ${d.latest.benchmark_id}, ${d.latest.benchmark_date})`,
     '',
-    `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)} vs ${pct(m.baseline_hit_at_5 * 100)} random baseline (${Number(m.retrieval_lift).toFixed(1)}× lift)`,
+    m.grep_baseline_hit_at_5 != null
+      ? `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)} vs ${pct(m.grep_baseline_hit_at_5 * 100)} single-shot grep baseline (${Number(m.grep_lift).toFixed(2)}× lift)`
+      : `- hit@5 retrieval: ${pct(m.hit_at_5 * 100)}`,
     `- Token reduction: ${pct(m.overall_token_reduction_pct)} average across benchmark repos`,
-    `- Task success: ${pct(m.task_success_proxy_pct)} vs 10% without SigMap`,
-    `- Prompts per task: ${m.prompts_per_task} vs ${m.baseline_prompts_per_task} baseline (${pct(m.prompt_reduction_pct)} fewer)`,
+    `- Task-success proxy: ${pct(m.task_success_proxy_pct)} (modeled from retrieval tiers, not measured LLM sessions)`,
+    `- Prompts per task: ${m.prompts_per_task} vs ${m.baseline_prompts_per_task} baseline (${pct(m.prompt_reduction_pct)} fewer, modeled)`,
     `- Languages: ${d.version.languages} supported · MCP tools: ${d.version.mcp_tools}`,
     '- Dependencies: zero npm runtime dependencies · fully offline',
   ].join('\n');
@@ -88,9 +90,11 @@ function metricsTable(d) {
     '',
     '| Metric | Without SigMap | With SigMap |',
     '|--------|----------------|-------------|',
-    `| Retrieval hit@5 | ${pct(m.baseline_hit_at_5 * 100)} (random) | ${pct(m.hit_at_5 * 100)} (${Number(m.retrieval_lift).toFixed(1)}× lift) |`,
+    m.grep_baseline_hit_at_5 != null
+      ? `| Retrieval hit@5 | ${pct(m.grep_baseline_hit_at_5 * 100)} (single-shot grep) | ${pct(m.hit_at_5 * 100)} (${Number(m.grep_lift).toFixed(2)}× lift) |`
+      : `| Retrieval hit@5 | — | ${pct(m.hit_at_5 * 100)} |`,
     `| Token reduction | — | ${pct(m.overall_token_reduction_pct)} average |`,
-    `| Task success proxy | 10% | ${pct(m.task_success_proxy_pct)} |`,
+    `| Task-success proxy (modeled) | — | ${pct(m.task_success_proxy_pct)} |`,
     `| Prompts per task | ${m.prompts_per_task < m.baseline_prompts_per_task ? m.baseline_prompts_per_task : '—'} | ${m.prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer) |`,
     `| Supported languages | — | ${d.version.languages} |`,
     `| MCP tools | — | ${d.version.mcp_tools} |`,

--- a/scripts/run-honest-benchmark.mjs
+++ b/scripts/run-honest-benchmark.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * run-honest-benchmark.mjs — SigMap ranker vs an honest grep-agent baseline.
+ *
+ * The task-benchmark's published baseline is random file selection
+ * (min(1, 5/fileCount)) — nobody works that way. This benchmark scores the
+ * production ranker against what an agent's grep loop actually does: scan the
+ * whole repo for the query's terms and rank files by term coverage, then
+ * occurrence count. Same task corpus (benchmarks/tasks/*.jsonl), same scorer
+ * (src/eval/scorer.js), single-shot for both sides.
+ *
+ * The baseline is implemented internally (pure Node fs scan — no ripgrep, no
+ * child processes) so the benchmark is zero-dependency and deterministic.
+ * Directories skipped mirror ripgrep defaults: VCS/vendor dirs plus top-level
+ * directory patterns from the scanned repo's .gitignore.
+ *
+ * SigMap's side reads each repo's committed context output via
+ * src/eval/runner.js — run scripts/run-retrieval-benchmark.mjs first if a
+ * repo's context file is missing.
+ *
+ *   node scripts/run-honest-benchmark.mjs           # print comparison table
+ *   node scripts/run-honest-benchmark.mjs --save    # also write benchmarks/reports/honest-baseline.json
+ *   node scripts/run-honest-benchmark.mjs --json    # print report JSON to stdout
+ *
+ * No LLM API. All metrics are retrieval-rank math.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const TASKS_DIR = path.join(ROOT, 'benchmarks', 'tasks');
+const REPOS_DIR = path.join(ROOT, 'benchmarks', 'repos');
+const REPORT_PATH = path.join(ROOT, 'benchmarks', 'reports', 'honest-baseline.json');
+
+const SAVE = process.argv.includes('--save');
+const JSON_OUT = process.argv.includes('--json');
+
+const runner = require(path.join(ROOT, 'src', 'eval', 'runner.js'));
+const scorer = require(path.join(ROOT, 'src', 'eval', 'scorer.js'));
+const { STOP } = require(path.join(ROOT, 'src', 'retrieval', 'bm25.js'));
+
+// Dirs a grep agent never scans (ripgrep skips VCS + honors .gitignore).
+const SKIP_DIRS = new Set([
+  '.git', '.hg', '.svn', 'node_modules', 'vendor', 'dist', 'build', 'target',
+  'out', 'coverage', '.next', '__pycache__', '.venv', 'venv', '.tox',
+]);
+const MAX_FILE_BYTES = 1024 * 1024; // grep-realistic cap; skips lockfile giants
+
+const round = (n, d = 3) => Math.round(Number(n) * 10 ** d) / 10 ** d;
+const norm = (p) => String(p).replace(/\\/g, '/').replace(/^\.\//, '');
+
+/** Significant literal query terms — no stemming; grep matches literals. */
+function terms(query) {
+  return [...new Set(
+    String(query).toLowerCase().split(/[^a-z0-9]+/)
+      .filter((w) => w.length >= 3 && !STOP.has(w))
+  )];
+}
+
+/** Top-level directory patterns from a repo's .gitignore (simple names only). */
+function gitignoreDirs(repoPath) {
+  const dirs = new Set();
+  try {
+    const src = fs.readFileSync(path.join(repoPath, '.gitignore'), 'utf8');
+    for (const raw of src.split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('#') || line.startsWith('!')) continue;
+      const m = line.match(/^\/?([A-Za-z0-9._-]+)\/?$/);
+      if (m) dirs.add(m[1]);
+    }
+  } catch (_) { /* no .gitignore — nothing to skip */ }
+  return dirs;
+}
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function countOccurrences(haystack, needle) {
+  let n = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) { n++; i = haystack.indexOf(needle, i + needle.length); }
+  return n;
+}
+
+/**
+ * Scan a repo once and rank files for every task's term set.
+ * @returns {Map<string, string[]>} task id → top-10 relative file paths
+ */
+function grepRank(repoPath, tasks) {
+  const perTask = new Map(tasks.map((t) => [t.id, new Map()])); // id → file → {cover, occ}
+  const termSets = tasks.map((t) => ({ id: t.id, terms: terms(t.query) }));
+  const ignored = gitignoreDirs(repoPath);
+
+  const walk = (dir) => {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    entries.sort((a, b) => a.name.localeCompare(b.name)); // deterministic order
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name) || ignored.has(e.name)) continue;
+        walk(full);
+        continue;
+      }
+      if (!e.isFile()) continue;
+      let buf;
+      try {
+        if (fs.statSync(full).size > MAX_FILE_BYTES) continue;
+        buf = fs.readFileSync(full);
+      } catch (_) { continue; }
+      if (buf.subarray(0, 8192).includes(0)) continue; // binary
+      const text = buf.toString('utf8').toLowerCase();
+      const rel = norm(path.relative(repoPath, full));
+
+      const termCount = new Map(); // term → occurrences in this file (shared across tasks)
+      for (const { id, terms: ts } of termSets) {
+        let cover = 0, occ = 0;
+        for (const t of ts) {
+          if (!termCount.has(t)) termCount.set(t, countOccurrences(text, t));
+          const c = termCount.get(t);
+          if (c > 0) { cover++; occ += c; }
+        }
+        if (cover > 0) perTask.get(id).set(rel, { cover, occ });
+      }
+    }
+  };
+  walk(repoPath);
+
+  const ranked = new Map();
+  for (const [id, fileScores] of perTask) {
+    ranked.set(id, [...fileScores.entries()]
+      .sort((a, b) => b[1].cover - a[1].cover || b[1].occ - a[1].occ || a[0].localeCompare(b[0]))
+      .slice(0, 10)
+      .map(([file]) => file));
+  }
+  return ranked;
+}
+
+function loadTasks(file) {
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+const taskFiles = fs.readdirSync(TASKS_DIR).filter((f) => f.endsWith('.jsonl')).sort();
+const perRepo = [];
+const skipped = [];
+let nTasks = 0;
+const totals = { sigHit: 0, grepHit: 0, sigMrr: 0, grepMrr: 0 };
+
+for (const f of taskFiles) {
+  const name = f.replace('.jsonl', '');
+  const repoPath = name === 'retrieval' ? ROOT : path.join(REPOS_DIR, name);
+  if (!fs.existsSync(repoPath)) { skipped.push({ repo: name, reason: 'repo not cloned' }); continue; }
+
+  const sigIndex = runner.buildSigIndex(repoPath);
+  if (!sigIndex || sigIndex.size === 0) {
+    skipped.push({ repo: name, reason: 'no context output — run scripts/run-retrieval-benchmark.mjs' });
+    continue;
+  }
+
+  const tasks = loadTasks(path.join(TASKS_DIR, f));
+  const grepRanked = grepRank(repoPath, tasks);
+
+  const row = { repo: name, tasks: tasks.length, sigHit: 0, grepHit: 0 };
+  for (const t of tasks) {
+    const expected = t.expected_files || [];
+    const sig = runner.rank(t.query, sigIndex, 10).map((r) => r.file);
+    const grep = grepRanked.get(t.id) || [];
+    row.sigHit += scorer.hitAtK(sig, expected, 5);
+    row.grepHit += scorer.hitAtK(grep, expected, 5);
+    totals.sigHit += scorer.hitAtK(sig, expected, 5) ? 1 : 0;
+    totals.grepHit += scorer.hitAtK(grep, expected, 5) ? 1 : 0;
+    totals.sigMrr += scorer.reciprocalRank(sig, expected);
+    totals.grepMrr += scorer.reciprocalRank(grep, expected);
+    nTasks++;
+  }
+  perRepo.push({
+    repo: name,
+    tasks: tasks.length,
+    sigmapHitAt5: round(row.sigHit / tasks.length),
+    grepHitAt5: round(row.grepHit / tasks.length),
+  });
+}
+
+if (nTasks === 0) {
+  console.error('No tasks scored — clone benchmark repos and generate context first.');
+  process.exit(1);
+}
+
+const sigHitAt5 = totals.sigHit / nTasks;
+const grepHitAt5 = totals.grepHit / nTasks;
+const report = {
+  generated: new Date().toISOString(),
+  methodology: {
+    corpus: 'benchmarks/tasks/*.jsonl',
+    scorer: 'src/eval/scorer.js hitAtK/reciprocalRank, k=5',
+    sigmap: 'src/eval/runner.js buildSigIndex + rank over committed context output',
+    baseline: 'internal single-shot grep-agent: whole-repo term scan, ranked by distinct-term coverage then occurrences; skips VCS/vendor dirs + top-level .gitignore dirs; files ≤1MB, non-binary',
+    note: 'Single-shot floor for agentic grep — a live agent iterates above this at the cost of extra turns and tokens.',
+  },
+  summary: {
+    tasks: nTasks,
+    repos: perRepo.length,
+    sigmap: { hitAt5: round(sigHitAt5), mrr: round(totals.sigMrr / nTasks) },
+    grepBaseline: { hitAt5: round(grepHitAt5), mrr: round(totals.grepMrr / nTasks) },
+    lift: round(grepHitAt5 > 0 ? sigHitAt5 / grepHitAt5 : 0, 2),
+    deltaPts: round((sigHitAt5 - grepHitAt5) * 100, 1),
+  },
+  repos: perRepo,
+  skipped,
+};
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  const pct = (v) => `${(v * 100).toFixed(0)}%`.padStart(5);
+  console.log('\n  repo                 tasks  SigMap  grep-agent');
+  console.log('  -------------------- -----  ------  ----------');
+  for (const r of perRepo) {
+    console.log(`  ${r.repo.padEnd(20)} ${String(r.tasks).padStart(5)}  ${pct(r.sigmapHitAt5)}  ${pct(r.grepHitAt5).padStart(9)}`);
+  }
+  const s = report.summary;
+  console.log(`\n  SigMap        hit@5 ${(s.sigmap.hitAt5 * 100).toFixed(1)}%   MRR ${s.sigmap.mrr.toFixed(3)}`);
+  console.log(`  grep baseline hit@5 ${(s.grepBaseline.hitAt5 * 100).toFixed(1)}%   MRR ${s.grepBaseline.mrr.toFixed(3)}`);
+  console.log(`  honest lift   ${s.lift}×  (+${s.deltaPts}pt over ${s.tasks} tasks, ${s.repos} repos)`);
+  for (const sk of skipped) console.log(`  [skipped] ${sk.repo}: ${sk.reason}`);
+}
+
+if (SAVE) {
+  fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2) + '\n');
+  console.log(`\n  saved → ${path.relative(ROOT, REPORT_PATH)}`);
+}

--- a/scripts/sync-metrics.mjs
+++ b/scripts/sync-metrics.mjs
@@ -43,11 +43,18 @@ export function renderTokens(root = ROOT) {
   const m = latest.metrics;
   const languages = deriveLanguages(root).length;
 
+  // Honest baseline (v8.19): quote the measured grep-agent comparison, never
+  // the random baseline. Falls back to no baseline clause if the honest
+  // report has not been generated yet.
+  const grepClause = m.grep_baseline_hit_at_5 != null
+    ? `vs ${pct(m.grep_baseline_hit_at_5 * 100)} single-shot grep baseline — ${Number(m.grep_lift).toFixed(2)}× lift`
+    : 'right file found in top 5 results';
+
   const bullets = [
-    `- **${pct(m.hit_at_5 * 100)} hit@5** — right file found in top 5 results (vs ${pct(m.baseline_hit_at_5 * 100)} baseline)`,
+    `- **${pct(m.hit_at_5 * 100)} hit@5** — right file in top 5 results (${grepClause})`,
     `- **${pct(m.overall_token_reduction_pct)} token reduction** — average across ${latest.repos_token} real repos`,
-    `- **${pct(m.task_success_proxy_pct)} task success rate** — up from 10% without context`,
-    `- **${m.prompts_per_task} prompts per task** — down from ${m.baseline_prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer retries)`,
+    `- **${pct(m.task_success_proxy_pct)} task-success proxy** — modeled from retrieval tiers, not measured LLM sessions`,
+    `- **${m.prompts_per_task} prompts per task** — down from ${m.baseline_prompts_per_task} (${pct(m.prompt_reduction_pct)} fewer retries, modeled)`,
   ].join('\n');
 
   // The fenced code block, rendered whole (markers sit *outside* the fence so
@@ -57,10 +64,12 @@ export function renderTokens(root = ROOT) {
     `Benchmark : ${latest.benchmark_id} (${latest.repos_token} repositories, including R language)`,
     `Date      : ${latest.benchmark_date}`,
     '',
-    `Hit@5          : ${pct(m.hit_at_5 * 100)}   (baseline ${pct(m.baseline_hit_at_5 * 100)}  — ${Number(m.retrieval_lift).toFixed(1)}× lift)`,
+    m.grep_baseline_hit_at_5 != null
+      ? `Hit@5          : ${pct(m.hit_at_5 * 100)}   (grep-agent baseline ${pct(m.grep_baseline_hit_at_5 * 100)}  — ${Number(m.grep_lift).toFixed(2)}× lift)`
+      : `Hit@5          : ${pct(m.hit_at_5 * 100)}`,
     `Token reduction: ${pct(m.overall_token_reduction_pct)}   (across ${latest.repos_token} repos)`,
-    `Prompt reduction : ${pct(m.prompt_reduction_pct)} (${m.baseline_prompts_per_task} → ${m.prompts_per_task} prompts per task)`,
-    `Task success   : ${pct(m.task_success_proxy_pct)}   (baseline 10%)`,
+    `Prompt reduction : ${pct(m.prompt_reduction_pct)} (${m.baseline_prompts_per_task} → ${m.prompts_per_task} prompts per task, modeled)`,
+    `Task success   : ${pct(m.task_success_proxy_pct)}   (proxy — modeled from retrieval tiers)`,
     `Repos tested   : ${latest.repos_token} (JavaScript, Python, Go, Rust, Java, R, C++, C#, Dart, Swift, Ruby, PHP, Scala, Kotlin, and more)`,
     '```',
   ].join('\n');

--- a/test/integration/features/readme-structure.test.js
+++ b/test/integration/features/readme-structure.test.js
@@ -77,8 +77,11 @@ test('why: hit@5 (from version.json) mentioned', () => {
   assert.ok(src.includes(pct1(M.hit_at_5 * 100)), `missing ${pct1(M.hit_at_5 * 100)} hit@5`);
 });
 
-test('why: baseline (from version.json) mentioned', () => {
-  assert.ok(src.includes(pct1(M.baseline_hit_at_5 * 100)), `missing ${pct1(M.baseline_hit_at_5 * 100)} baseline`);
+test('why: grep baseline (from version.json) mentioned', () => {
+  // v8.19 (#495): human surfaces quote the measured grep-agent baseline,
+  // never the random baseline (baseline_hit_at_5 stays data-only).
+  assert.ok(src.includes(pct1(M.grep_baseline_hit_at_5 * 100)), `missing ${pct1(M.grep_baseline_hit_at_5 * 100)} grep baseline`);
+  assert.ok(!src.includes(pct1(M.baseline_hit_at_5 * 100)), `random baseline ${pct1(M.baseline_hit_at_5 * 100)} must stay off the README`);
 });
 
 test('why: token reduction (from version.json) mentioned', () => {
@@ -145,8 +148,8 @@ test('benchmark: Hit@5 (from version.json) present', () => {
   assert.ok(src.includes(pct1(M.hit_at_5 * 100)), `missing Hit@5 ${pct1(M.hit_at_5 * 100)}`);
 });
 
-test('benchmark: baseline (from version.json) present', () => {
-  assert.ok(src.includes(pct1(M.baseline_hit_at_5 * 100)), `missing baseline ${pct1(M.baseline_hit_at_5 * 100)}`);
+test('benchmark: grep baseline (from version.json) present', () => {
+  assert.ok(src.includes(pct1(M.grep_baseline_hit_at_5 * 100)), `missing grep baseline ${pct1(M.grep_baseline_hit_at_5 * 100)}`);
 });
 
 test('benchmark: prompt reduction (from version.json) present', () => {

--- a/test/integration/honest-baseline.test.js
+++ b/test/integration/honest-baseline.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * Honest grep-agent baseline (v8.19 A1/A2, #495).
+ * The published lift must come from the measured grep-agent comparison
+ * (benchmarks/reports/honest-baseline.json), and the random baseline /
+ * unsourced "10% without" claims must stay off every human surface.
+ * Run: node test/integration/honest-baseline.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+(async () => {
+  const report = JSON.parse(fs.readFileSync(path.join(ROOT, 'benchmarks/reports/honest-baseline.json'), 'utf8'));
+  const latest = JSON.parse(fs.readFileSync(path.join(ROOT, 'benchmarks/latest.json'), 'utf8'));
+  const version = JSON.parse(fs.readFileSync(path.join(ROOT, 'version.json'), 'utf8'));
+  const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+  const llms = fs.readFileSync(path.join(ROOT, 'llms.txt'), 'utf8');
+  const llmsFull = fs.readFileSync(path.join(ROOT, 'llms-full.txt'), 'utf8');
+
+  test('honest-baseline report has both sides, lift, and per-repo rows', () => {
+    const s = report.summary;
+    assert.ok(s.tasks >= 100, `tasks=${s.tasks}`);
+    assert.ok(s.repos >= 15, `repos=${s.repos}`);
+    assert.ok(s.sigmap.hitAt5 > 0 && s.sigmap.hitAt5 <= 1, `sigmap hitAt5=${s.sigmap.hitAt5}`);
+    assert.ok(s.grepBaseline.hitAt5 > 0 && s.grepBaseline.hitAt5 < s.sigmap.hitAt5,
+      `grep baseline ${s.grepBaseline.hitAt5} must sit below sigmap ${s.sigmap.hitAt5}`);
+    assert.ok(s.lift > 1 && s.lift < 5, `lift=${s.lift} must be honest (1–5×), not random-baseline scale`);
+    assert.ok(Array.isArray(report.repos) && report.repos.length === s.repos);
+  });
+
+  test('latest.json grep metrics derive from the report, not hand-typed', () => {
+    const round = (n, d) => Math.round(Number(n) * 10 ** d) / 10 ** d;
+    assert.strictEqual(latest.metrics.grep_baseline_hit_at_5, round(report.summary.grepBaseline.hitAt5, 3));
+    assert.strictEqual(latest.metrics.grep_lift, round(report.summary.lift, 2));
+  });
+
+  test('version.json mirrors the grep metrics (single source of truth)', () => {
+    assert.strictEqual(version.metrics.grep_baseline_hit_at_5, latest.metrics.grep_baseline_hit_at_5);
+    assert.strictEqual(version.metrics.grep_lift, latest.metrics.grep_lift);
+  });
+
+  test('README quotes the grep baseline and labels task success as proxy', () => {
+    assert.ok(/grep baseline|grep-agent baseline/.test(readme), 'README missing grep-baseline clause');
+    assert.ok(/task-success proxy|proxy — modeled/.test(readme), 'README missing proxy label');
+  });
+
+  test('random-baseline lift retired from all human surfaces', () => {
+    for (const [name, src] of [['README.md', readme], ['llms.txt', llms], ['llms-full.txt', llmsFull]]) {
+      assert.ok(!/6\.4×|6\.4x/.test(src), `${name} still shows the 6.4× random-baseline lift`);
+      assert.ok(!/13\.6%/.test(src), `${name} still shows the 13.6% random baseline`);
+      assert.ok(!/vs 10% without|baseline 10%|up from 10%/.test(src), `${name} still shows the unsourced 10% claim`);
+    }
+  });
+
+  test('llms surfaces quote the measured grep lift', () => {
+    const liftStr = `${Number(latest.metrics.grep_lift).toFixed(2)}× lift`;
+    assert.ok(llms.includes(liftStr) || llmsFull.includes(liftStr), `llms files missing "${liftStr}"`);
+  });
+
+  test('benchmark script is zero-dep — no child processes, no shell', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'scripts/run-honest-benchmark.mjs'), 'utf8');
+    assert.ok(!/child_process|execSync|execFileSync|spawnSync|shell:\s*true/.test(src),
+      'honest benchmark must not spawn processes');
+  });
+
+  console.log(`\n  honest-baseline: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 124,
+  "tests": 125,
   "metrics": {
     "hit_at_5": 0.867,
     "baseline_hit_at_5": 0.136,
@@ -15,7 +15,9 @@
     "prompts_per_task": 1.44,
     "baseline_prompts_per_task": 2.84,
     "prompt_reduction_pct": 49.2,
-    "graph_boosted_hit_at_5": 0.867
+    "graph_boosted_hit_at_5": 0.867,
+    "grep_baseline_hit_at_5": 0.427,
+    "grep_lift": 2.02
   },
   "ablation": {
     "benchmark_id": "sigmap-v7.24-ablation",


### PR DESCRIPTION
Closes #495 — v8.19 "Honest Numbers" (P0).

## What
- **A1**: `scripts/run-honest-benchmark.mjs` — the production ranker (`src/eval/runner.js`) vs an **internal single-shot grep-agent baseline** (pure Node fs scan; zero deps, no child processes — enforced by a guard test) on the same `benchmarks/tasks/*.jsonl` corpus, scored by `src/eval/scorer.js`. Wired as `npm run benchmark:honest`.
- **Measured**: SigMap **86.4% hit@5 / MRR .780** vs grep baseline **42.7% / .228** → **2.02× lift, +43.6pt** (110 tasks, 19 repos) → `benchmarks/reports/honest-baseline.json`.
- **A2**: `computeLatest` derives `grep_baseline_hit_at_5` + `grep_lift` from the report (optional-report pattern, hermetic fixture unaffected). README + llms surfaces now quote the measured grep lift; the 6.4×-vs-random claim and the unsourced "10% without" baseline are retired from all human surfaces (random-baseline fields remain data-only in latest.json/version.json). Task success is labeled a retrieval-tier proxy everywhere.

## Why
The published 6.4× lift compared hit@5 against **random file selection** (`min(1, 5/fileCount)`) — not something any agent does. One skeptical reader of `run-task-benchmark.mjs` could discredit every other claim. This replaces it with a reproducible, defensible number.

## Tests
- New `test/integration/honest-baseline.test.js` — 7 checks: report shape, derived-not-hand-typed metrics, version.json mirror, README/llms claim hygiene (no 6.4× / 13.6% / 10% anywhere), zero-child-process guard on the script.
- `readme-structure.test.js` baseline assertions advanced: README must show the grep baseline and must **not** show the random one.
- Full suite: **119 integration + unit + r-language + validate:llms — all green.** `sync-metrics --check` and `gen-benchmark-latest --check` pass.

## Supply chain (Phase 4B)
Local audit PASS — no shell spawns, no install scripts, `main` exports API, no fingerprinting; tarball 550KB/159 files (new script is in `scripts/`, outside the published surface).

Release flow: merge to develop → `/update-docs` → `/ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)