### PR TITLE
feat: add MiniMax ablation provider

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -18544,6 +18544,8 @@ __factories["./src/tracking/pricing"] = function(module, exports) {
     'gpt-4o-mini': 0.15,
     'gemini-1.5-pro': 1.25,
     'gemini-1.5-flash': 0.075,
+    'minimax-m3': 0.6,
+    'minimax-m2.7': 0.3,
   };
 
   const DEFAULT_MODEL = 'claude-sonnet';

--- a/scripts/run-llm-ablation.mjs
+++ b/scripts/run-llm-ablation.mjs
@@ -13,10 +13,12 @@
  * Providers (auto-detected from the present key; --provider overrides):
  *   anthropic — ANTHROPIC_API_KEY            (default model claude-sonnet-4-6)
  *   gemini    — GEMINI_API_KEY / GOOGLE_API_KEY  (default model gemini-2.5-flash)
+ *   minimax   — MINIMAX_API_KEY               (default model MiniMax-M3)
  *
  * Usage:
  *   ANTHROPIC_API_KEY=sk-...  node scripts/run-llm-ablation.mjs
  *   GEMINI_API_KEY=...        node scripts/run-llm-ablation.mjs            # AI Studio key
+ *   MINIMAX_API_KEY=...       node scripts/run-llm-ablation.mjs            # OpenAI-compatible API
  *   GEMINI_API_KEY=...        node scripts/run-llm-ablation.mjs --save --model gemini-2.5-pro
  *   GEMINI_API_KEY=...        node scripts/run-llm-ablation.mjs --verbose   # print flagged items per arm
  *   GEMINI_API_KEY=...        node scripts/run-llm-ablation.mjs --runs 5    # average 5 passes (mean ± range)
@@ -43,12 +45,18 @@ const RUNS = Math.max(1, parseInt(flag('--runs') || '1', 10));
 
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
 const GEMINI_KEY = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+const MINIMAX_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_BASE_URL = (process.env.MINIMAX_BASE_URL || 'https://api.minimax.io/v1').replace(/\/+$/, '');
 
-const DEFAULT_MODEL = { anthropic: 'claude-sonnet-4-6', gemini: 'gemini-2.5-flash' };
+const DEFAULT_MODEL = {
+  anthropic: 'claude-sonnet-4-6',
+  gemini: 'gemini-2.5-flash',
+  minimax: 'MiniMax-M3',
+};
 
 // Resolve the provider: explicit flag, else whichever key is present (Gemini first).
 let provider = flag('--provider');
