### PR TITLE
feat(extractors): JS/TS doc-comment hints + sigmap memory command

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -123,6 +123,8 @@ sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 
 sigmap evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
 sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
 sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
+sigmap memory                            List cross-session stores (.context/) — entries, size, age
+sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/gen-context.js
+++ b/gen-context.js
@@ -6203,7 +6203,12 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
     const anchors = [];
+    // docHintFor[i] is the doc-comment hint for sigs[i] (top-level functions
+    // only), appended after the anchor as `  # <hint>` — same convention as the
+    // Python extractor's extractDocHint.
+    const docHintFor = [];
     const returnHints = buildReturnHints(src);
+    const docHints = buildDocHints(src);
 
     // Block comments are blanked newline-by-newline (non-newline chars → spaces)
     // so character offsets AND line numbers stay exact for anchors.
@@ -6238,6 +6243,7 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
       const retStr = formatReturnHint(returnHints.get(m[1]));
       const startLn = lineAt(stripped, m.index);
       sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      docHintFor[sigs.length - 1] = docHints.get(m[1]);
       anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
 
@@ -6247,6 +6253,7 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
       const retStr = formatReturnHint(returnHints.get(m[1]));
       const startLn = lineAt(stripped, m.index);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+      docHintFor[sigs.length - 1] = docHints.get(m[1]);
       anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
 
@@ -6267,10 +6274,14 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
       const retStr = formatReturnHint(returnHints.get(m[1]));
       const startLn = lineAt(stripped, m.index);
       sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+      docHintFor[sigs.length - 1] = docHints.get(m[1]);
       anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
     }
 
-    const withAnchors = sigs.map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s));
+    const withAnchors = sigs.map((s, i) => {
+      const anchored = anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s;
+      return docHintFor[i] ? `${anchored}  # ${docHintFor[i]}` : anchored;
+    });
     return capWithNotice(withAnchors, 25, 'signatures');
   }
 
@@ -6317,6 +6328,36 @@ __factories["./src/extractors/javascript"] = function(module, exports) {
       hints.set(m[2], normalizeType(m[1]));
     }
     return hints;
+  }
+
+  // First prose sentence of the JSDoc block immediately preceding a top-level
+  // function (same three shapes as buildReturnHints). Mirrors the Python
+  // extractor's extractDocHint: first sentence only, 60-char cap.
+  function buildDocHints(src) {
+    const hints = new Map();
+    // Body may not contain `*/` — otherwise a failed adjacency check would let
+    // the match expand across a whole function to the next comment block and
+    // misattribute the hint.
+    const patterns = [
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(/g,
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(/g,
+    ];
+    for (const re of patterns) {
+      for (const m of src.matchAll(re)) {
+        const hint = firstDocSentence(m[1]);
+        if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+      }
+    }
+    return hints;
+  }
+
+  // First non-tag prose line of a JSDoc body → first sentence, 60-char cap.
+  function firstDocSentence(body) {
+    const line = String(body).split('\n')
+      .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+      .find((l) => l && !l.startsWith('@'));
+    if (!line) return '';
+    return line.split(/[.!?]/)[0].trim().slice(0, 60);
   }
 
   function normalizeType(type) {
@@ -8307,6 +8348,11 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    // docHintFor[i] is the doc-comment hint for sigs[i] (exported top-level
+    // functions only), appended after the anchor as `  # <hint>` — same
+    // convention as the Python extractor's extractDocHint.
+    const docHintFor = [];
+    const docHints = buildDocHints(src);
     // anchors[i] is [start, end] for a top-level sig, or null for an indented member.
     // Kept parallel to `sigs` so existing push/mutation logic stays untouched;
     // anchors are applied once at return.
@@ -8374,6 +8420,7 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
       const retStr = retType ? ` → ${retType}` : '';
       const bodyStart = m.index + m[0].length;
       sigs.push(`export ${asyncKw}function ${m[1]}(${params})${retStr}`);
+      docHintFor[sigs.length - 1] = docHints.get(m[1]);
       anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
 
       // Hooks: capture compact return object shape for use* functions.
@@ -8398,6 +8445,7 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
       const asyncKw = /=\s*async\s+/.test(m[0]) ? 'async ' : '';
       const params = normalizeParams(m[2]);
       sigs.push(`export const ${m[1]} = ${asyncKw}(${params}) =>`);
+      docHintFor[sigs.length - 1] = docHints.get(m[1]);
       const bodyStart = stripped.indexOf('{', m.index + m[0].length);
       const endLn = bodyStart !== -1
         ? lineAt(stripped, blockEndIdx(bodyStart + 1))
@@ -8447,7 +8495,10 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
       }
     }
 
-    const withAnchors = sigs.map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s));
+    const withAnchors = sigs.map((s, i) => {
+      const anchored = anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s;
+      return docHintFor[i] ? `${anchored}  # ${docHintFor[i]}` : anchored;
+    });
     return capWithNotice(withAnchors, 35, 'signatures');
   }
 
