### PR TITLE
feat(eval,benchmarks): hard-split corpus, leakage gate, size buckets (A3, v8.22)

### DIFF
--- a/benchmarks/tasks/axios.jsonl
+++ b/benchmarks/tasks/axios.jsonl
@@ -3,3 +3,6 @@
 {"id":"axios-t003","query":"merge config defaults baseURL headers","expected_files":["lib/core/mergeConfig.js","lib/defaults/index.js"]}
 {"id":"axios-t004","query":"HTTP adapter fetch XHR send request","expected_files":["lib/adapters/http.js","lib/adapters/xhr.js"]}
 {"id":"axios-t005","query":"build URL params serialization query string","expected_files":["lib/helpers/buildURL.js","lib/core/buildFullPath.js"]}
+{"id":"axios-h001","query":"run custom logic before sending and after receiving","expected_files":["lib/core/InterceptorManager.js","lib/core/dispatchRequest.js"],"split":"hard"}
+{"id":"axios-h002","query":"combine per call options with instance defaults","expected_files":["lib/core/mergeConfig.js"],"split":"hard"}
+{"id":"axios-h003","query":"decide fulfilled or rejected based on status code","expected_files":["lib/core/settle.js"],"split":"hard"}

--- a/benchmarks/tasks/express.jsonl
+++ b/benchmarks/tasks/express.jsonl
@@ -3,3 +3,6 @@
 {"id":"express-t003","query":"parse incoming request path params query string","expected_files":["lib/request.js"]}
 {"id":"express-t004","query":"define router group nested routes use method","expected_files":["lib/application.js","lib/express.js"]}
 {"id":"express-t005","query":"render template view engine lookup","expected_files":["lib/view.js","lib/application.js"]}
+{"id":"express-h001","query":"why does my middleware chain stop when a handler throws","expected_files":["lib/application.js"],"split":"hard"}
+{"id":"express-h002","query":"where are template engines registered and pages rendered","expected_files":["lib/view.js","lib/application.js"],"split":"hard"}
+{"id":"express-h003","query":"how does the framework decide which content type the client accepts","expected_files":["lib/request.js"],"split":"hard"}

--- a/benchmarks/tasks/fastify.jsonl
+++ b/benchmarks/tasks/fastify.jsonl
@@ -3,3 +3,6 @@
 {"id":"fastify-t003","query":"reply send status headers serialization","expected_files":["lib/reply.js"]}
 {"id":"fastify-t004","query":"hook lifecycle onRequest preHandler onResponse","expected_files":["lib/hooks.js"]}
 {"id":"fastify-t005","query":"custom content type parser and body parsing","expected_files":["lib/content-type-parser.js"]}
+{"id":"fastify-h001","query":"lifecycle callbacks that run around each incoming call","expected_files":["lib/hooks.js"],"split":"hard"}
+{"id":"fastify-h002","query":"what happens when no registered path matches the url","expected_files":["lib/four-oh-four.js"],"split":"hard"}
+{"id":"fastify-h003","query":"turn request body text into an object by mime","expected_files":["lib/content-type-parser.js"],"split":"hard"}

--- a/benchmarks/tasks/flask.jsonl
+++ b/benchmarks/tasks/flask.jsonl
@@ -3,3 +3,6 @@
 {"id":"flask-t003","query":"blueprint register endpoints url prefix","expected_files":["src/flask/blueprints.py","src/flask/sansio/blueprints.py"]}
 {"id":"flask-t004","query":"session interface cookie signing open save","expected_files":["src/flask/sessions.py"]}
 {"id":"flask-t005","query":"render template Jinja2 template_rendered signal","expected_files":["src/flask/templating.py","src/flask/signals.py"]}
+{"id":"flask-h001","query":"keep user data across browser visits with a signed cookie","expected_files":["src/flask/sessions.py"],"split":"hard"}
+{"id":"flask-h002","query":"modular pieces of an application registered under a url prefix","expected_files":["src/flask/blueprints.py"],"split":"hard"}
+{"id":"flask-h003","query":"current request object accessible anywhere during handling","expected_files":["src/flask/ctx.py","src/flask/globals.py"],"split":"hard"}