-if (!provider) provider = GEMINI_KEY ? 'gemini' : ANTHROPIC_KEY ? 'anthropic' : null;
+if (!provider) provider = GEMINI_KEY ? 'gemini' : ANTHROPIC_KEY ? 'anthropic' : MINIMAX_KEY ? 'minimax' : null;
 const MODEL = modelArg || (provider ? DEFAULT_MODEL[provider] : null);
 
 function loadTasks() {
@@ -84,7 +92,19 @@ async function geminiComplete(prompt) {
   return ((data.candidates || [])[0]?.content?.parts || []).map((p) => p.text || '').join('\n');
 }
 
-const COMPLETERS = { anthropic: anthropicComplete, gemini: geminiComplete };
+/** MiniMax OpenAI-compatible chat completions → completion text. */
+async function minimaxComplete(prompt) {
+  const res = await fetch(`${MINIMAX_BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${MINIMAX_KEY}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: MODEL, max_tokens: 1024, messages: [{ role: 'user', content: prompt }] }),
+  });
+  if (!res.ok) throw new Error(`MiniMax API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || '';
+}
+
+const COMPLETERS = { anthropic: anthropicComplete, gemini: geminiComplete, minimax: minimaxComplete };
 
 async function main() {
   const tasks = loadTasks();
@@ -100,6 +120,7 @@ async function main() {
     console.log('  Run live with one of:');
     console.log('    ANTHROPIC_API_KEY=sk-...  npm run benchmark:llm-ablation');
     console.log('    GEMINI_API_KEY=...        npm run benchmark:llm-ablation   # AI Studio key');
+    console.log('    MINIMAX_API_KEY=...       npm run benchmark:llm-ablation   # OpenAI-compatible API');
     process.exit(0);
   }
 

--- a/src/tracking/pricing.js
+++ b/src/tracking/pricing.js
@@ -20,6 +20,8 @@ const PRICES = {
   'gpt-4o-mini': 0.15,
   'gemini-1.5-pro': 1.25,
   'gemini-1.5-flash': 0.075,
+  'minimax-m3': 0.6,
+  'minimax-m2.7': 0.3,
 };
 
 const DEFAULT_MODEL = 'claude-sonnet';

--- a/test/integration/llm-ablation.test.js
+++ b/test/integration/llm-ablation.test.js
@@ -14,6 +14,7 @@ const { spawnSync, execFileSync } = require('child_process');
 const ROOT = path.resolve(__dirname, '../..');
 const SCRIPT = path.join(ROOT, 'scripts', 'run-llm-ablation.mjs');
 const { buildGrounding, scoreAnswer, scoreAnswerDetail, runAblation, aggregateRuns } = require(path.join(ROOT, 'src/eval/llm-ablation'));
+const { resolvePrice, listModels } = require(path.join(ROOT, 'src/tracking/pricing'));
 
 let passed = 0, failed = 0;
 function test(name, fn) {
@@ -154,6 +155,14 @@ test('aggregateRuns: single run mean equals that run', () => {
   assert.strictEqual(a.deltaPer100.mean, 10);
 });
 
+// ── MiniMax provider metadata ──────────────────────────────────────────────
+test('MiniMax models: target input pricing is registered', () => {
+  assert.ok(listModels().includes('minimax-m3'));
+  assert.ok(listModels().includes('minimax-m2.7'));
+  assert.strictEqual(resolvePrice('MiniMax-M3').perMtok, 0.6);
+  assert.strictEqual(resolvePrice('MiniMax-M2.7').perMtok, 0.3);
+});
+
 // ── corpus shape (fact questions, not code-writing) ─────────────────────────
 test('corpus: checkable repo-fact questions — no example-code tasks', () => {
   const corpus = JSON.parse(fs.readFileSync(path.join(ROOT, 'benchmarks', 'llm-ablation-tasks.json'), 'utf8'));
@@ -171,11 +180,13 @@ test('script: exits 0 with guidance when no API key is set', () => {
   delete env.ANTHROPIC_API_KEY;
   delete env.GEMINI_API_KEY;
   delete env.GOOGLE_API_KEY;
+  delete env.MINIMAX_API_KEY;
   const res = spawnSync('node', [SCRIPT], { cwd: ROOT, encoding: 'utf8', env });
   assert.strictEqual(res.status, 0, res.stderr);
   assert.ok(/No API key set/.test(res.stdout), 'prints skip guidance');
   assert.ok(/harness is ready/.test(res.stdout));
   assert.ok(/GEMINI_API_KEY/.test(res.stdout), 'mentions the Gemini provider');
+  assert.ok(/MINIMAX_API_KEY/.test(res.stdout), 'mentions the MiniMax provider');
 });
 
 console.log(`\nllm-ablation: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 provider support to the executable LLM ablation runner and pricing registry.

Changes:
- Register MiniMax-M3 and MiniMax-M2.7 input pricing in the tracking registry.
- Add MiniMax OpenAI-compatible chat completions with the global endpoint as the default and an environment override for regional endpoints.
- Add MiniMax provider guidance to the runner and regression coverage for model pricing and no-key behavior.

Checks:
- `git diff --check`
- `node --check scripts/run-llm-ablation.mjs`
- `node test/integration/llm-ablation.test.js` (14 passed)
