### PR TITLE
feat: v8.21 Semantic Bridge II — Go/Rust/Java doc hints + centrality blend

### DIFF
--- a/benchmarks/reports/centrality-blend.json
+++ b/benchmarks/reports/centrality-blend.json
@@ -1,0 +1,163 @@
+{
+  "benchmark": "centrality-blend-ab",
+  "arms": {
+    "A": "rank + import graph",
+    "B": "rank + import graph + centrality prior"
+  },
+  "tasks": 90,
+  "hitAt5A": 77.8,
+  "hitAt5B": 77.8,
+  "deltaTasks": 0,
+  "perRepo": [
+    {
+      "repo": "abseil-cpp",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "akka",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "axios",
+      "tasks": 5,
+      "centralityFiles": 64,
+      "hitA": 4,
+      "hitB": 4,
+      "delta": 0
+    },
+    {
+      "repo": "express",
+      "tasks": 5,
+      "centralityFiles": 7,
+      "hitA": 4,
+      "hitB": 4,
+      "delta": 0
+    },
+    {
+      "repo": "fastapi",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 4,
+      "hitB": 4,
+      "delta": 0
+    },
+    {
+      "repo": "fastify",
+      "tasks": 5,
+      "centralityFiles": 31,
+      "hitA": 4,
+      "hitB": 4,
+      "delta": 0
+    },
+    {
+      "repo": "flask",
+      "tasks": 5,
+      "centralityFiles": 24,
+      "hitA": 0,
+      "hitB": 0,
+      "delta": 0
+    },
+    {
+      "repo": "gin",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "laravel",
+      "tasks": 5,
+      "centralityFiles": 2,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "okhttp",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "rails",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "riverpod",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "rust-analyzer",
+      "tasks": 5,
+      "centralityFiles": 33,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "serilog",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 0,
+      "hitB": 0,
+      "delta": 0
+    },
+    {
+      "repo": "spring-petclinic",
+      "tasks": 5,
+      "centralityFiles": 47,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    },
+    {
+      "repo": "svelte",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 4,
+      "hitB": 4,
+      "delta": 0
+    },
+    {
+      "repo": "vapor",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 0,
+      "hitB": 0,
+      "delta": 0
+    },
+    {
+      "repo": "vue-core",
+      "tasks": 5,
+      "centralityFiles": 0,
+      "hitA": 5,
+      "hitB": 5,
+      "delta": 0
+    }
+  ],
+  "skipped": [
+    {
+      "repo": "retrieval",
+      "reason": "repo not cloned"
+    }
+  ]
+}

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -345,7 +345,7 @@ testCoverage = false
 testDirs = ["tests","test","__tests__","spec"]
 sigCache = false
 impactRadius = false