--- a/benchmarks/tasks/gin.jsonl
+++ b/benchmarks/tasks/gin.jsonl
@@ -3,3 +3,6 @@
 {"id":"gin-t003","query":"request context abort next handler","expected_files":["context.go"]}
 {"id":"gin-t004","query":"render response JSON XML HTML template","expected_files":["render/json.go","render/html.go","context.go"]}
 {"id":"gin-t005","query":"recovery middleware panic handler logger","expected_files":["recovery.go","logger.go"]}
+{"id":"gin-h001","query":"match incoming url path segments with wildcards efficiently","expected_files":["tree.go"],"split":"hard"}
+{"id":"gin-h002","query":"shared prefix grouping of endpoint registrations","expected_files":["routergroup.go"],"split":"hard"}
+{"id":"gin-h003","query":"restrict access with username password challenge","expected_files":["auth.go"],"split":"hard"}

--- a/gen-context.js
+++ b/gen-context.js
@@ -4101,6 +4101,93 @@ __factories["./src/eval/analyzer"] = function(module, exports) {
   
 };
 
+// ── ./src/eval/corpus ──
+__factories["./src/eval/corpus"] = function(module, exports) {
+  
+  /**
+   * Task-corpus hygiene (A3, v8.22 "Hard Corpus").
+   *
+   * A benchmark query "leaks" when it shares a token with the basenames of its
+   * expected files — hit@5 then partly measures filename matching, not
+   * retrieval. The criterion is deterministic and reuses the production
+   * tokenizer (identifier splitting + stemming from src/retrieval/bm25.js), so
+   * "payments" leaks against payment.js and "InterceptorManager" leaks against
+   * "interceptor manager" the same way the ranker would see them.
+   *
+   * Tasks carry an optional `split` field: 'hard' tasks MUST be leak-free
+   * (validateTasks reports them as violations); 'easy' tasks (the default) may
+   * leak — that is what makes them easy.
+   *
+   * Size buckets group repos by indexed file count so large repos stop being
+   * averaged away by tiny ones. Thresholds are the rough tertiles of the
+   * current benchmarks/repos corpus (43 repos, 27–3450 source files).
+   */
+
+  const { tokenize } = __require('./src/retrieval/bm25');
+
+  const BUCKET_LIMITS = { small: 200, medium: 1000 }; // files; large = above medium
+
+  /**
+   * Stemmed tokens of a file path's basename (extension stripped).
+   * @param {string} filePath
+   * @returns {string[]}
+   */
+  function basenameTokens(filePath) {
+    const base = String(filePath).split('/').pop() || '';
+    return tokenize(base.replace(/\.[^.]*$/, ''));
+  }
+
+  /**
+   * Leaked tokens between a query and its expected files' basenames.
+   * @param {string} query
+   * @param {string[]} expectedFiles
+   * @returns {{ leaked: string[], clean: boolean }}
+   */
+  function queryLeakage(query, expectedFiles) {
+    const qToks = new Set(tokenize(query));
+    const leaked = new Set();
+    for (const f of expectedFiles || []) {
+      for (const t of basenameTokens(f)) {
+        if (qToks.has(t)) leaked.add(t);
+      }
+    }
+    return { leaked: [...leaked].sort(), clean: leaked.size === 0 };
+  }
+
+  /**
+   * Validate a task list: every task gets a leakage result; hard-split tasks
+   * that leak are violations.
+   * @param {Array<{id?:string, query:string, expected_files?:string[], split?:string}>} tasks
+   * @returns {{ results: object[], hardViolations: object[] }}
+   */
+  function validateTasks(tasks) {
+    const results = [];
+    const hardViolations = [];
+    for (const t of tasks || []) {
+      const split = t.split === 'hard' ? 'hard' : 'easy';
+      const { leaked, clean } = queryLeakage(t.query, t.expected_files);
+      const row = { id: t.id || '?', split, leaked, clean };
+      results.push(row);
+      if (split === 'hard' && !clean) hardViolations.push(row);
+    }
+    return { results, hardViolations };
+  }
+
+  /**
+   * Size bucket for a repo by indexed file count.
+   * @param {number} fileCount
+   * @returns {'small'|'medium'|'large'}
+   */
+  function sizeBucket(fileCount) {
+    if (fileCount < BUCKET_LIMITS.small) return 'small';
+    if (fileCount <= BUCKET_LIMITS.medium) return 'medium';
+    return 'large';
+  }
+
+  module.exports = { basenameTokens, queryLeakage, validateTasks, sizeBucket, BUCKET_LIMITS };
+  
+};
+
 // ── ./src/eval/llm-ablation ──
 __factories["./src/eval/llm-ablation"] = function(module, exports) {
   
@@ -4400,7 +4487,7 @@ __factories["./src/eval/runner"] = function(module, exports) {
 
   /**
    * Load tasks from a JSONL file.
-   * Each line: { id, query, expected_files, repo }
+   * Each line: { id, query, expected_files, repo, split? ('easy'|'hard') }
    * Invalid or blank lines are silently skipped.
    * @param {string} tasksFile - absolute or relative path
    * @returns {Array<{id:string, query:string, expected:string[], repo:string}>}
@@ -4420,6 +4507,7 @@ __factories["./src/eval/runner"] = function(module, exports) {
             query: obj.query,
             expected: obj.expected_files,
             repo: obj.repo || '.',
+            split: obj.split === 'hard' ? 'hard' : 'easy',
           });
         }
       } catch {

--- a/scripts/run-honest-benchmark.mjs
+++ b/scripts/run-honest-benchmark.mjs
@@ -45,6 +45,7 @@ const JSON_OUT = process.argv.includes('--json');
 const runner = require(path.join(ROOT, 'src', 'eval', 'runner.js'));
 const scorer = require(path.join(ROOT, 'src', 'eval', 'scorer.js'));
 const { STOP } = require(path.join(ROOT, 'src', 'retrieval', 'bm25.js'));
+const { sizeBucket } = require(path.join(ROOT, 'src', 'eval', 'corpus.js'));
 
 // Dirs a grep agent never scans (ripgrep skips VCS + honors .gitignore).
 const SKIP_DIRS = new Set([
@@ -89,12 +90,16 @@ function countOccurrences(haystack, needle) {
 
 /**
  * Scan a repo once and rank files for every task's term set.
- * @returns {Map<string, string[]>} task id → top-10 relative file paths
+ * @returns {{ ranked: Map<string, string[]>, filesScanned: number }}
+ *   ranked: task id → top-10 relative file paths; filesScanned: repo size
+ *   basis for the A3 bucket (files the scan visited — NOT the budget-capped
+ *   context index, which measures maxTokens rather than the repo).
  */
 function grepRank(repoPath, tasks) {
   const perTask = new Map(tasks.map((t) => [t.id, new Map()])); // id → file → {cover, occ}
   const termSets = tasks.map((t) => ({ id: t.id, terms: terms(t.query) }));
   const ignored = gitignoreDirs(repoPath);
+  let filesScanned = 0;
 
   const walk = (dir) => {
     let entries;
@@ -108,6 +113,7 @@ function grepRank(repoPath, tasks) {
         continue;
       }
       if (!e.isFile()) continue;
+      filesScanned++;
       let buf;
       try {
         if (fs.statSync(full).size > MAX_FILE_BYTES) continue;
@@ -138,7 +144,7 @@ function grepRank(repoPath, tasks) {
       .slice(0, 10)
       .map(([file]) => file));
   }
-  return ranked;
+  return { ranked, filesScanned };
 }
 
 function loadTasks(file) {
@@ -152,6 +158,19 @@ const skipped = [];
 let nTasks = 0;
 const totals = { sigHit: 0, grepHit: 0, sigMrr: 0, grepMrr: 0 };
 
+// A3: per-split (easy/hard) and per-repo-size-bucket accumulators.
+const newAcc = () => ({ n: 0, sigHit: 0, grepHit: 0, sigMrr: 0, grepMrr: 0 });
+const splits = { easy: newAcc(), hard: newAcc() };
+const buckets = { small: newAcc(), medium: newAcc(), large: newAcc() };
+const accAdd = (acc, sigH, grepH, sigRr, grepRr) => {
+  acc.n++; acc.sigHit += sigH; acc.grepHit += grepH; acc.sigMrr += sigRr; acc.grepMrr += grepRr;
+};
+const accSummary = (acc) => (acc.n === 0 ? null : {
+  tasks: acc.n,
+  sigmap: { hitAt5: round(acc.sigHit / acc.n), mrr: round(acc.sigMrr / acc.n) },
+  grepBaseline: { hitAt5: round(acc.grepHit / acc.n), mrr: round(acc.grepMrr / acc.n) },
+});
+
 for (const f of taskFiles) {
   const name = f.replace('.jsonl', '');
   const repoPath = name === 'retrieval' ? ROOT : path.join(REPOS_DIR, name);
@@ -164,24 +183,33 @@ for (const f of taskFiles) {
   }
 
   const tasks = loadTasks(path.join(TASKS_DIR, f));
-  const grepRanked = grepRank(repoPath, tasks);
+  const { ranked: grepRanked, filesScanned } = grepRank(repoPath, tasks);
 
+  const bucket = sizeBucket(filesScanned);
   const row = { repo: name, tasks: tasks.length, sigHit: 0, grepHit: 0 };
   for (const t of tasks) {
     const expected = t.expected_files || [];
+    const split = t.split === 'hard' ? 'hard' : 'easy';
     const sig = runner.rank(t.query, sigIndex, 10).map((r) => r.file);
     const grep = grepRanked.get(t.id) || [];
-    row.sigHit += scorer.hitAtK(sig, expected, 5);
-    row.grepHit += scorer.hitAtK(grep, expected, 5);
-    totals.sigHit += scorer.hitAtK(sig, expected, 5) ? 1 : 0;
-    totals.grepHit += scorer.hitAtK(grep, expected, 5) ? 1 : 0;
-    totals.sigMrr += scorer.reciprocalRank(sig, expected);
-    totals.grepMrr += scorer.reciprocalRank(grep, expected);
+    const sigH = scorer.hitAtK(sig, expected, 5);
+    const grepH = scorer.hitAtK(grep, expected, 5);
+    const sigRr = scorer.reciprocalRank(sig, expected);
+    const grepRr = scorer.reciprocalRank(grep, expected);
+    row.sigHit += sigH;
+    row.grepHit += grepH;
+    totals.sigHit += sigH ? 1 : 0;
+    totals.grepHit += grepH ? 1 : 0;
+    totals.sigMrr += sigRr;
+    totals.grepMrr += grepRr;
+    accAdd(splits[split], sigH, grepH, sigRr, grepRr);
+    accAdd(buckets[bucket], sigH, grepH, sigRr, grepRr);
     nTasks++;
   }
   perRepo.push({
     repo: name,
     tasks: tasks.length,
+    bucket,
     sigmapHitAt5: round(row.sigHit / tasks.length),
     grepHitAt5: round(row.grepHit / tasks.length),
   });
@@ -210,6 +238,12 @@ const report = {
     grepBaseline: { hitAt5: round(grepHitAt5), mrr: round(totals.grepMrr / nTasks) },
     lift: round(grepHitAt5 > 0 ? sigHitAt5 / grepHitAt5 : 0, 2),
     deltaPts: round((sigHitAt5 - grepHitAt5) * 100, 1),
+    splits: { easy: accSummary(splits.easy), hard: accSummary(splits.hard) },
+    buckets: {
+      small: accSummary(buckets.small),
+      medium: accSummary(buckets.medium),
+      large: accSummary(buckets.large),
+    },
   },
   repos: perRepo,
   skipped,
@@ -228,6 +262,13 @@ if (JSON_OUT) {
   console.log(`\n  SigMap        hit@5 ${(s.sigmap.hitAt5 * 100).toFixed(1)}%   MRR ${s.sigmap.mrr.toFixed(3)}`);
   console.log(`  grep baseline hit@5 ${(s.grepBaseline.hitAt5 * 100).toFixed(1)}%   MRR ${s.grepBaseline.mrr.toFixed(3)}`);
   console.log(`  honest lift   ${s.lift}×  (+${s.deltaPts}pt over ${s.tasks} tasks, ${s.repos} repos)`);
+  const line = (label, a) => a && console.log(
+    `  ${label.padEnd(13)} hit@5 ${(a.sigmap.hitAt5 * 100).toFixed(1)}%  MRR ${a.sigmap.mrr.toFixed(3)}  vs grep ${(a.grepBaseline.hitAt5 * 100).toFixed(1)}%  (${a.tasks} tasks)`);
+  line('split easy', s.splits.easy);
+  line('split hard', s.splits.hard);
+  line('repos small', s.buckets.small);
+  line('repos medium', s.buckets.medium);
+  line('repos large', s.buckets.large);
   for (const sk of skipped) console.log(`  [skipped] ${sk.repo}: ${sk.reason}`);
 }
 

--- a/scripts/validate-task-corpus.mjs
+++ b/scripts/validate-task-corpus.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * validate-task-corpus.mjs — leakage gate for benchmarks/tasks/*.jsonl (A3).
+ *
+ * A hard-split task whose query shares a stemmed token with an expected file's
+ * basename is a violation: the "hard" label would be a lie. Easy-split leakage
+ * is reported as information only — easy tasks are allowed to leak.
+ *
+ *   node scripts/validate-task-corpus.mjs           # table; exit 1 on hard violations
+ *   node scripts/validate-task-corpus.mjs --json    # report JSON to stdout
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const TASKS_DIR = path.join(ROOT, 'benchmarks', 'tasks');
+
+const JSON_OUT = process.argv.includes('--json');
+
+const { validateTasks } = require(path.join(ROOT, 'src', 'eval', 'corpus.js'));
+
+const files = fs.readdirSync(TASKS_DIR).filter((f) => f.endsWith('.jsonl')).sort();
+const report = { files: [], totals: { tasks: 0, hard: 0, hardViolations: 0, easyLeaky: 0 } };
+
+for (const f of files) {
+  const tasks = fs.readFileSync(path.join(TASKS_DIR, f), 'utf8')
+    .split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  const { results, hardViolations } = validateTasks(tasks);
+  const easyLeaky = results.filter((r) => r.split === 'easy' && !r.clean).length;
+  const hard = results.filter((r) => r.split === 'hard').length;
+  report.files.push({ file: f, tasks: results.length, hard, hardViolations, easyLeaky });
+  report.totals.tasks += results.length;
+  report.totals.hard += hard;
+  report.totals.hardViolations += hardViolations.length;
+  report.totals.easyLeaky += easyLeaky;
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log('\n  task file                  tasks  hard  hard-violations  easy-leaky');
+  console.log('  -------------------------  -----  ----  ---------------  ----------');
+  for (const r of report.files) {
+    console.log(`  ${r.file.padEnd(25)} ${String(r.tasks).padStart(6)} ${String(r.hard).padStart(5)}  ${String(r.hardViolations.length).padStart(15)}  ${String(r.easyLeaky).padStart(10)}`);
+    for (const v of r.hardViolations) {
+      console.log(`      LEAK ${v.id}: [${v.leaked.join(', ')}]`);
+    }
+  }
+  const t = report.totals;
+  console.log(`\n  ${t.tasks} tasks · ${t.hard} hard · ${t.hardViolations} hard violation(s) · ${t.easyLeaky} easy task(s) leak (allowed)`);
+}
+
+process.exit(report.totals.hardViolations > 0 ? 1 : 0);

--- a/src/eval/corpus.js
+++ b/src/eval/corpus.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * Task-corpus hygiene (A3, v8.22 "Hard Corpus").
+ *
+ * A benchmark query "leaks" when it shares a token with the basenames of its
+ * expected files — hit@5 then partly measures filename matching, not
+ * retrieval. The criterion is deterministic and reuses the production
+ * tokenizer (identifier splitting + stemming from src/retrieval/bm25.js), so
+ * "payments" leaks against payment.js and "InterceptorManager" leaks against
+ * "interceptor manager" the same way the ranker would see them.
+ *
+ * Tasks carry an optional `split` field: 'hard' tasks MUST be leak-free
+ * (validateTasks reports them as violations); 'easy' tasks (the default) may
+ * leak — that is what makes them easy.
+ *
+ * Size buckets group repos by indexed file count so large repos stop being
+ * averaged away by tiny ones. Thresholds are the rough tertiles of the
+ * current benchmarks/repos corpus (43 repos, 27–3450 source files).
+ */
+
+const { tokenize } = require('../retrieval/bm25');
+
+const BUCKET_LIMITS = { small: 200, medium: 1000 }; // files; large = above medium
+
+/**
+ * Stemmed tokens of a file path's basename (extension stripped).
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+function basenameTokens(filePath) {
+  const base = String(filePath).split('/').pop() || '';
+  return tokenize(base.replace(/\.[^.]*$/, ''));
+}
+
+/**
+ * Leaked tokens between a query and its expected files' basenames.
+ * @param {string} query
+ * @param {string[]} expectedFiles
+ * @returns {{ leaked: string[], clean: boolean }}
+ */
+function queryLeakage(query, expectedFiles) {
+  const qToks = new Set(tokenize(query));
+  const leaked = new Set();
+  for (const f of expectedFiles || []) {
+    for (const t of basenameTokens(f)) {
+      if (qToks.has(t)) leaked.add(t);
+    }
+  }
+  return { leaked: [...leaked].sort(), clean: leaked.size === 0 };
+}
+
+/**
+ * Validate a task list: every task gets a leakage result; hard-split tasks
+ * that leak are violations.
+ * @param {Array<{id?:string, query:string, expected_files?:string[], split?:string}>} tasks
+ * @returns {{ results: object[], hardViolations: object[] }}
+ */
+function validateTasks(tasks) {
+  const results = [];
+  const hardViolations = [];
+  for (const t of tasks || []) {
+    const split = t.split === 'hard' ? 'hard' : 'easy';
+    const { leaked, clean } = queryLeakage(t.query, t.expected_files);
+    const row = { id: t.id || '?', split, leaked, clean };
+    results.push(row);
+    if (split === 'hard' && !clean) hardViolations.push(row);
+  }
+  return { results, hardViolations };
+}
+
+/**
+ * Size bucket for a repo by indexed file count.
+ * @param {number} fileCount
+ * @returns {'small'|'medium'|'large'}
+ */
+function sizeBucket(fileCount) {
+  if (fileCount < BUCKET_LIMITS.small) return 'small';
+  if (fileCount <= BUCKET_LIMITS.medium) return 'medium';
+  return 'large';
+}
+
+module.exports = { basenameTokens, queryLeakage, validateTasks, sizeBucket, BUCKET_LIMITS };

--- a/src/eval/runner.js
+++ b/src/eval/runner.js
@@ -124,7 +124,7 @@ function estimateTokens(sigs) {
 
 /**
  * Load tasks from a JSONL file.
- * Each line: { id, query, expected_files, repo }
+ * Each line: { id, query, expected_files, repo, split? ('easy'|'hard') }
  * Invalid or blank lines are silently skipped.
  * @param {string} tasksFile - absolute or relative path
  * @returns {Array<{id:string, query:string, expected:string[], repo:string}>}
@@ -144,6 +144,7 @@ function loadTasks(tasksFile) {
           query: obj.query,
           expected: obj.expected_files,
           repo: obj.repo || '.',
+          split: obj.split === 'hard' ? 'hard' : 'easy',
         });
       }
     } catch {

--- a/test/integration/hard-corpus.test.js
+++ b/test/integration/hard-corpus.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Integration tests for the A3 hard-corpus tooling (v8.22).
+ *
+ * Tests:
+ *  1.  corpus.queryLeakage — direct token overlap is flagged
+ *  2.  corpus.queryLeakage — stemmed overlap is flagged (payments vs payment.js)
+ *  3.  corpus.queryLeakage — camelCase basename splitting is flagged
+ *  4.  corpus.queryLeakage — disjoint query/basenames is clean
+ *  5.  corpus.validateTasks — leaky hard task is a violation, leaky easy task is not
+ *  6.  runner.loadTasks — split field passthrough ('hard' kept, absent → 'easy')
+ *  7.  corpus.sizeBucket — thresholds at 200 and 1000
+ *  8.  validate-task-corpus.mjs — exits 0 on the committed corpus
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+const corpus = require(path.join(ROOT, 'src', 'eval', 'corpus'));
+const runner = require(path.join(ROOT, 'src', 'eval', 'runner'));
+
+console.log('[hard-corpus.test.js] A3 hard-corpus: leakage gate, splits, buckets');
+console.log('');
+
+test('queryLeakage flags direct token overlap', () => {
+  const r = corpus.queryLeakage('parse time zone offsets', ['absl/time/time.h']);
+  assert.strictEqual(r.clean, false);
+  assert.ok(r.leaked.includes('time'), `leaked=${r.leaked}`);
+});
+
+test('queryLeakage flags stemmed overlap', () => {
+  const r = corpus.queryLeakage('handle failed payments', ['lib/payment.js']);
+  assert.strictEqual(r.clean, false, 'stemming should equate payments/payment');
+});
+
+test('queryLeakage flags camelCase basename tokens', () => {
+  const r = corpus.queryLeakage('interceptor chains', ['lib/core/InterceptorManager.js']);
+  assert.strictEqual(r.clean, false);
+  assert.ok(r.leaked.includes('interceptor'), `leaked=${r.leaked}`);
+});
+
+test('queryLeakage clean when disjoint', () => {
+  const r = corpus.queryLeakage('decide fulfilled or rejected based on status code', ['lib/core/settle.js']);
+  assert.strictEqual(r.clean, true);
+  assert.deepStrictEqual(r.leaked, []);
+});
+
+test('validateTasks: hard leak is a violation, easy leak is not', () => {
+  const { results, hardViolations } = corpus.validateTasks([
+    { id: 'a', query: 'session cookie', expected_files: ['sessions.py'], split: 'hard' },
+    { id: 'b', query: 'session cookie', expected_files: ['sessions.py'] },
+  ]);
+  assert.strictEqual(results.length, 2);
+  assert.strictEqual(hardViolations.length, 1);
+  assert.strictEqual(hardViolations[0].id, 'a');
+});
+
+test('loadTasks passes split through, defaults to easy', () => {
+  const tmp = path.join(os.tmpdir(), `sigmap-hard-corpus-${process.pid}.jsonl`);
+  fs.writeFileSync(tmp, [
+    JSON.stringify({ id: 't1', query: 'q one', expected_files: ['a.js'], split: 'hard' }),
+    JSON.stringify({ id: 't2', query: 'q two', expected_files: ['b.js'] }),
+  ].join('\n'));
+  try {
+    const tasks = runner.loadTasks(tmp);
+    assert.strictEqual(tasks[0].split, 'hard');
+    assert.strictEqual(tasks[1].split, 'easy');
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('sizeBucket thresholds', () => {
+  assert.strictEqual(corpus.sizeBucket(199), 'small');
+  assert.strictEqual(corpus.sizeBucket(200), 'medium');
+  assert.strictEqual(corpus.sizeBucket(1000), 'medium');
+  assert.strictEqual(corpus.sizeBucket(1001), 'large');
+});
+
+test('validate-task-corpus.mjs exits 0 on committed corpus', () => {
+  const r = spawnSync(process.execPath, [path.join(ROOT, 'scripts', 'validate-task-corpus.mjs')], { encoding: 'utf8' });
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`);
+  assert.ok(/0 hard violation/.test(r.stdout), r.stdout);
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('');
+console.log(`[hard-corpus.test.js] ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 20,
-  "tests": 127,
+  "tests": 128,
   "metrics": {
     "hit_at_5": 0.856,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #505. Implements plan v2 item **A3** (v8.22 "Hard Corpus").

## What
- **`src/eval/corpus.js`** — deterministic leakage criterion: a task leaks when its BM25-tokenized query shares a stemmed token with the tokenized basenames of its expected files. Plus `validateTasks` and `sizeBucket` (thresholds 200/1000 = tertiles of the current 43-repo corpus).
- **`scripts/validate-task-corpus.mjs`** — CI-gateable: exits 1 if any `split: hard` task leaks; easy-split leakage reported as info.
- **`loadTasks`** carries the optional `split` field (default `easy`).
- **`benchmark:honest`** now reports hit@5/MRR per split and per repo-size bucket. Buckets use files scanned on disk — *not* `sigIndex.size`, which measures the token budget, not the repo (deviation from the issue text, for correctness).
- **15 hard tasks** (3 each: express, flask, axios, fastify, gin), all verified leak-free and pointing at real files.

## Measured (honest harness, this branch)
| Split | SigMap hit@5 | grep baseline |
|---|---|---|
| easy (110) | 78.2% | 43.6% |
| **hard (15)** | **33.3%** | **53.3%** |

The hard split does its job: with filename leakage removed, the grep baseline currently *beats* SigMap — the measured vocabulary-mismatch ceiling that B2 (repo-mined expansion, v9.0) is scheduled to attack. 90 of 110 pre-existing easy tasks leak.

## Also
- Bundle regenerated (`build:bundle`) — heals pre-existing bundle-repro drift on develop; version.json test count synced (128).
- Full suite: **122 passed, 0 failed** (was 119/3 on develop before the bundle/version heal).
- Supply-chain local audit: no shell spawns · no install scripts · `main` exports API · no fingerprinting · tarball 563KB/162 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)