@@ -8510,6 +8561,36 @@ __factories["./src/extractors/typescript"] = function(module, exports) {
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ').replace(/:[^,)]+/g, '').trim();
+  }
+
+  // First prose sentence of the JSDoc block immediately preceding an exported
+  // top-level function (function or arrow-const form). Mirrors the Python
+  // extractor's extractDocHint: first sentence only, 60-char cap.
+  function buildDocHints(src) {
+    const hints = new Map();
+    // Body may not contain `*/` — otherwise a failed adjacency check would let
+    // the match expand across a whole function to the next comment block and
+    // misattribute the hint.
+    const patterns = [
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+(?:async\s+)?function\s+(\w+)\s*[<(]/g,
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+const\s+(\w+)\s*[:=]/g,
+    ];
+    for (const re of patterns) {
+      for (const m of src.matchAll(re)) {
+        const hint = firstDocSentence(m[1]);
+        if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+      }
+    }
+    return hints;
+  }
+
+  // First non-tag prose line of a JSDoc body → first sentence, 60-char cap.
+  function firstDocSentence(body) {
+    const line = String(body).split('\n')
+      .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+      .find((l) => l && !l.startsWith('@'));
+    if (!line) return '';
+    return line.split(/[.!?]/)[0].trim().slice(0, 60);
   }
 
   module.exports = { extract };
@@ -17202,6 +17283,96 @@ __factories["./src/session/memory"] = function(module, exports) {
   
 };
 
+// ── ./src/session/memory-inspect ──
+__factories["./src/session/memory-inspect"] = function(module, exports) {
+  
+  /**
+   * memory-inspect.js — one view over SigMap's existing cross-session stores.
+   * No new storage: reads the JSON/NDJSON files the session, notes, weights,
+   * evidence, and tracking modules already own under `.context/`.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  /** store name → { file, kind } (kind drives the entry count). */
+  const STORES = {
+    session: { file: 'session.json', kind: 'json' },
+    notes: { file: 'notes.ndjson', kind: 'ndjson' },
+    weights: { file: 'weights.json', kind: 'weights' },
+    evidence: { file: 'evidence-pack.json', kind: 'json' },
+    gain: { file: 'gain.ndjson', kind: 'ndjson' },
+    usage: { file: 'usage.ndjson', kind: 'ndjson' },
+  };
+
+  /** Stores `clearMemory` may delete ('gain'/'usage' have their own reset flows). */
+  const CLEARABLE = ['session', 'notes', 'weights', 'evidence'];
+
+  function storePath(cwd, name) {
+    return path.join(cwd, '.context', STORES[name].file);
+  }
+
+  function countEntries(kind, filePath) {
+    try {
+      if (kind === 'ndjson') {
+        return fs.readFileSync(filePath, 'utf8').split('\n').filter(Boolean).length;
+      }
+      if (kind === 'weights') {
+        const w = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return Object.keys((w && w.files) || w || {}).length;
+      }
+      return 1; // json: a single snapshot object
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  /**
+   * Describe every cross-session store.
+   * @param {string} cwd
+   * @returns {Array<{store:string, path:string, exists:boolean, entries:number, bytes:number, modified:string|null, clearable:boolean}>}
+   */
+  function inspectMemory(cwd) {
+    return Object.entries(STORES).map(([store, { file, kind }]) => {
+      const p = storePath(cwd, store);
+      let stat = null;
+      try { stat = fs.statSync(p); } catch (_) {}
+      return {
+        store,
+        path: path.join('.context', file),
+        exists: !!stat,
+        entries: stat ? countEntries(kind, p) : 0,
+        bytes: stat ? stat.size : 0,
+        modified: stat ? new Date(stat.mtimeMs).toISOString() : null,
+        clearable: CLEARABLE.includes(store),
+      };
+    });
+  }
+
+  /**
+   * Delete one clearable store (or 'all' clearable stores).
+   * @param {string} cwd
+   * @param {string} store - session|notes|weights|evidence|all
+   * @returns {string[]} names of stores actually removed
+   */
+  function clearMemory(cwd, store) {
+    const targets = store === 'all' ? CLEARABLE : [store];
+    for (const t of targets) {
+      if (!CLEARABLE.includes(t)) {
+        throw new Error(`unknown or protected store "${t}" — clearable: ${CLEARABLE.join(', ')}, all`);
+      }
+    }
+    const removed = [];
+    for (const t of targets) {
+      try { fs.unlinkSync(storePath(cwd, t)); removed.push(t); } catch (_) {}
+    }
+    return removed;
+  }
+
+  module.exports = { inspectMemory, clearMemory, STORES, CLEARABLE };
+  
+};
+
 // ── ./src/session/notes ──
 __factories["./src/session/notes"] = function(module, exports) {
   
@@ -21593,6 +21764,8 @@ Usage:
   ${cmd} evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
   ${cmd} evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
   ${cmd} evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
+  ${cmd} memory                            List cross-session stores (.context/) — entries, size, age
+  ${cmd} memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -22986,6 +23159,56 @@ function main() {
 
   // `sigmap note "<text>"` — append to the cross-session decision log.
   // With no text, lists recent notes (also `note --list [N]`).
+  // `sigmap memory` — one view over the cross-session stores in .context/.
+  if (args[0] === 'memory') {
+    const jsonOut = args.includes('--json');
+    const { inspectMemory, clearMemory } = requireSourceOrBundled('./src/session/memory-inspect');
+    const clearIdx = args.indexOf('--clear');
+
+    if (clearIdx !== -1) {
+      const store = args[clearIdx + 1];
+      if (!store || store.startsWith('--')) {
+        console.error('[sigmap] usage: sigmap memory --clear <session|notes|weights|evidence|all>');
+        process.exit(1);
+      }
+      let removed;
+      try {
+        removed = clearMemory(cwd, store);
+      } catch (err) {
+        console.error(`[sigmap] ${err.message}`);
+        process.exit(1);
+      }
+      if (jsonOut) {
+        process.stdout.write(JSON.stringify({ cleared: removed }) + '\n');
+      } else {
+        console.log(removed.length
+          ? `[sigmap] cleared: ${removed.join(', ')}`
+          : `[sigmap] nothing to clear for "${store}"`);
+      }
+      process.exit(0);
+    }
+
+    const stores = inspectMemory(cwd);
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify({ stores }) + '\n');
+      process.exit(0);
+    }
+    const fmtAge = (iso) => {
+      if (!iso) return '—';
+      const m = Math.floor((Date.now() - Date.parse(iso)) / 60000);
+      const h = Math.floor(m / 60), d = Math.floor(h / 24);
+      return d > 0 ? `${d}d ago` : h > 0 ? `${h}h ago` : `${m}m ago`;
+    };
+    const fmtKB = (b) => (b >= 1024 ? `${(b / 1024).toFixed(1)}KB` : `${b}B`);
+    console.log('[sigmap] cross-session memory (.context/)');
+    for (const s of stores) {
+      const state = s.exists ? `${String(s.entries).padStart(5)} entries  ${fmtKB(s.bytes).padStart(8)}  ${fmtAge(s.modified)}` : '    — empty';
+      console.log(`  ${s.store.padEnd(9)} ${state}${s.clearable ? '' : '   (reset via its own command)'}`);
+    }
+    console.log('  clear: sigmap memory --clear <session|notes|weights|evidence|all>');
+    process.exit(0);
+  }
+
   if (args[0] === 'note') {
     const jsonOut = args.includes('--json');
     const { addNote, readNotes, formatNotes } = requireSourceOrBundled('./src/session/notes');

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -123,6 +123,8 @@ sigmap ask "<query>" --squeeze-threshold N  Min reduction %% to prompt (default 
 sigmap evidence "<query>"                Build a deterministic Evidence Pack (JSON) → .context/evidence-pack.json
 sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to stdout
 sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
+sigmap memory                            List cross-session stores (.context/) — entries, size, age
+sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/src/extractors/javascript.js
+++ b/src/extractors/javascript.js
@@ -14,7 +14,12 @@ function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
   const anchors = [];
+  // docHintFor[i] is the doc-comment hint for sigs[i] (top-level functions
+  // only), appended after the anchor as `  # <hint>` — same convention as the
+  // Python extractor's extractDocHint.
+  const docHintFor = [];
   const returnHints = buildReturnHints(src);
+  const docHints = buildDocHints(src);
 
   // Block comments are blanked newline-by-newline (non-newline chars → spaces)
   // so character offsets AND line numbers stay exact for anchors.
@@ -49,6 +54,7 @@ function extract(src) {
     const retStr = formatReturnHint(returnHints.get(m[1]));
     const startLn = lineAt(stripped, m.index);
     sigs.push(`export ${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    docHintFor[sigs.length - 1] = docHints.get(m[1]);
     anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
@@ -58,6 +64,7 @@ function extract(src) {
     const retStr = formatReturnHint(returnHints.get(m[1]));
     const startLn = lineAt(stripped, m.index);
     sigs.push(`export const ${m[1]} = ${asyncKw}(${normalizeParams(m[2])}) =>${retStr}`);
+    docHintFor[sigs.length - 1] = docHints.get(m[1]);
     anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
@@ -78,10 +85,14 @@ function extract(src) {
     const retStr = formatReturnHint(returnHints.get(m[1]));
     const startLn = lineAt(stripped, m.index);
     sigs.push(`${asyncKw}function ${m[1]}(${normalizeParams(m[2])})${retStr}`);
+    docHintFor[sigs.length - 1] = docHints.get(m[1]);
     anchors.push([startLn, fnEndLine(m.index + m[0].length, startLn)]);
   }
 
-  const withAnchors = sigs.map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s));
+  const withAnchors = sigs.map((s, i) => {
+    const anchored = anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s;
+    return docHintFor[i] ? `${anchored}  # ${docHintFor[i]}` : anchored;
+  });
   return capWithNotice(withAnchors, 25, 'signatures');
 }
 
@@ -128,6 +139,36 @@ function buildReturnHints(src) {
     hints.set(m[2], normalizeType(m[1]));
   }
   return hints;
+}
+
+// First prose sentence of the JSDoc block immediately preceding a top-level
+// function (same three shapes as buildReturnHints). Mirrors the Python
+// extractor's extractDocHint: first sentence only, 60-char cap.
+function buildDocHints(src) {
+  const hints = new Map();
+  // Body may not contain `*/` — otherwise a failed adjacency check would let
+  // the match expand across a whole function to the next comment block and
+  // misattribute the hint.
+  const patterns = [
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(/g,
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\(/g,
+  ];
+  for (const re of patterns) {
+    for (const m of src.matchAll(re)) {
+      const hint = firstDocSentence(m[1]);
+      if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+    }
+  }
+  return hints;
+}
+
+// First non-tag prose line of a JSDoc body → first sentence, 60-char cap.
+function firstDocSentence(body) {
+  const line = String(body).split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+    .find((l) => l && !l.startsWith('@'));
+  if (!line) return '';
+  return line.split(/[.!?]/)[0].trim().slice(0, 60);
 }
 
 function normalizeType(type) {

--- a/src/extractors/typescript.js
+++ b/src/extractors/typescript.js
@@ -13,6 +13,11 @@ const { capWithNotice, capMembersWithNotice } = require('../util/truncate');
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  // docHintFor[i] is the doc-comment hint for sigs[i] (exported top-level
+  // functions only), appended after the anchor as `  # <hint>` — same
+  // convention as the Python extractor's extractDocHint.
+  const docHintFor = [];
+  const docHints = buildDocHints(src);
   // anchors[i] is [start, end] for a top-level sig, or null for an indented member.
   // Kept parallel to `sigs` so existing push/mutation logic stays untouched;
   // anchors are applied once at return.
@@ -80,6 +85,7 @@ function extract(src) {
     const retStr = retType ? ` → ${retType}` : '';
     const bodyStart = m.index + m[0].length;
     sigs.push(`export ${asyncKw}function ${m[1]}(${params})${retStr}`);
+    docHintFor[sigs.length - 1] = docHints.get(m[1]);
     anchors.push([lineAt(stripped, m.index), lineAt(stripped, blockEndIdx(bodyStart))]);
 
     // Hooks: capture compact return object shape for use* functions.
@@ -104,6 +110,7 @@ function extract(src) {
     const asyncKw = /=\s*async\s+/.test(m[0]) ? 'async ' : '';
     const params = normalizeParams(m[2]);
     sigs.push(`export const ${m[1]} = ${asyncKw}(${params}) =>`);
+    docHintFor[sigs.length - 1] = docHints.get(m[1]);
     const bodyStart = stripped.indexOf('{', m.index + m[0].length);
     const endLn = bodyStart !== -1
       ? lineAt(stripped, blockEndIdx(bodyStart + 1))
@@ -153,7 +160,10 @@ function extract(src) {
     }
   }
 
-  const withAnchors = sigs.map((s, i) => (anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s));
+  const withAnchors = sigs.map((s, i) => {
+    const anchored = anchors[i] ? withAnchor(s, anchors[i][0], anchors[i][1]) : s;
+    return docHintFor[i] ? `${anchored}  # ${docHintFor[i]}` : anchored;
+  });
   return capWithNotice(withAnchors, 35, 'signatures');
 }
 
@@ -216,6 +226,36 @@ function extractClassMembers(block) {
 function normalizeParams(params) {
   if (!params) return '';
   return params.trim().replace(/\s+/g, ' ').replace(/:[^,)]+/g, '').trim();
+}
+
+// First prose sentence of the JSDoc block immediately preceding an exported
+// top-level function (function or arrow-const form). Mirrors the Python
+// extractor's extractDocHint: first sentence only, 60-char cap.
+function buildDocHints(src) {
+  const hints = new Map();
+  // Body may not contain `*/` — otherwise a failed adjacency check would let
+  // the match expand across a whole function to the next comment block and
+  // misattribute the hint.
+  const patterns = [
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+(?:async\s+)?function\s+(\w+)\s*[<(]/g,
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*export\s+const\s+(\w+)\s*[:=]/g,
+  ];
+  for (const re of patterns) {
+    for (const m of src.matchAll(re)) {
+      const hint = firstDocSentence(m[1]);
+      if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+    }
+  }
+  return hints;
+}
+
+// First non-tag prose line of a JSDoc body → first sentence, 60-char cap.
+function firstDocSentence(body) {
+  const line = String(body).split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+    .find((l) => l && !l.startsWith('@'));
+  if (!line) return '';
+  return line.split(/[.!?]/)[0].trim().slice(0, 60);
 }
 
 module.exports = { extract };

--- a/src/session/memory-inspect.js
+++ b/src/session/memory-inspect.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * memory-inspect.js — one view over SigMap's existing cross-session stores.
+ * No new storage: reads the JSON/NDJSON files the session, notes, weights,
+ * evidence, and tracking modules already own under `.context/`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/** store name → { file, kind } (kind drives the entry count). */
+const STORES = {
+  session: { file: 'session.json', kind: 'json' },
+  notes: { file: 'notes.ndjson', kind: 'ndjson' },
+  weights: { file: 'weights.json', kind: 'weights' },
+  evidence: { file: 'evidence-pack.json', kind: 'json' },
+  gain: { file: 'gain.ndjson', kind: 'ndjson' },
+  usage: { file: 'usage.ndjson', kind: 'ndjson' },
+};
+
+/** Stores `clearMemory` may delete ('gain'/'usage' have their own reset flows). */
+const CLEARABLE = ['session', 'notes', 'weights', 'evidence'];
+
+function storePath(cwd, name) {
+  return path.join(cwd, '.context', STORES[name].file);
+}
+
+function countEntries(kind, filePath) {
+  try {
+    if (kind === 'ndjson') {
+      return fs.readFileSync(filePath, 'utf8').split('\n').filter(Boolean).length;
+    }
+    if (kind === 'weights') {
+      const w = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      return Object.keys((w && w.files) || w || {}).length;
+    }
+    return 1; // json: a single snapshot object
+  } catch (_) {
+    return 0;
+  }
+}
+
+/**
+ * Describe every cross-session store.
+ * @param {string} cwd
+ * @returns {Array<{store:string, path:string, exists:boolean, entries:number, bytes:number, modified:string|null, clearable:boolean}>}
+ */
+function inspectMemory(cwd) {
+  return Object.entries(STORES).map(([store, { file, kind }]) => {
+    const p = storePath(cwd, store);
+    let stat = null;
+    try { stat = fs.statSync(p); } catch (_) {}
+    return {
+      store,
+      path: path.join('.context', file),
+      exists: !!stat,
+      entries: stat ? countEntries(kind, p) : 0,
+      bytes: stat ? stat.size : 0,
+      modified: stat ? new Date(stat.mtimeMs).toISOString() : null,
+      clearable: CLEARABLE.includes(store),
+    };
+  });
+}
+
+/**
+ * Delete one clearable store (or 'all' clearable stores).
+ * @param {string} cwd
+ * @param {string} store - session|notes|weights|evidence|all
+ * @returns {string[]} names of stores actually removed
+ */
+function clearMemory(cwd, store) {
+  const targets = store === 'all' ? CLEARABLE : [store];
+  for (const t of targets) {
+    if (!CLEARABLE.includes(t)) {
+      throw new Error(`unknown or protected store "${t}" — clearable: ${CLEARABLE.join(', ')}, all`);
+    }
+  }
+  const removed = [];
+  for (const t of targets) {
+    try { fs.unlinkSync(storePath(cwd, t)); removed.push(t); } catch (_) {}
+  }
+  return removed;
+}
+
+module.exports = { inspectMemory, clearMemory, STORES, CLEARABLE };

--- a/test/integration/semantic-bridge.test.js
+++ b/test/integration/semantic-bridge.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Semantic Bridge I (v8.20, #498): JS/TS doc-comment hints + `sigmap memory`.
+ * Run: node test/integration/semantic-bridge.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const js = require(path.join(ROOT, 'src/extractors/javascript.js'));
+const ts = require(path.join(ROOT, 'src/extractors/typescript.js'));
+const { bm25rank } = require(path.join(ROOT, 'src/retrieval/bm25.js'));
+const { inspectMemory, clearMemory } = require(path.join(ROOT, 'src/session/memory-inspect.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+// ── B1a: doc-comment hints ──────────────────────────────────────────────────
+
+const JS_SRC = `
+/**
+ * Retries the payment with exponential backoff. Second sentence ignored.
+ * @param {number} n
+ */
+export function chargeBackoff(n) { return n; }
+
+/** Formats a user-facing error message */
+export const fmtError = (e) => String(e);
+
+/**
+ * @param {string} x
+ */
+function tagOnly(x) { return x; }
+
+/** Walks the config tree and resolves every include directive found there for later use */
+function walkConfig(root) { return root; }
+
+function noDoc(x) { return x; }
+`;
+
+test('JS: hint on exported function — first sentence, after anchor, `  # ` prefix', () => {
+  const sig = js.extract(JS_SRC).find((s) => s.includes('chargeBackoff'));
+  assert.ok(/:\d+-\d+  # Retries the payment with exponential backoff$/.test(sig), sig);
+  assert.ok(!sig.includes('Second sentence'), 'must stop at first sentence');
+});
+
+test('JS: hint on exported arrow const, correctly attributed (no cross-block bleed)', () => {
+  const sig = js.extract(JS_SRC).find((s) => s.includes('fmtError'));
+  assert.ok(sig.endsWith('# Formats a user-facing error message'), sig);
+});
+
+test('JS: tag-only doc and no doc → signature unchanged', () => {
+  const sigs = js.extract(JS_SRC);
+  assert.ok(!sigs.find((s) => s.includes('tagOnly')).includes('#'));
+  assert.ok(!sigs.find((s) => s.includes('noDoc')).includes('#'));
+});
+
+test('JS: hint capped at 60 chars', () => {
+  const sig = js.extract(JS_SRC).find((s) => s.includes('walkConfig'));
+  const hint = sig.split('# ')[1];
+  assert.ok(hint.length <= 60, `hint ${hint.length} chars: ${hint}`);
+});
+
+const TS_SRC = `
+/**
+ * Fetches the user profile from the session store. Extra.
+ */
+export async function fetchProfile(id: string): Promise<P> { return db.get(id); }
+
+/** Debounces the search input */
+export const useSearch = (q: string) => { return { query: q }; };
+
+export function noDoc(x: number) { return x; }
+`;
+
+test('TS: hints on exported function and arrow const; no doc → unchanged', () => {
+  const sigs = ts.extract(TS_SRC);
+  assert.ok(sigs.find((s) => s.includes('fetchProfile')).endsWith('# Fetches the user profile from the session store'));
+  assert.ok(sigs.find((s) => s.includes('useSearch')).includes('# Debounces the search input'));
+  assert.ok(!sigs.find((s) => s.includes('noDoc')).includes('#'));
+});
+
+test('vocab-mismatch query retrieves the file ONLY via its doc hint', () => {
+  // Query vocabulary is fully disjoint from every identifier (BM25 splits
+  // camelCase, so hint words must not overlap the function name either).
+  const src = `
+/** Waits between failed attempts before contacting the gateway again */
+export function chargeBackoff(n) { return n; }
+`;
+  const withHints = js.extract(src);
+  const noHints = withHints.map((s) => s.split('  # ')[0]);
+  const decoy = { file: 'util/strings.js', sigs: ['function pad(s, w)', 'function trim(s)'] };
+  const query = 'waits between failed attempts gateway';
+  const hinted = bm25rank(query, [{ file: 'billing/charge.js', sigs: withHints }, decoy]);
+  const plain = bm25rank(query, [{ file: 'billing/charge.js', sigs: noHints }, decoy]);
+  assert.ok(hinted[0].file === 'billing/charge.js' && hinted[0].score > 0, 'hinted arm must match');
+  const plainScore = plain.find((r) => r.file === 'billing/charge.js').score;
+  assert.strictEqual(plainScore, 0, 'without hints the query matches nothing');
+});
+
+test('JS/TS extraction with hints is deterministic (same input → same output)', () => {
+  assert.deepStrictEqual(js.extract(JS_SRC), js.extract(JS_SRC));
+  assert.deepStrictEqual(ts.extract(TS_SRC), ts.extract(TS_SRC));
+});
+
+// ── E2: sigmap memory ───────────────────────────────────────────────────────
+
+function tmpStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-mem-'));
+  fs.mkdirSync(path.join(dir, '.context'));
+  fs.writeFileSync(path.join(dir, '.context/session.json'), JSON.stringify({ intent: 'x' }));
+  fs.writeFileSync(path.join(dir, '.context/notes.ndjson'), '{"text":"a"}\n{"text":"b"}\n');
+  fs.writeFileSync(path.join(dir, '.context/weights.json'), JSON.stringify({ files: { 'a.js': 1.1, 'b.js': 0.9 } }));
+  return dir;
+}
+
+test('memory: inspectMemory reports counts, sizes, ages for existing stores', () => {
+  const dir = tmpStore();
+  const byName = Object.fromEntries(inspectMemory(dir).map((s) => [s.store, s]));
+  assert.strictEqual(byName.notes.entries, 2);
+  assert.strictEqual(byName.weights.entries, 2);
+  assert.strictEqual(byName.session.entries, 1);
+  assert.strictEqual(byName.evidence.exists, false);
+  assert.ok(byName.gain && byName.usage, 'tracking stores listed');
+  assert.ok(!byName.gain.clearable && !byName.usage.clearable, 'tracking stores not clearable here');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('memory: clearMemory removes exactly the named store; rejects unknown/protected', () => {
+  const dir = tmpStore();
+  assert.deepStrictEqual(clearMemory(dir, 'notes'), ['notes']);
+  assert.ok(!fs.existsSync(path.join(dir, '.context/notes.ndjson')));
+  assert.ok(fs.existsSync(path.join(dir, '.context/weights.json')), 'other stores untouched');
+  assert.throws(() => clearMemory(dir, 'gain'), /protected/);
+  assert.throws(() => clearMemory(dir, 'bogus'), /unknown or protected/);
+  const removed = clearMemory(dir, 'all');
+  assert.ok(removed.includes('session') && removed.includes('weights'));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI: `sigmap memory` runs and --help documents it', () => {
+  const dir = tmpStore();
+  const out = execFileSync(process.execPath, [path.join(ROOT, 'gen-context.js'), 'memory', '--json'], { cwd: dir, encoding: 'utf8' });
+  const { stores } = JSON.parse(out);
+  assert.strictEqual(stores.find((s) => s.store === 'notes').entries, 2);
+  const help = execFileSync(process.execPath, [path.join(ROOT, 'gen-context.js'), '--help'], { encoding: 'utf8' });
+  assert.ok(/memory\s+List cross-session stores/.test(help), '--help missing memory');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+console.log(`\n  semantic-bridge: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 125,
+  "tests": 126,
   "metrics": {
     "hit_at_5": 0.867,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #498 — v8.20 "Semantic Bridge I".

## What
- **B1a — doc-comment hints (JS/TS):** `buildDocHints` mines the first prose sentence of the JSDoc block immediately preceding each top-level function form and appends it after the line anchor as `  # <hint>` — byte-format identical to the Python extractor's `extractDocHint`, restoring cross-language consistency. A tempered comment-body pattern (`(?:[^*]|\*(?!\/))*`) prevents the non-greedy-expansion bug that misattributed hints across blocks (caught in smoke testing).
- **E2 — `sigmap memory`:** one view over the existing `.context/` stores — session, notes, weights, evidence, gain, usage — with entries/size/age, `--json`, and explicit `--clear <session|notes|weights|evidence|all>`. Tracking stores (gain/usage) are listed but protected (they have their own reset flows). **No new storage, zero deps.**

## Measured (the number decides — reported honestly)
Canonical order (retrieval harness regenerates contexts, honest runs immediately after):

| Metric | Before | After | Delta |
|---|---|---|---|
| hit@5 | 86.4% | **85.5%** | **−0.9pt** (1/110 tasks) |
| MRR | .780 | .774 | −.006 |
| grep baseline | 42.7% | 42.7% | — |
| honest lift | 2.02× | 2.00× | −.02 |

**Root cause:** `svelte-t002` ("effects side effect reactive run schedule") — competing public-API files gained hints carrying exactly those English words and outrank `effects.js`. Classic dilution on a lexical-favoring corpus.

**Decision (user-approved): default-on**, per the v8.18 anchors precedent (−1.1pt shipped default-on, documented) and Python-parity. The semantic upside is proven directly by the new vocab-mismatch fixture test — a query whose vocabulary is fully disjoint from every identifier retrieves the file **only** via its hint (BM25 score 0 without). The v8.22 hard-split corpus (A3) will measure that upside properly.

## Tests
- 10 new in `test/integration/semantic-bridge.test.js`: hint format/attribution/cap/tag-only/determinism (JS+TS), vocab-mismatch A/B, memory inspect/clear/CLI/help
- Bundle rebuilt (143 modules) · version meta 125→126 · llms regenerated (new help lines)
- **Full suite: 120 passed, 0 failed**

## Supply chain (Phase 4B)
Local audit PASS — no shell spawns, no install scripts, `main` exports API, no fingerprinting; tarball 558KB/160 files (+1 file: the memory-inspect module).

Release flow: merge to develop → `/update-docs` (will pick up the −0.9pt in the full benchmark run and document it in the changelog) → `/ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)