-retrieval = {"topK":10,"recencyBoost":1.5,"callGraphBoost":false,"surfaceEnrichment":false}
+retrieval = {"topK":10,"recencyBoost":1.5,"callGraphBoost":false,"centralityBlend":false,"surfaceEnrichment":false}
 impact = {"depth":3,"includeSigs":true}
 ```
 

--- a/gen-context.js
+++ b/gen-context.js
@@ -1533,6 +1533,8 @@ __factories["./src/config/defaults"] = function(module, exports) {
       recencyBoost: 1.5,
       // Boost files call-graph-connected to query matches (opt-in, measure-gated)
       callGraphBoost: false,
+      // Blend import-graph centrality into ranking as a small prior (opt-in, measure-gated)
+      centralityBlend: false,
       // Append route pseudo-signatures to the rankable index (opt-in, measure-gated)
       surfaceEnrichment: false,
     },
@@ -5928,6 +5930,10 @@ __factories["./src/extractors/go"] = function(module, exports) {
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    const docHints = buildDocHints(src);
+    // Append the godoc hint after the anchor as `  # <hint>` — same convention
+    // as the Python/JS extractors' doc hints.
+    const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
@@ -5939,14 +5945,14 @@ __factories["./src/extractors/go"] = function(module, exports) {
     // Structs
     for (const m of stripped.matchAll(/^type\s+(\w+)\s+struct\s*\{/gm)) {
       const end = blockEndIdx(m.index + m[0].length);
-      sigs.push(withAnchor(`type ${m[1]} struct`, lineAt(stripped, m.index), lineAt(stripped, end)));
+      sigs.push(hinted(withAnchor(`type ${m[1]} struct`, lineAt(stripped, m.index), lineAt(stripped, end)), m[1]));
     }
 
     // Interfaces
     for (const m of stripped.matchAll(/^type\s+(\w+)\s+interface\s*\{/gm)) {
       const bodyStart = m.index + m[0].length;
       const block = extractBlock(stripped, bodyStart);
-      sigs.push(withAnchor(`type ${m[1]} interface`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      sigs.push(hinted(withAnchor(`type ${m[1]} interface`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[1]));
       for (const meth of extractInterfaceMethods(block)) {
         sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
       }
@@ -5958,7 +5964,7 @@ __factories["./src/extractors/go"] = function(module, exports) {
       const retType = m[4] ? m[4].trim().replace(/\s+/g, ' ') : '';
       const retStr = retType ? ` → ${retType.slice(0, 30)}` : '';
       const end = blockEndIdx(m.index + m[0].length);
-      sigs.push(withAnchor(`func ${receiver}${m[2]}(${normalizeParams(m[3])})${retStr}`, lineAt(stripped, m.index), lineAt(stripped, end)));
+      sigs.push(hinted(withAnchor(`func ${receiver}${m[2]}(${normalizeParams(m[3])})${retStr}`, lineAt(stripped, m.index), lineAt(stripped, end)), m[2]));
     }
 
     return sigs.slice(0, 25);
@@ -5992,6 +5998,30 @@ __factories["./src/extractors/go"] = function(module, exports) {
   function normalizeParams(params) {
     if (!params) return '';
     return params.trim().replace(/\s+/g, ' ');
+  }
+
+  // Godoc: the `//` comment block directly above a top-level func/type/method
+  // declaration → first prose sentence, 60-char cap. Runs on the ORIGINAL src
+  // (extract strips comments before matching). Compiler directives (`//go:...`)
+  // carry no prose and are skipped.
+  function buildDocHints(src) {
+    const hints = new Map();
+    const re = /((?:^\/\/[^\n]*\n)+)(?:func\s+(?:\(\w+\s+[\w*]+\)\s+)?(\w+)\s*\(|type\s+(\w+)\s+(?:struct|interface)\b)/gm;
+    for (const m of src.matchAll(re)) {
+      const name = m[2] || m[3];
+      const hint = firstDocSentence(m[1]);
+      if (hint && !hints.has(name)) hints.set(name, hint);
+    }
+    return hints;
+  }
+
+  // First non-directive prose line of a `//` block → first sentence, 60-char cap.
+  function firstDocSentence(block) {
+    const line = String(block).split('\n')
+      .map((l) => l.replace(/^\/\/\s?/, '').trim())
+      .find((l) => l && !l.startsWith('go:') && !l.startsWith('nolint'));
+    if (!line) return '';
+    return line.split(/[.!?]/)[0].trim().slice(0, 60);
   }
 
   module.exports = { extract };
@@ -6126,6 +6156,10 @@ __factories["./src/extractors/java"] = function(module, exports) {
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    const docHints = buildDocHints(src);
+    // Append the Javadoc hint after the anchor as `  # <hint>` — same convention
+    // as the Python/JS extractors' doc hints.
+    const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
@@ -6136,9 +6170,9 @@ __factories["./src/extractors/java"] = function(module, exports) {
     for (const m of stripped.matchAll(typeRegex)) {
       const bodyStart = m.index + m[0].length;
       const block = extractBlock(stripped, bodyStart);
-      sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+      sigs.push(hinted(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[2]));
       for (const meth of extractMembers(block)) {
-        sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+        sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)), meth.name));
       }
     }
 
@@ -6165,6 +6199,7 @@ __factories["./src/extractors/java"] = function(module, exports) {
       const retStr = ret ? ` → ${ret}` : '';
       members.push({
         text: `${m[2]}(${normalizeParams(m[3])})${retStr}`,
+        name: m[2],
         declIdx: m.index + (m[0].length - m[0].trimStart().length),
         endIdx: m.index + m[0].length,
       });
@@ -6180,6 +6215,36 @@ __factories["./src/extractors/java"] = function(module, exports) {
   function normalizeType(type) {
     if (!type) return '';
     return type.trim().replace(/\s+/g, ' ').slice(0, 30);
+  }
+
+  // Javadoc: the `/** ... */` block directly above a type or public/protected
+  // member declaration → first prose sentence, 60-char cap. Runs on the
+  // ORIGINAL src (extract strips comments before matching). Annotation lines
+  // (`@Override` etc.) between the doc block and the declaration are tolerated.
+  // Body may not contain `*/` so a failed adjacency check can't expand across
+  // code to the next comment block and misattribute the hint.
+  function buildDocHints(src) {
+    const hints = new Map();
+    const patterns = [
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:public\s+|protected\s+)?(?:abstract\s+|final\s+)?(?:class|interface|enum)\s+(\w+)/g,
+      /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:public|protected)\s+(?:static\s+)?(?:final\s+)?(?:synchronized\s+)?(?:<[^>]+>\s+)?[\w<>\[\], ?.]+\s+(\w+)\s*\(/g,
+    ];
+    for (const re of patterns) {
+      for (const m of src.matchAll(re)) {
+        const hint = firstDocSentence(m[1]);
+        if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+      }
+    }
+    return hints;
+  }
+
+  // First non-tag prose line of a Javadoc body → first sentence, 60-char cap.
+  function firstDocSentence(body) {
+    const line = String(body).split('\n')
+      .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+      .find((l) => l && !l.startsWith('@'));
+    if (!line) return '';
+    return line.split(/[.!?]/)[0].trim().slice(0, 60);
   }
 
   module.exports = { extract };
@@ -7680,6 +7745,10 @@ __factories["./src/extractors/rust"] = function(module, exports) {
   function extract(src) {
     if (!src || typeof src !== 'string') return [];
     const sigs = [];
+    const docHints = buildDocHints(src);
+    // Append the doc-comment hint after the anchor as `  # <hint>` — same
+    // convention as the Python/JS extractors' doc hints.
+    const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
     const stripped = src
       .replace(/\/\/.*$/gm, '')
@@ -7701,19 +7770,19 @@ __factories["./src/extractors/rust"] = function(module, exports) {
     // Structs
     for (const m of stripped.matchAll(/^pub\s+struct\s+(\w+)(?:<[^{]*>)?/gm)) {
       const [s, e] = rangeFor(m.index, m.index + m[0].length);
-      sigs.push(withAnchor(`pub struct ${m[1]}`, s, e));
+      sigs.push(hinted(withAnchor(`pub struct ${m[1]}`, s, e), m[1]));
     }
 
     // Enums
     for (const m of stripped.matchAll(/^pub\s+enum\s+(\w+)(?:<[^{]*>)?/gm)) {
       const [s, e] = rangeFor(m.index, m.index + m[0].length);
-      sigs.push(withAnchor(`pub enum ${m[1]}`, s, e));
+      sigs.push(hinted(withAnchor(`pub enum ${m[1]}`, s, e), m[1]));
     }
 
     // Traits
     for (const m of stripped.matchAll(/^pub\s+trait\s+(\w+)(?:<[^{]*>)?/gm)) {
       const [s, e] = rangeFor(m.index, m.index + m[0].length);
-      sigs.push(withAnchor(`pub trait ${m[1]}`, s, e));
+      sigs.push(hinted(withAnchor(`pub trait ${m[1]}`, s, e), m[1]));
     }
 
     // impl blocks
@@ -7722,7 +7791,7 @@ __factories["./src/extractors/rust"] = function(module, exports) {
       const block = extractBlock(stripped, bodyStart);
       sigs.push(withAnchor(`impl ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
       for (const fn of extractMethods(block)) {
-        sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+        sigs.push(hinted(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)), fn.name));
       }
     }
 
@@ -7731,7 +7800,7 @@ __factories["./src/extractors/rust"] = function(module, exports) {
       const asyncKw = m[0].includes('async') ? 'async ' : '';
       const retStr = extractReturnType(m[3]);
       const [s, e] = rangeFor(m.index, m.index + m[0].length);
-      sigs.push(withAnchor(`pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
+      sigs.push(hinted(withAnchor(`pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e), m[1]));
     }
 
     return sigs.slice(0, 25);
@@ -7755,6 +7824,7 @@ __factories["./src/extractors/rust"] = function(module, exports) {
       const retStr = extractReturnType(m[3]);
       methods.push({
         text: `pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+        name: m[1],
         declIdx: m.index + (m[0].length - m[0].trimStart().length),
         endIdx: m.index + m[0].length,
       });
@@ -7773,6 +7843,29 @@ __factories["./src/extractors/rust"] = function(module, exports) {
     if (!m) return '';
     const rt = m[1].trim().replace(/\s+/g, ' ');
     return ` → ${rt.length > 30 ? rt.slice(0, 27) + '...' : rt}`;
+  }
+
+  // Rustdoc: the `///` block directly above a declaration → first prose
+  // sentence, 60-char cap. Runs on the ORIGINAL src (extract strips comments
+  // before matching). Attribute lines (`#[...]`) between the doc block and the
+  // declaration are tolerated.
+  function buildDocHints(src) {
+    const hints = new Map();
+    const re = /((?:^[ \t]*\/\/\/[^\n]*\n)+)(?:[ \t]*#\[[^\n]*\n)*[ \t]*pub(?:\s+async)?\s+(?:fn|struct|enum|trait)\s+(\w+)/gm;
+    for (const m of src.matchAll(re)) {
+      const hint = firstDocSentence(m[1]);
+      if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+    }
+    return hints;
+  }
+
+  // First prose line of a `///` block → first sentence, 60-char cap.
+  function firstDocSentence(block) {
+    const line = String(block).split('\n')
+      .map((l) => l.replace(/^[ \t]*\/\/\/\s?/, '').trim())
+      .find((l) => l);
+    if (!line) return '';
+    return line.split(/[.!?]/)[0].trim().slice(0, 60);
   }
 
   module.exports = { extract };
@@ -11806,6 +11899,71 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
   
 };
 
+// ── ./src/graph/centrality ──
+__factories["./src/graph/centrality"] = function(module, exports) {
+  
+  /**
+   * Zero-dependency import-graph centrality (Semantic Bridge II, B3).
+   *
+   * Power iteration over the forward dependency graph: rank flows from each
+   * importer to the files it imports, so heavily-referenced files accumulate
+   * centrality and one-off helpers do not. Deterministic — fixed damping,
+   * fixed iteration count, nodes processed in sorted order.
+   *
+   * The result feeds the opt-in `retrieval.centralityBlend` ranking prior
+   * (see src/retrieval/ranker.js) — a principled deepening of the existing
+   * graph-boost idea, not a replacement for query relevance.
+   */
+
+  const DAMPING = 0.85;
+  const ITERATIONS = 20;
+
+  /**
+   * Compute a normalized centrality score for every file in a dependency graph.
+   *
+   * @param {{ forward: Map<string, string[]> }} graph - forward dependency graph
+   *        (file → files it imports), as built by src/graph/builder.js
+   * @returns {Map<string, number>} file → centrality in (0, 1], max-normalized;
+   *          empty Map when the graph is missing or empty
+   */
+  function computeCentrality(graph) {
+    if (!graph || !(graph.forward instanceof Map) || graph.forward.size === 0) return new Map();
+
+    const nodes = new Set(graph.forward.keys());
+    for (const deps of graph.forward.values()) {
+      for (const dep of deps || []) nodes.add(dep);
+    }
+    const nodeList = [...nodes].sort();
+    const n = nodeList.length;
+    const indexOf = new Map(nodeList.map((file, i) => [file, i]));
+    const outLinks = nodeList.map((file) =>
+      (graph.forward.get(file) || []).map((dep) => indexOf.get(dep)).filter((i) => i !== undefined));
+
+    let ranks = new Array(n).fill(1 / n);
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      const next = new Array(n).fill((1 - DAMPING) / n);
+      let dangling = 0;
+      for (let i = 0; i < n; i++) {
+        if (outLinks[i].length === 0) { dangling += ranks[i]; continue; }
+        const share = (DAMPING * ranks[i]) / outLinks[i].length;
+        for (const j of outLinks[i]) next[j] += share;
+      }
+      // Dangling mass (files that import nothing) is redistributed uniformly.
+      const danglingShare = (DAMPING * dangling) / n;
+      for (let i = 0; i < n; i++) next[i] += danglingShare;
+      ranks = next;
+    }
+
+    const max = Math.max(...ranks) || 1;
+    const result = new Map();
+    for (let i = 0; i < n; i++) result.set(nodeList[i], ranks[i] / max);
+    return result;
+  }
+
+  module.exports = { computeCentrality, DAMPING, ITERATIONS };
+  
+};
+
 // ── ./src/graph/impact ──
 __factories["./src/graph/impact"] = function(module, exports) {
   
@@ -13963,8 +14121,9 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
       // Build dependency graph for neighbor boost — non-fatal if it fails
       let graph = null;
       try { graph = buildFromCwd(cwd); } catch (_) {}
-      // Opt-in call-graph neighbor boost + surface enrichment — non-fatal
+      // Opt-in call-graph neighbor boost + surface enrichment + centrality blend — non-fatal
       let callGraph = null;
+      let centrality = null;
       try {
         const { loadConfig } = __require('./src/config/loader');
         const retrieval = loadConfig(cwd).retrieval;
@@ -13974,8 +14133,11 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
         if (retrieval && retrieval.surfaceEnrichment) {
           __require('./src/retrieval/enrich-from-maps').enrichWithSurfaces(index, cwd);
         }
+        if (retrieval && retrieval.centralityBlend && graph) {
+          centrality = __require('./src/graph/centrality').computeCentrality(graph);
+        }
       } catch (_) {}
-      const results = rank(args.query, index, { topK, cwd, graph, callGraph });
+      const results = rank(args.query, index, { topK, cwd, graph, callGraph, centrality });
       return formatRankTable(results, args.query);
     } catch (err) {
       return `_query_context failed: ${err.message}_`;
@@ -15818,6 +15980,9 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     callHop: 0.30, // call-graph file neighbor (opt-in retrieval.callGraphBoost)
   };
 
+  // Max additive prior for import-graph centrality (opt-in retrieval.centralityBlend)
+  const CENTRALITY_BLEND_WEIGHT = 0.3;
+
   // Intent-specific weight adjustments
   const INTENT_WEIGHTS = {
     search:     DEFAULT_WEIGHTS,
@@ -15950,6 +16115,8 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
    * @param {{ forward: Map<string,string[]> }} [opts.graph] - dependency graph for neighbor boost
    * @param {{ forward: Map<string,string[]> }} [opts.callGraph] - file-level call-graph edges
    *        (from buildCallFileGraph) for the opt-in call-neighbor boost
+   * @param {Map<string,number>} [opts.centrality] - absolute file → normalized
+   *        centrality (from computeCentrality) for the opt-in centrality blend
    * @returns {{ file: string, score: number, sigs: string[], tokens: number, intent: string, signals: object }[]}
    */
   function rank(query, sigIndex, opts) {
@@ -16094,6 +16261,26 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
             scored[idx].score += GRAPH_BOOST_AMOUNTS.callHop;
             scored[idx].signals.callGraphBoost = (scored[idx].signals.callGraphBoost || 0) + GRAPH_BOOST_AMOUNTS.callHop;
           }
+        }
+      }
+    }
+
+    // Centrality blend (opt-in via retrieval.centralityBlend): a small additive
+    // prior from import-graph centrality so heavily-referenced files rank above
+    // one-off helpers on ambiguous queries. Applied only to positively-scored
+    // files — a tie-breaker among matches, never a way to surface non-matches.
+    const centrality = (opts && opts.centrality instanceof Map && opts.centrality.size > 0) ? opts.centrality : null;
+    if (centrality && cwd) {
+      const path = require('path');
+      for (const entry of scored) {
+        if (entry.score <= 0) continue;
+        const abs = path.resolve(cwd, entry.file);
+        // The graph builder lowercases paths (normalizePath) — probe both forms.
+        const c = centrality.get(abs) || centrality.get(abs.toLowerCase());
+        if (c) {
+          const bonus = CENTRALITY_BLEND_WEIGHT * c;
+          entry.score += bonus;
+          entry.signals.centrality = bonus;
         }
       }
     }
@@ -16373,7 +16560,7 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     return 'search';
   }
 
-  module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, detectIntent };
+  module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
   
 };
 
@@ -22215,8 +22402,16 @@ function main() {
     if (config && config.retrieval && config.retrieval.surfaceEnrichment) {
       try { requireSourceOrBundled('./src/retrieval/enrich-from-maps').enrichWithSurfaces(sigIndex, cwd); } catch (_) {}
     }
+    // Opt-in import-graph centrality blend (retrieval.centralityBlend) — non-fatal
+    let askCentrality = null;
+    if (config && config.retrieval && config.retrieval.centralityBlend) {
+      try {
+        const askCentralityGraph = requireSourceOrBundled('./src/graph/builder').buildFromCwd(cwd);
+        askCentrality = requireSourceOrBundled('./src/graph/centrality').computeCentrality(askCentralityGraph);
+      } catch (_) {}
+    }
 
-    let ranked = rank(query, sigIndex, { topK: 5, weights: intentWeights, cwd, callGraph: askCallGraph });
+    let ranked = rank(query, sigIndex, { topK: 5, weights: intentWeights, cwd, callGraph: askCallGraph, centrality: askCentrality });
 
     // v6.10: Workspace scoping — infer package from query and apply boost
     const workspaces = detectWorkspaces(cwd);
@@ -24447,7 +24642,15 @@ function main() {
       if (config && config.retrieval && config.retrieval.surfaceEnrichment) {
         try { requireSourceOrBundled('./src/retrieval/enrich-from-maps').enrichWithSurfaces(index, cwd); } catch (_) {}
       }
-      const results = rank(query, index, { topK, recencyBoost, cwd, callGraph: queryCallGraph });
+      // Opt-in import-graph centrality blend (retrieval.centralityBlend) — non-fatal
+      let queryCentrality = null;
+      if (config && config.retrieval && config.retrieval.centralityBlend) {
+        try {
+          const centralityGraph = requireSourceOrBundled('./src/graph/builder').buildFromCwd(cwd);
+          queryCentrality = requireSourceOrBundled('./src/graph/centrality').computeCentrality(centralityGraph);
+        } catch (_) {}
+      }
+      const results = rank(query, index, { topK, recencyBoost, cwd, callGraph: queryCallGraph, centrality: queryCentrality });
       if (args.includes('--context')) {
         const miniCtx  = buildMiniContext(results, cwd);
         const ctxOut   = path.join(cwd, '.context', 'query-context.md');

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -345,7 +345,7 @@ testCoverage = false
 testDirs = ["tests","test","__tests__","spec"]
 sigCache = false
 impactRadius = false
-retrieval = {"topK":10,"recencyBoost":1.5,"callGraphBoost":false,"surfaceEnrichment":false}
+retrieval = {"topK":10,"recencyBoost":1.5,"callGraphBoost":false,"centralityBlend":false,"surfaceEnrichment":false}
 impact = {"depth":3,"includeSigs":true}
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "benchmark:test-discovery": "node scripts/run-test-discovery-benchmark.mjs --save",
     "benchmark:terse": "node scripts/run-terse-benchmark.mjs --save",
     "benchmark:callgraph-boost": "node scripts/run-callgraph-boost-benchmark.mjs --save",
+    "benchmark:centrality-blend": "node scripts/run-centrality-blend-benchmark.mjs --save",
     "benchmark:surface-enrichment": "node scripts/run-surface-enrichment-benchmark.mjs --save",
     "validate:squeeze": "node scripts/run-squeeze-benchmark.mjs --gate",
     "health": "node gen-context.js --health",

--- a/scripts/run-centrality-blend-benchmark.mjs
+++ b/scripts/run-centrality-blend-benchmark.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Centrality blend A/B — the measure gate for retrieval.centralityBlend.
+ *
+ *   node scripts/run-centrality-blend-benchmark.mjs            # run, print table
+ *   node scripts/run-centrality-blend-benchmark.mjs --json     # machine-readable
+ *   node scripts/run-centrality-blend-benchmark.mjs --save     # write benchmarks/reports/centrality-blend.json
+ *
+ * Runs the same tasks as the retrieval harness through the FULL ranker
+ * (`src/retrieval/ranker.js` rank()) in two arms per repo:
+ *   A — import graph only              rank(q, idx, { cwd, graph })
+ *   B — import graph + centrality      rank(q, idx, { cwd, graph, centrality })
+ * and reports hit@5 for both arms + the delta. The headline BM25 benchmark
+ * is untouched; this is the only legitimate source for the blend's number.
+ * Flip the default only if arm B ≥ arm A here.
+ *
+ * Requires cached benchmark repos with generated context (run the retrieval
+ * benchmark first, or gen-context per repo); repos without either are skipped
+ * and reported.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const REPOS_DIR = path.join(ROOT, 'benchmarks', 'repos');
+const TASKS_DIR = path.join(ROOT, 'benchmarks', 'tasks');
+const OUT = path.join(ROOT, 'benchmarks', 'reports', 'centrality-blend.json');
+
+const JSON_OUT = process.argv.includes('--json');
+const SAVE = process.argv.includes('--save');
+
+const { rank, buildSigIndex } = require(path.join(ROOT, 'src/retrieval/ranker.js'));
+const { buildFromCwd } = require(path.join(ROOT, 'src/graph/builder.js'));
+const { computeCentrality } = require(path.join(ROOT, 'src/graph/centrality.js'));
+
+function loadTasks(repo) {
+  const p = path.join(TASKS_DIR, `${repo}.jsonl`);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function hitAt5(ranked, expected) {
+  const norm = (x) => String(x).replace(/\\/g, '/');
+  const top5 = ranked.slice(0, 5).map((r) => norm(r.file));
+  return expected.some((e) => top5.some((f) => f === norm(e) || f.endsWith('/' + norm(e)))) ? 1 : 0;
+}
+
+const repos = fs.readdirSync(TASKS_DIR).filter((f) => f.endsWith('.jsonl')).map((f) => f.replace(/\.jsonl$/, '')).sort();
+const perRepo = [];
+const skipped = [];
+let tasksA = 0, hitsA = 0, hitsB = 0;
+
+for (const repo of repos) {
+  const dir = path.join(REPOS_DIR, repo);
+  if (!fs.existsSync(dir)) { skipped.push({ repo, reason: 'repo not cloned' }); continue; }
+  const tasks = loadTasks(repo);
+  if (!tasks.length) { skipped.push({ repo, reason: 'no tasks' }); continue; }
+  let index;
+  try { index = buildSigIndex(dir); } catch { index = new Map(); }
+  if (!index || index.size === 0) { skipped.push({ repo, reason: 'no context (run retrieval benchmark first)' }); continue; }
+
+  let graph = null;
+  try { graph = buildFromCwd(dir); } catch { /* optional */ }
+  let centrality = null;
+  try { centrality = computeCentrality(graph); } catch { /* optional */ }
+  const centralityFiles = centrality ? centrality.size : 0;
+
+  let a = 0, b = 0;
+  for (const t of tasks) {
+    const expected = t.expected_files || t.expected || [];
+    a += hitAt5(rank(t.query, index, { topK: 10, cwd: dir, graph }), expected);
+    b += hitAt5(rank(t.query, index, { topK: 10, cwd: dir, graph, centrality }), expected);
+  }
+  tasksA += tasks.length; hitsA += a; hitsB += b;
+  perRepo.push({ repo, tasks: tasks.length, centralityFiles, hitA: a, hitB: b, delta: b - a });
+}
+
+const pct = (h) => (tasksA ? Math.round((h / tasksA) * 1000) / 10 : 0);
+const result = {
+  benchmark: 'centrality-blend-ab',
+  arms: { A: 'rank + import graph', B: 'rank + import graph + centrality prior' },
+  tasks: tasksA,
+  hitAt5A: pct(hitsA),
+  hitAt5B: pct(hitsB),
+  deltaTasks: hitsB - hitsA,
+  perRepo,
+  skipped,
+};
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(result, null, 2));
+} else {
+  console.log('Centrality blend A/B (full rank(); headline BM25 harness untouched)');
+  console.log('  note        : reads each repo\'s context AS-IS — run the retrieval benchmark first for canonical contexts');
+  console.log(`  tasks       : ${tasksA} across ${perRepo.length} repos (${skipped.length} skipped)`);
+  console.log(`  arm A hit@5 : ${result.hitAt5A}%  (import graph)`);
+  console.log(`  arm B hit@5 : ${result.hitAt5B}%  (+ centrality prior)`);
+  console.log(`  delta       : ${hitsB - hitsA >= 0 ? '+' : ''}${hitsB - hitsA} task(s)`);
+  const moved = perRepo.filter((r) => r.delta !== 0);
+  if (moved.length) {
+    console.log('  moved repos :');
+    for (const r of moved) console.log(`    ${r.repo}: ${r.hitA}/${r.tasks} → ${r.hitB}/${r.tasks} (${r.delta > 0 ? '+' : ''}${r.delta}, ${r.centralityFiles} centrality files)`);
+  } else {
+    console.log('  moved repos : none — arms identical on every repo');
+  }
+  if (skipped.length) console.log('  skipped     : ' + skipped.map((s) => `${s.repo} (${s.reason})`).join(', '));
+}
+
+if (SAVE) {
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(result, null, 2) + '\n');
+  if (!JSON_OUT) console.log(`  saved       : ${path.relative(ROOT, OUT)}`);
+}

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -149,6 +149,8 @@ const DEFAULTS = {
     recencyBoost: 1.5,
     // Boost files call-graph-connected to query matches (opt-in, measure-gated)
     callGraphBoost: false,
+    // Blend import-graph centrality into ranking as a small prior (opt-in, measure-gated)
+    centralityBlend: false,
     // Append route pseudo-signatures to the rankable index (opt-in, measure-gated)
     surfaceEnrichment: false,
   },

--- a/src/extractors/go.js
+++ b/src/extractors/go.js
@@ -12,6 +12,10 @@ const { lineAt, withAnchor } = require('./line-anchor');
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  const docHints = buildDocHints(src);
+  // Append the godoc hint after the anchor as `  # <hint>` — same convention
+  // as the Python/JS extractors' doc hints.
+  const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
@@ -23,14 +27,14 @@ function extract(src) {
   // Structs
   for (const m of stripped.matchAll(/^type\s+(\w+)\s+struct\s*\{/gm)) {
     const end = blockEndIdx(m.index + m[0].length);
-    sigs.push(withAnchor(`type ${m[1]} struct`, lineAt(stripped, m.index), lineAt(stripped, end)));
+    sigs.push(hinted(withAnchor(`type ${m[1]} struct`, lineAt(stripped, m.index), lineAt(stripped, end)), m[1]));
   }
 
   // Interfaces
   for (const m of stripped.matchAll(/^type\s+(\w+)\s+interface\s*\{/gm)) {
     const bodyStart = m.index + m[0].length;
     const block = extractBlock(stripped, bodyStart);
-    sigs.push(withAnchor(`type ${m[1]} interface`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    sigs.push(hinted(withAnchor(`type ${m[1]} interface`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[1]));
     for (const meth of extractInterfaceMethods(block)) {
       sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
     }
@@ -42,7 +46,7 @@ function extract(src) {
     const retType = m[4] ? m[4].trim().replace(/\s+/g, ' ') : '';
     const retStr = retType ? ` → ${retType.slice(0, 30)}` : '';
     const end = blockEndIdx(m.index + m[0].length);
-    sigs.push(withAnchor(`func ${receiver}${m[2]}(${normalizeParams(m[3])})${retStr}`, lineAt(stripped, m.index), lineAt(stripped, end)));
+    sigs.push(hinted(withAnchor(`func ${receiver}${m[2]}(${normalizeParams(m[3])})${retStr}`, lineAt(stripped, m.index), lineAt(stripped, end)), m[2]));
   }
 
   return sigs.slice(0, 25);
@@ -76,6 +80,30 @@ function extractInterfaceMethods(block) {
 function normalizeParams(params) {
   if (!params) return '';
   return params.trim().replace(/\s+/g, ' ');
+}
+
+// Godoc: the `//` comment block directly above a top-level func/type/method
+// declaration → first prose sentence, 60-char cap. Runs on the ORIGINAL src
+// (extract strips comments before matching). Compiler directives (`//go:...`)
+// carry no prose and are skipped.
+function buildDocHints(src) {
+  const hints = new Map();
+  const re = /((?:^\/\/[^\n]*\n)+)(?:func\s+(?:\(\w+\s+[\w*]+\)\s+)?(\w+)\s*\(|type\s+(\w+)\s+(?:struct|interface)\b)/gm;
+  for (const m of src.matchAll(re)) {
+    const name = m[2] || m[3];
+    const hint = firstDocSentence(m[1]);
+    if (hint && !hints.has(name)) hints.set(name, hint);
+  }
+  return hints;
+}
+
+// First non-directive prose line of a `//` block → first sentence, 60-char cap.
+function firstDocSentence(block) {
+  const line = String(block).split('\n')
+    .map((l) => l.replace(/^\/\/\s?/, '').trim())
+    .find((l) => l && !l.startsWith('go:') && !l.startsWith('nolint'));
+  if (!line) return '';
+  return line.split(/[.!?]/)[0].trim().slice(0, 60);
 }
 
 module.exports = { extract };

--- a/src/extractors/java.js
+++ b/src/extractors/java.js
@@ -12,6 +12,10 @@ const { lineAt, withAnchor } = require('./line-anchor');
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  const docHints = buildDocHints(src);
+  // Append the Javadoc hint after the anchor as `  # <hint>` — same convention
+  // as the Python/JS extractors' doc hints.
+  const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
@@ -22,9 +26,9 @@ function extract(src) {
   for (const m of stripped.matchAll(typeRegex)) {
     const bodyStart = m.index + m[0].length;
     const block = extractBlock(stripped, bodyStart);
-    sigs.push(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
+    sigs.push(hinted(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[2]));
     for (const meth of extractMembers(block)) {
-      sigs.push(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)));
+      sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)), meth.name));
     }
   }
 
@@ -51,6 +55,7 @@ function extractMembers(block) {
     const retStr = ret ? ` → ${ret}` : '';
     members.push({
       text: `${m[2]}(${normalizeParams(m[3])})${retStr}`,
+      name: m[2],
       declIdx: m.index + (m[0].length - m[0].trimStart().length),
       endIdx: m.index + m[0].length,
     });
@@ -66,6 +71,36 @@ function normalizeParams(params) {
 function normalizeType(type) {
   if (!type) return '';
   return type.trim().replace(/\s+/g, ' ').slice(0, 30);
+}
+
+// Javadoc: the `/** ... */` block directly above a type or public/protected
+// member declaration → first prose sentence, 60-char cap. Runs on the
+// ORIGINAL src (extract strips comments before matching). Annotation lines
+// (`@Override` etc.) between the doc block and the declaration are tolerated.
+// Body may not contain `*/` so a failed adjacency check can't expand across
+// code to the next comment block and misattribute the hint.
+function buildDocHints(src) {
+  const hints = new Map();
+  const patterns = [
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:public\s+|protected\s+)?(?:abstract\s+|final\s+)?(?:class|interface|enum)\s+(\w+)/g,
+    /\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:public|protected)\s+(?:static\s+)?(?:final\s+)?(?:synchronized\s+)?(?:<[^>]+>\s+)?[\w<>\[\], ?.]+\s+(\w+)\s*\(/g,
+  ];
+  for (const re of patterns) {
+    for (const m of src.matchAll(re)) {
+      const hint = firstDocSentence(m[1]);
+      if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+    }
+  }
+  return hints;
+}
+
+// First non-tag prose line of a Javadoc body → first sentence, 60-char cap.
+function firstDocSentence(body) {
+  const line = String(body).split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, '').trim())
+    .find((l) => l && !l.startsWith('@'));
+  if (!line) return '';
+  return line.split(/[.!?]/)[0].trim().slice(0, 60);
 }
 
 module.exports = { extract };

--- a/src/extractors/rust.js
+++ b/src/extractors/rust.js
@@ -12,6 +12,10 @@ const { lineAt, withAnchor } = require('./line-anchor');
 function extract(src) {
   if (!src || typeof src !== 'string') return [];
   const sigs = [];
+  const docHints = buildDocHints(src);
+  // Append the doc-comment hint after the anchor as `  # <hint>` — same
+  // convention as the Python/JS extractors' doc hints.
+  const hinted = (sig, name) => (docHints.has(name) ? `${sig}  # ${docHints.get(name)}` : sig);
 
   const stripped = src
     .replace(/\/\/.*$/gm, '')
@@ -33,19 +37,19 @@ function extract(src) {
   // Structs
   for (const m of stripped.matchAll(/^pub\s+struct\s+(\w+)(?:<[^{]*>)?/gm)) {
     const [s, e] = rangeFor(m.index, m.index + m[0].length);
-    sigs.push(withAnchor(`pub struct ${m[1]}`, s, e));
+    sigs.push(hinted(withAnchor(`pub struct ${m[1]}`, s, e), m[1]));
   }
 
   // Enums
   for (const m of stripped.matchAll(/^pub\s+enum\s+(\w+)(?:<[^{]*>)?/gm)) {
     const [s, e] = rangeFor(m.index, m.index + m[0].length);
-    sigs.push(withAnchor(`pub enum ${m[1]}`, s, e));
+    sigs.push(hinted(withAnchor(`pub enum ${m[1]}`, s, e), m[1]));
   }
 
   // Traits
   for (const m of stripped.matchAll(/^pub\s+trait\s+(\w+)(?:<[^{]*>)?/gm)) {
     const [s, e] = rangeFor(m.index, m.index + m[0].length);
-    sigs.push(withAnchor(`pub trait ${m[1]}`, s, e));
+    sigs.push(hinted(withAnchor(`pub trait ${m[1]}`, s, e), m[1]));
   }
 
   // impl blocks
@@ -54,7 +58,7 @@ function extract(src) {
     const block = extractBlock(stripped, bodyStart);
     sigs.push(withAnchor(`impl ${m[1]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)));
     for (const fn of extractMethods(block)) {
-      sigs.push(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)));
+      sigs.push(hinted(withAnchor(`  ${fn.text}`, lineAt(stripped, bodyStart + fn.declIdx), lineAt(stripped, bodyStart + fn.endIdx)), fn.name));
     }
   }
 
@@ -63,7 +67,7 @@ function extract(src) {
     const asyncKw = m[0].includes('async') ? 'async ' : '';
     const retStr = extractReturnType(m[3]);
     const [s, e] = rangeFor(m.index, m.index + m[0].length);
-    sigs.push(withAnchor(`pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e));
+    sigs.push(hinted(withAnchor(`pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`, s, e), m[1]));
   }
 
   return sigs.slice(0, 25);
@@ -87,6 +91,7 @@ function extractMethods(block) {
     const retStr = extractReturnType(m[3]);
     methods.push({
       text: `pub ${asyncKw}fn ${m[1]}(${normalizeParams(m[2])})${retStr}`,
+      name: m[1],
       declIdx: m.index + (m[0].length - m[0].trimStart().length),
       endIdx: m.index + m[0].length,
     });
@@ -105,6 +110,29 @@ function extractReturnType(afterParen) {
   if (!m) return '';
   const rt = m[1].trim().replace(/\s+/g, ' ');
   return ` → ${rt.length > 30 ? rt.slice(0, 27) + '...' : rt}`;
+}
+
+// Rustdoc: the `///` block directly above a declaration → first prose
+// sentence, 60-char cap. Runs on the ORIGINAL src (extract strips comments
+// before matching). Attribute lines (`#[...]`) between the doc block and the
+// declaration are tolerated.
+function buildDocHints(src) {
+  const hints = new Map();
+  const re = /((?:^[ \t]*\/\/\/[^\n]*\n)+)(?:[ \t]*#\[[^\n]*\n)*[ \t]*pub(?:\s+async)?\s+(?:fn|struct|enum|trait)\s+(\w+)/gm;
+  for (const m of src.matchAll(re)) {
+    const hint = firstDocSentence(m[1]);
+    if (hint && !hints.has(m[2])) hints.set(m[2], hint);
+  }
+  return hints;
+}
+
+// First prose line of a `///` block → first sentence, 60-char cap.
+function firstDocSentence(block) {
+  const line = String(block).split('\n')
+    .map((l) => l.replace(/^[ \t]*\/\/\/\s?/, '').trim())
+    .find((l) => l);
+  if (!line) return '';
+  return line.split(/[.!?]/)[0].trim().slice(0, 60);
 }
 
 module.exports = { extract };

--- a/src/graph/centrality.js
+++ b/src/graph/centrality.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Zero-dependency import-graph centrality (Semantic Bridge II, B3).
+ *
+ * Power iteration over the forward dependency graph: rank flows from each
+ * importer to the files it imports, so heavily-referenced files accumulate
+ * centrality and one-off helpers do not. Deterministic — fixed damping,
+ * fixed iteration count, nodes processed in sorted order.
+ *
+ * The result feeds the opt-in `retrieval.centralityBlend` ranking prior
+ * (see src/retrieval/ranker.js) — a principled deepening of the existing
+ * graph-boost idea, not a replacement for query relevance.
+ */
+
+const DAMPING = 0.85;
+const ITERATIONS = 20;
+
+/**
+ * Compute a normalized centrality score for every file in a dependency graph.
+ *
+ * @param {{ forward: Map<string, string[]> }} graph - forward dependency graph
+ *        (file → files it imports), as built by src/graph/builder.js
+ * @returns {Map<string, number>} file → centrality in (0, 1], max-normalized;
+ *          empty Map when the graph is missing or empty
+ */
+function computeCentrality(graph) {
+  if (!graph || !(graph.forward instanceof Map) || graph.forward.size === 0) return new Map();
+
+  const nodes = new Set(graph.forward.keys());
+  for (const deps of graph.forward.values()) {
+    for (const dep of deps || []) nodes.add(dep);
+  }
+  const nodeList = [...nodes].sort();
+  const n = nodeList.length;
+  const indexOf = new Map(nodeList.map((file, i) => [file, i]));
+  const outLinks = nodeList.map((file) =>
+    (graph.forward.get(file) || []).map((dep) => indexOf.get(dep)).filter((i) => i !== undefined));
+
+  let ranks = new Array(n).fill(1 / n);
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    const next = new Array(n).fill((1 - DAMPING) / n);
+    let dangling = 0;
+    for (let i = 0; i < n; i++) {
+      if (outLinks[i].length === 0) { dangling += ranks[i]; continue; }
+      const share = (DAMPING * ranks[i]) / outLinks[i].length;
+      for (const j of outLinks[i]) next[j] += share;
+    }
+    // Dangling mass (files that import nothing) is redistributed uniformly.
+    const danglingShare = (DAMPING * dangling) / n;
+    for (let i = 0; i < n; i++) next[i] += danglingShare;
+    ranks = next;
+  }
+
+  const max = Math.max(...ranks) || 1;
+  const result = new Map();
+  for (let i = 0; i < n; i++) result.set(nodeList[i], ranks[i] / max);
+  return result;
+}
+
+module.exports = { computeCentrality, DAMPING, ITERATIONS };

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -421,8 +421,9 @@ function queryContext(args, cwd) {
     // Build dependency graph for neighbor boost — non-fatal if it fails
     let graph = null;
     try { graph = buildFromCwd(cwd); } catch (_) {}
-    // Opt-in call-graph neighbor boost + surface enrichment — non-fatal
+    // Opt-in call-graph neighbor boost + surface enrichment + centrality blend — non-fatal
     let callGraph = null;
+    let centrality = null;
     try {
       const { loadConfig } = require('../config/loader');
       const retrieval = loadConfig(cwd).retrieval;
@@ -432,8 +433,11 @@ function queryContext(args, cwd) {
       if (retrieval && retrieval.surfaceEnrichment) {
         require('../retrieval/enrich-from-maps').enrichWithSurfaces(index, cwd);
       }
+      if (retrieval && retrieval.centralityBlend && graph) {
+        centrality = require('../graph/centrality').computeCentrality(graph);
+      }
     } catch (_) {}
-    const results = rank(args.query, index, { topK, cwd, graph, callGraph });
+    const results = rank(args.query, index, { topK, cwd, graph, callGraph, centrality });
     return formatRankTable(results, args.query);
   } catch (err) {
     return `_query_context failed: ${err.message}_`;

--- a/src/retrieval/ranker.js
+++ b/src/retrieval/ranker.js
@@ -40,6 +40,9 @@ const GRAPH_BOOST_AMOUNTS = {
   callHop: 0.30, // call-graph file neighbor (opt-in retrieval.callGraphBoost)
 };
 
+// Max additive prior for import-graph centrality (opt-in retrieval.centralityBlend)
+const CENTRALITY_BLEND_WEIGHT = 0.3;
+
 // Intent-specific weight adjustments
 const INTENT_WEIGHTS = {
   search:     DEFAULT_WEIGHTS,
@@ -172,6 +175,8 @@ function scoreFile(filePath, sigs, queryTokens, weights) {
  * @param {{ forward: Map<string,string[]> }} [opts.graph] - dependency graph for neighbor boost
  * @param {{ forward: Map<string,string[]> }} [opts.callGraph] - file-level call-graph edges
  *        (from buildCallFileGraph) for the opt-in call-neighbor boost
+ * @param {Map<string,number>} [opts.centrality] - absolute file → normalized
+ *        centrality (from computeCentrality) for the opt-in centrality blend
  * @returns {{ file: string, score: number, sigs: string[], tokens: number, intent: string, signals: object }[]}
  */
 function rank(query, sigIndex, opts) {
@@ -316,6 +321,26 @@ function rank(query, sigIndex, opts) {
           scored[idx].score += GRAPH_BOOST_AMOUNTS.callHop;
           scored[idx].signals.callGraphBoost = (scored[idx].signals.callGraphBoost || 0) + GRAPH_BOOST_AMOUNTS.callHop;
         }
+      }
+    }
+  }
+
+  // Centrality blend (opt-in via retrieval.centralityBlend): a small additive
+  // prior from import-graph centrality so heavily-referenced files rank above
+  // one-off helpers on ambiguous queries. Applied only to positively-scored
+  // files — a tie-breaker among matches, never a way to surface non-matches.
+  const centrality = (opts && opts.centrality instanceof Map && opts.centrality.size > 0) ? opts.centrality : null;
+  if (centrality && cwd) {
+    const path = require('path');
+    for (const entry of scored) {
+      if (entry.score <= 0) continue;
+      const abs = path.resolve(cwd, entry.file);
+      // The graph builder lowercases paths (normalizePath) — probe both forms.
+      const c = centrality.get(abs) || centrality.get(abs.toLowerCase());
+      if (c) {
+        const bonus = CENTRALITY_BLEND_WEIGHT * c;
+        entry.score += bonus;
+        entry.signals.centrality = bonus;
       }
     }
   }
@@ -595,4 +620,4 @@ function detectIntent(query) {
   return 'search';
 }
 
-module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, detectIntent };
+module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };

--- a/test/integration/semantic-bridge-2.test.js
+++ b/test/integration/semantic-bridge-2.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * Semantic Bridge II (v8.21, #501): Go/Rust/Java doc-comment hints (B1b) +
+ * import-graph centrality rank blend (B3, opt-in retrieval.centralityBlend).
+ * Run: node test/integration/semantic-bridge-2.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const GEN_CONTEXT = path.join(ROOT, 'gen-context.js');
+const go = require(path.join(ROOT, 'src/extractors/go.js'));
+const rust = require(path.join(ROOT, 'src/extractors/rust.js'));
+const java = require(path.join(ROOT, 'src/extractors/java.js'));
+const { computeCentrality } = require(path.join(ROOT, 'src/graph/centrality.js'));
+const { rank } = require(path.join(ROOT, 'src/retrieval/ranker.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+// ── B1b: Go doc hints ───────────────────────────────────────────────────────
+
+const GO_SRC = `package main
+
+//go:build linux
+// ChargeBackoff retries the payment with exponential backoff. Second ignored.
+func ChargeBackoff(n int) error { return nil }
+
+// Store keeps active sessions in memory and evicts stale entries lazily too
+type Store struct {
+	m map[string]string
+}
+
+func NoDoc(x int) int { return x }
+`;
+
+test('Go: hint on func — first sentence, after anchor, `  # ` prefix; directive skipped', () => {
+  const sig = go.extract(GO_SRC).find((s) => s.includes('ChargeBackoff'));
+  assert.ok(/:\d+-\d+  # ChargeBackoff retries the payment with exponential backoff$/.test(sig), sig);
+  assert.ok(!sig.includes('Second ignored'), 'must stop at first sentence');
+  assert.ok(!sig.includes('go:build'), 'directive must not become the hint');
+});
+
+test('Go: hint on type; capped at 60 chars; no doc → unchanged', () => {
+  const sigs = go.extract(GO_SRC);
+  const store = sigs.find((s) => s.includes('Store'));
+  const hint = store.split('# ')[1];
+  assert.ok(hint && hint.startsWith('Store keeps active sessions'), store);
+  assert.ok(hint.length <= 60, `hint ${hint.length} chars: ${hint}`);
+  assert.ok(!sigs.find((s) => s.includes('NoDoc')).includes('#'));
+});
+
+// ── B1b: Rust doc hints ─────────────────────────────────────────────────────
+
+const RUST_SRC = `
+/// Retries the payment with exponential backoff. Extra.
+#[inline]
+pub fn charge_backoff(n: u32) -> Result<(), Error> { Ok(()) }
+
+/// Holds the parsed session state
+#[derive(Debug)]
+pub struct Session { id: u64 }
+
+impl Session {
+    /// Serializes the session to disk
+    pub fn persist(&self) -> io::Result<()> { Ok(()) }
+}
+
+pub fn no_doc(x: u32) -> u32 { x }
+`;
+
+test('Rust: hint on pub fn through an attribute line; first sentence only', () => {
+  const sig = rust.extract(RUST_SRC).find((s) => s.includes('charge_backoff'));
+  assert.ok(sig.endsWith('# Retries the payment with exponential backoff'), sig);
+});
+
+test('Rust: hints on struct and impl method; no doc → unchanged', () => {
+  const sigs = rust.extract(RUST_SRC);
+  assert.ok(sigs.find((s) => s.includes('struct Session')).endsWith('# Holds the parsed session state'));
+  assert.ok(sigs.find((s) => s.includes('persist')).endsWith('# Serializes the session to disk'));
+  assert.ok(!sigs.find((s) => s.includes('no_doc')).includes('#'));
+});
+
+// ── B1b: Java doc hints ─────────────────────────────────────────────────────
+
+const JAVA_SRC = `
+/**
+ * Coordinates payment retries with exponential backoff. Extra.
+ */
+public class PaymentRetrier {
+  /**
+   * Charges the card, waiting between failed attempts.
+   * @param amount cents
+   */
+  public boolean charge(int amount) { return true; }
+
+  /**
+   * @param x only tags here
+   */
+  public int tagOnly(int x) { return x; }
+
+  public int noDoc(int x) { return x; }
+}
+`;
+
+test('Java: hints on class and member; tag-only and no doc → unchanged', () => {
+  const sigs = java.extract(JAVA_SRC);
+  assert.ok(sigs.find((s) => s.includes('class PaymentRetrier')).endsWith('# Coordinates payment retries with exponential backoff'));
+  assert.ok(sigs.find((s) => s.includes('charge(')).endsWith('# Charges the card, waiting between failed attempts'));
+  assert.ok(!sigs.find((s) => s.includes('tagOnly')).includes('#'));
+  assert.ok(!sigs.find((s) => s.includes('noDoc')).includes('#'));
+});
+
+test('Go/Rust/Java extraction with hints is deterministic', () => {
+  assert.deepStrictEqual(go.extract(GO_SRC), go.extract(GO_SRC));
+  assert.deepStrictEqual(rust.extract(RUST_SRC), rust.extract(RUST_SRC));
+  assert.deepStrictEqual(java.extract(JAVA_SRC), java.extract(JAVA_SRC));
+});
+
+// ── B3: centrality computation ──────────────────────────────────────────────
+
+function syntheticGraph() {
+  return { forward: new Map([
+    ['/p/importer1.js', ['/p/hub.js']],
+    ['/p/importer2.js', ['/p/hub.js']],
+    ['/p/importer3.js', ['/p/hub.js', '/p/leaf.js']],
+    ['/p/hub.js', []],
+    ['/p/leaf.js', []],
+  ]) };
+}
+
+test('computeCentrality: hub outranks leaf and importers; scores normalized to (0,1]', () => {
+  const c = computeCentrality(syntheticGraph());
+  assert.strictEqual(c.get('/p/hub.js'), 1, 'hub must carry the max score');
+  assert.ok(c.get('/p/leaf.js') < 1 && c.get('/p/leaf.js') > 0);
+  assert.ok(c.get('/p/importer1.js') < c.get('/p/hub.js'));
+});
+
+test('computeCentrality: deterministic; empty/missing graph → empty Map', () => {
+  assert.deepStrictEqual([...computeCentrality(syntheticGraph())], [...computeCentrality(syntheticGraph())]);
+  assert.strictEqual(computeCentrality(null).size, 0);
+  assert.strictEqual(computeCentrality({ forward: new Map() }).size, 0);
+});
+
+// ── B3: rank() blend + isolation ────────────────────────────────────────────
+
+test('rank(): centrality breaks the tie toward the hub; only score>0 files boosted', () => {
+  const c = computeCentrality(syntheticGraph());
+  const index = new Map([
+    ['hub.js', ['function connectDb()']],
+    ['leaf.js', ['function connectDb()']],
+    ['importer1.js', ['function unrelatedStuff()']],
+  ]);
+  const on = rank('connect db', index, { topK: 5, cwd: '/p', centrality: c });
+  const hub = on.find((r) => r.file === 'hub.js');
+  const leaf = on.find((r) => r.file === 'leaf.js');
+  const unrelated = on.find((r) => r.file === 'importer1.js');
+  assert.ok(hub.signals.centrality > leaf.signals.centrality, 'hub must get the larger prior');
+  assert.ok(hub.score > leaf.score, 'tie must break toward the hub');
+  assert.strictEqual(unrelated.signals.centrality, undefined, 'zero-score file must not be boosted');
+});
+
+test('rank(): without centrality (absent or null) output is unchanged, no signal', () => {
+  const index = new Map([['hub.js', ['function connectDb()']], ['leaf.js', ['function connectDb()']]]);
+  const a = rank('connect db', index, { topK: 5, cwd: '/p' });
+  const b = rank('connect db', index, { topK: 5, cwd: '/p', centrality: null });
+  assert.deepStrictEqual(a.map((r) => [r.file, r.score]), b.map((r) => [r.file, r.score]));
+  assert.ok(a.every((r) => r.signals.centrality === undefined));
+});
+
+// ── B3: config-gated CLI wiring ─────────────────────────────────────────────
+
+/** JS fixture with a real import edge: a.js and b.js both import hub.js. */
+function withJsProject(fn, config) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-central-'));
+  try {
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'hub.js'),
+      "'use strict';\nfunction connectDatabase(url) { return url; }\nmodule.exports = { connectDatabase };\n");
+    fs.writeFileSync(path.join(dir, 'src', 'a.js'),
+      "'use strict';\nconst { connectDatabase } = require('./hub');\nfunction startApp() { return connectDatabase('x'); }\nmodule.exports = { startApp };\n");
+    fs.writeFileSync(path.join(dir, 'src', 'b.js'),
+      "'use strict';\nconst { connectDatabase } = require('./hub');\nfunction runWorker() { return connectDatabase('y'); }\nmodule.exports = { runWorker };\n");
+    if (config) {
+      fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify(config, null, 2));
+    }
+    const gen = spawnSync(process.execPath, [GEN_CONTEXT], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(gen.status, 0, gen.stderr);
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('--query: centrality signal appears only when retrieval.centralityBlend is on', () => {
+  withJsProject((dir) => {
+    const off = spawnSync(process.execPath, [GEN_CONTEXT, '--query', 'connect database', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(off.status, 0, off.stderr);
+    assert.ok(!off.stdout.includes('"centrality"'), 'blend active without config');
+  });
+  withJsProject((dir) => {
+    const on = spawnSync(process.execPath, [GEN_CONTEXT, '--query', 'connect database', '--json'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(on.status, 0, on.stderr);
+    assert.ok(on.stdout.includes('"centrality"'), 'centrality signal missing with config on');
+  }, { retrieval: { centralityBlend: true } });
+});
+
+console.log(`\n  semantic-bridge-2: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 126,
+  "tests": 127,
   "metrics": {
     "hit_at_5": 0.856,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #501

## What

**B1b — doc-comment hints for Go/Rust/Java** (extends v8.20's JS/TS hints, #498):
- `go.js`: godoc `//` blocks above top-level `func`/`type`; `//go:`/`nolint` directive lines skipped.
- `rust.js`: `///` blocks above `pub fn`/`struct`/`enum`/`trait` and impl methods; `#[attr]` lines between doc and declaration tolerated.
- `java.js`: Javadoc on type declarations and public/protected members; tag-only blocks produce no hint.
- Byte-format identical to Python/JS/TS: first prose sentence, 60-char cap, `  # <hint>` after the line anchor. Undocumented signatures unchanged.

**B3 — centrality rank blend** (flag-gated, measured):
- New `src/graph/centrality.js`: zero-dep power iteration over the forward import graph (damping 0.85, 20 iterations, deterministic), max-normalized.
- `rank()` blends `0.3 × centrality` as an additive prior onto **positively-scored files only** (`signals.centrality`) — tie-breaker among matches, never surfaces non-matches.
- New flag `retrieval.centralityBlend` (default **off**), wired like `callGraphBoost`: MCP `query_context` + CLI `ask`/`--query`, all non-fatal.

## Measured

`npm run benchmark:centrality-blend` (A/B through the full ranker, mirrors the callgraph-boost measure gate):

| arm | hit@5 |
|---|---|
| A — import graph | 77.8% |
| B — + centrality prior | 77.8% |

Delta +0 tasks over 90 tasks / 18 repos — non-regressing but neutral on this corpus, so the default stays **off** per the measure gate. Report committed at `benchmarks/reports/centrality-blend.json`.

## Tests

11 new tests in `test/integration/semantic-bridge-2.test.js` (hint format/attribution/directive-skipping/cap/determinism per language; centrality math, rank isolation, config-gated CLI wiring). Full integration suite: **121 files, 0 failures**; unit suite all pass. Bundle rebuilt reproducibly (144 modules); version.json test count 126 → 127.

## Supply-chain gate

Local audit PASS — no shell spawns, no install scripts, `main` exports the API, no fingerprinting; tarball 564KB packed / 161 files. External scanners re-grade after `/ship`.

Release flow: merge to develop → `/update-docs` → `/ship`.