### PR TITLE
feat(tracking,mcp): sigmap budget — session spend ledger + get_budget (F1, v8.23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use SigMap with open-source tools and fully self-hosted setups:
 | **JetBrains** | [Marketplace](https://plugins.jetbrains.com/plugin/31109-sigmap--ai-context-engine/) | [github.com/manojmallick/sigmap-jetbrains](https://github.com/manojmallick/sigmap-jetbrains) | IntelliJ IDEA, WebStorm, PyCharm, GoLand — tool window + actions |
 | **Neovim** | lazy.nvim / packer / vim-plug | [github.com/manojmallick/sigmap.nvim](https://github.com/manojmallick/sigmap.nvim) | `:SigMap`, `:SigMapQuery` float window, statusline widget |
 
-**MCP server** — 20 on-demand tools for Claude Code and Cursor:
+**MCP server** — 21 on-demand tools for Claude Code and Cursor:
 
 ```bash
 sigmap --mcp
@@ -269,7 +269,7 @@ SigMap treats coding agents as **consumers, not competitors**: it hands them a d
 
 | Agent | One-time setup | How it consumes SigMap |
 |---|---|---|
-| **Claude Code** | `sigmap mcp install claude` | 20 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`, `squeeze_output`…) |
+| **Claude Code** | `sigmap mcp install claude` | 21 MCP tools (`search_signatures`, `get_lines`, `get_diff_context`, `squeeze_output`…) |
 | **Cursor** | `sigmap mcp install cursor` | MCP tools, plus the `cursor` adapter writes `.cursorrules` |
 | **Cline** | `sigmap mcp install cursor` | Reads `.cursorrules`; same MCP server |
 | **Continue** | `sigmap mcp install vscode` | MCP tools inside the Continue extension |

--- a/docs-vp/guide/mcp.md
+++ b/docs-vp/guide/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP server setup
-description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 20 tools over stdio. Zero npm install.
+description: Set up the SigMap MCP server for Claude Code, Cursor, and Windsurf. On-demand codebase access with 21 tools over stdio. Zero npm install.
 head:
   - - meta
     - property: og:title
@@ -22,7 +22,7 @@ head:
 
 Give Claude Code, Cursor, and Windsurf on-demand access to your codebase signatures. Zero npm install.
 
-The SigMap MCP server exposes 20 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
+The SigMap MCP server exposes 21 tools over the stdio Model Context Protocol. Your AI agent calls only what it needs — keeping token costs low.
 
 > **Setup time: under 2 minutes.** Use `sigmap --setup` for automatic configuration.
 
@@ -99,7 +99,7 @@ Stack both MCP servers for the two-layer context strategy — SigMap for always-
 ## 11 available tools
 
 ::: tip New in v6.3.0 — native tool registration
-Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 20 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
+Claude Code and Codex now receive the full tool list at MCP startup without a discovery round-trip. The server declares all 21 tools in the `initialize` response, so your AI sees them immediately. No config change needed — upgrade via `npm install -g sigmap@latest`.
 :::
 
 All tools are available on-demand — your AI agent calls only what it needs.

--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task-success proxy (modeled) | — | 64.8% |
 | Prompts per task | 2.84 | 1.53 (46.1% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 20 |
+| MCP tools | — | 21 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -125,6 +125,8 @@ sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to 
 sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
 sigmap memory                            List cross-session stores (.context/) — entries, size, age
 sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
+sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
+sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
@@ -138,7 +140,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 20 tools
+## MCP server — 21 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -306,6 +308,14 @@ Compress noisy tool, command, or agent output before it enters context — a sta
 Input:  { content: string }
 ```
 
+### get_budget
+
+Session spend ledger — estimated tokens SigMap has emitted this session (chars/4 estimates from the local gain log), optional budget remaining, and context freshness. Scope honesty: counts only SigMap output, NOT the whole chat's spend. Check this mid-session and degrade gracefully when near budget: prefer terse encoding, squeeze large outputs, summarize-then-drop context. Local-only; no LLM, no network.
+
+```
+Input:  { session?: string, budgetTokens?: number }
+```
+
 ---
 
 ## Configuration (gen-context.config.json)
@@ -334,6 +344,8 @@ watchDebounce = 300
 routing = false
 format = default
 tracking = false
+sessionBudgetTokens = null
+contextTtlDays = null
 mcp = {"autoRegister":true}
 depMap = true
 versionPins = true

--- a/docs-vp/public/llms.txt
+++ b/docs-vp/public/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 96.8% average across benchmark repos
 - Task-success proxy: 64.8% (modeled from retrieval tiers, not measured LLM sessions)
 - Prompts per task: 1.53 vs 2.84 baseline (46.1% fewer, modeled)
-- Languages: 33 supported · MCP tools: 20
+- Languages: 33 supported · MCP tools: 21
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/gen-context.js
+++ b/gen-context.js
@@ -1490,6 +1490,14 @@ __factories["./src/config/defaults"] = function(module, exports) {
     // Append run metrics to .context/usage.ndjson after each generate
     tracking: false,
 
+    // Session spend ledger (`sigmap budget` / MCP get_budget). Estimates only —
+    // counts tokens SigMap emitted (chars/4), not the host chat's total spend.
+    // Number → warn threshold for estimated SigMap-emitted tokens per session.
+    sessionBudgetTokens: null,
+
+    // Number of days before generated context counts as stale in budget output.
+    contextTtlDays: null,
+
     // MCP server configuration
     mcp: {
       autoRegister: true,
@@ -14375,6 +14383,41 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
   }
 
   /**
+   * get_budget({ session?, budgetTokens? }) → string
+   *
+   * Session spend ledger (F1): estimated tokens SigMap emitted this session,
+   * optional budget remaining, and context freshness. Estimates only (chars/4);
+   * does NOT see the host chat's total spend.
+   */
+  function getBudget(args, cwd) {
+    const { budgetStatus } = __require('./src/tracking/budget');
+    let config = {};
+    try { config = __require('./src/config/loader').loadConfig(cwd) || {}; } catch (_) {}
+    const opts = { config };
+    if (args && args.session) opts.session = String(args.session);
+    if (args && args.budgetTokens != null) opts.budgetTokens = Number(args.budgetTokens);
+    const s = budgetStatus(cwd, opts);
+
+    const out = ['# SigMap session spend (estimates — chars/4; SigMap-emitted tokens only)'];
+    out.push('');
+    out.push(`Session   : ${s.session}`);
+    out.push(`Ops       : ${s.ops}`);
+    out.push(`Spent     : ~${s.spentTokens.toLocaleString()} tokens (baseline ~${s.baselineTokens.toLocaleString()}, saved ~${s.savedTokens.toLocaleString()})`);
+    if (s.budgetTokens != null) {
+      out.push(`Budget    : ${s.budgetTokens.toLocaleString()} → remaining ~${s.remainingTokens.toLocaleString()} (${s.pctUsed}% used)${s.overBudget ? '  ⚠ OVER BUDGET' : ''}`);
+      if (s.overBudget || (s.pctUsed != null && s.pctUsed >= 80)) {
+        out.push('Advice    : prefer terse output, squeeze large inputs, summarize-then-drop context.');
+      }
+    } else {
+      out.push('Budget    : none set (config sessionBudgetTokens or budgetTokens arg)');
+    }
+    out.push(s.context.exists
+      ? `Context   : ${s.context.ageDays} day(s) old${s.context.stale ? ` — STALE (> ${s.context.ttlDays}d TTL); re-run sigmap` : ''}`
+      : 'Context   : no generated context found — run sigmap first');
+    return out.join('\n');
+  }
+
+  /**
    * get_callee_signatures — return the exact defining signature(s) of named
    * symbols from the index, so an agent never guesses a callee's parameter types.
    * Unknown names get a closest-match suggestion.
@@ -14767,7 +14810,7 @@ __factories["./src/mcp/handlers"] = function(module, exports) {
     return header + sq.squeezed;
   }
 
-  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
+  module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput, getBudget };
   
 };
 
@@ -14934,7 +14977,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
 
   const readline = require('readline');
   const { TOOLS } = __require('./src/mcp/tools');
-  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = __require('./src/mcp/handlers');
+  const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput, getBudget } = __require('./src/mcp/handlers');
 
   const SERVER_INFO = {
     name: 'sigmap',
@@ -15006,6 +15049,7 @@ __factories["./src/mcp/server"] = function(module, exports) {
         else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
         else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
         else if (name === 'squeeze_output') text = squeezeOutput(args, cwd);
+        else if (name === 'get_budget') text = getBudget(args, cwd);
         else {
           respondError(id, -32601, `Unknown tool: ${name}`);
           return;
@@ -15450,6 +15494,32 @@ __factories["./src/mcp/tools"] = function(module, exports) {
           },
         },
         required: ['content'],
+      },
+    },
+    {
+      name: 'get_budget',
+      description:
+        'Session spend ledger — estimated tokens SigMap has emitted this session ' +
+        '(chars/4 estimates from the local gain log), optional budget remaining, and ' +
+        'context freshness. Scope honesty: counts only SigMap output, NOT the whole ' +
+        "chat's spend. Check this mid-session and degrade gracefully when near budget: " +
+        'prefer terse encoding, squeeze large outputs, summarize-then-drop context. ' +
+        'Local-only; no LLM, no network.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          session: {
+            type: 'string',
+            description:
+              'Session key to report on (default: SIGMAP_SESSION env or the UTC day bucket).',
+          },
+          budgetTokens: {
+            type: 'number',
+            description:
+              'Budget override in estimated tokens (default: config sessionBudgetTokens).',
+          },
+        },
+        required: [],
       },
     },
   ];
@@ -18408,6 +18478,123 @@ __factories["./src/tracking/aggregate"] = function(module, exports) {
   
 };
 
+// ── ./src/tracking/budget ──
+__factories["./src/tracking/budget"] = function(module, exports) {
+  
+  /**
+   * Session spend ledger (v8.23 F1) — a queryable view over the existing gain
+   * log (.context/gain.ndjson, written by recordUsage).
+   *
+   * Honesty scope: this ledger counts tokens **SigMap emitted** (chars/4
+   * estimates), not the host chat's total spend — conversation history, model
+   * output, and other tools are invisible to a CLI. Every number here is an
+   * estimate and is labeled as such in output.
+   *
+   * Session identity: `SIGMAP_SESSION` env var when the host sets one, else a
+   * UTC day bucket (YYYY-MM-DD). Legacy gain entries (written before the
+   * `session` field existed) match day-bucket sessions by timestamp prefix.
+   *
+   * Zero dependencies; local JSON only.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { readGainLog } = __require('./src/tracking/logger');
+
+  // Same generated-context surfaces cache/freshen.js watches.
+  const CONTEXT_PATHS = [
+    ['.github', 'copilot-instructions.md'],
+    ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+  ];
+
+  /** Session key: SIGMAP_SESSION override, else UTC day bucket. */
+  function sessionKey(env) {
+    const e = env || process.env;
+    if (e.SIGMAP_SESSION) return String(e.SIGMAP_SESSION);
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  /** Newest mtime (ms) among generated context files, or 0 if none exist. */
+  function contextMtime(cwd) {
+    let newest = 0;
+    for (const parts of CONTEXT_PATHS) {
+      try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+    }
+    return newest;
+  }
+
+  /** Does a gain-log entry belong to this session? */
+  function entryInSession(entry, session) {
+    if (entry.session) return entry.session === session;
+    // Legacy entry: match day-bucket sessions on the timestamp date.
+    return /^\d{4}-\d{2}-\d{2}$/.test(session) && String(entry.ts || '').startsWith(session);
+  }
+
+  /**
+   * Session spend status.
+   * @param {string} cwd
+   * @param {object} [opts]
+   * @param {string} [opts.session]          session key (default: sessionKey())
+   * @param {number} [opts.budgetTokens]     budget override (else config sessionBudgetTokens)
+   * @param {number} [opts.contextTtlDays]   TTL override (else config contextTtlDays)
+   * @param {object} [opts.config]           loaded config (for the two keys above)
+   * @param {number} [opts.now]              clock override for tests (ms)
+   * @returns {{
+   *   session: string, unit: 'estimated-tokens', ops: number,
+   *   spentTokens: number, baselineTokens: number, savedTokens: number,
+   *   budgetTokens: number|null, remainingTokens: number|null, pctUsed: number|null,
+   *   overBudget: boolean,
+   *   context: { exists: boolean, ageMs: number|null, ageDays: number|null,
+   *              ttlDays: number|null, stale: boolean }
+   * }}
+   */
+  function budgetStatus(cwd, opts = {}) {
+    const session = opts.session || sessionKey();
+    const cfg = opts.config || {};
+    const budget = opts.budgetTokens != null ? Number(opts.budgetTokens)
+      : (Number.isFinite(cfg.sessionBudgetTokens) ? cfg.sessionBudgetTokens : null);
+    const ttlDays = opts.contextTtlDays != null ? Number(opts.contextTtlDays)
+      : (Number.isFinite(cfg.contextTtlDays) ? cfg.contextTtlDays : null);
+    const now = opts.now != null ? opts.now : Date.now();
+
+    let ops = 0, spent = 0, baseline = 0, saved = 0;
+    for (const e of readGainLog(cwd)) {
+      if (!entryInSession(e, session)) continue;
+      ops++;
+      spent += Number(e.actualTokens) || 0;
+      baseline += Number(e.baselineTokens) || 0;
+      saved += Number(e.savedTokens) || 0;
+    }
+
+    const mtime = contextMtime(cwd);
+    const ageMs = mtime > 0 ? Math.max(0, now - mtime) : null;
+    const ageDays = ageMs != null ? ageMs / 86400000 : null;
+
+    return {
+      session,
+      unit: 'estimated-tokens',
+      ops,
+      spentTokens: spent,
+      baselineTokens: baseline,
+      savedTokens: saved,
+      budgetTokens: budget,
+      remainingTokens: budget != null ? Math.max(0, budget - spent) : null,
+      pctUsed: budget > 0 ? Math.round((spent / budget) * 1000) / 10 : null,
+      overBudget: budget != null && spent > budget,
+      context: {
+        exists: mtime > 0,
+        ageMs,
+        ageDays: ageDays != null ? Math.round(ageDays * 10) / 10 : null,
+        ttlDays,
+        stale: ttlDays != null && ageDays != null && ageDays > ttlDays,
+      },
+    };
+  }
+
+  module.exports = { sessionKey, budgetStatus, contextMtime, entryInSession };
+  
+};
+
 // ── ./src/tracking/logger ──
 __factories["./src/tracking/logger"] = function(module, exports) {
   
@@ -18586,10 +18773,12 @@ __factories["./src/tracking/logger"] = function(module, exports) {
       const baseline = Math.max(0, Number(entry.baselineTokens) || 0);
       const actual = Math.max(0, Number(entry.actualTokens) || 0);
       const saved = Math.max(0, baseline - actual);
+      const ts = new Date().toISOString();
       const record = {
-        ts: new Date().toISOString(),
+        ts,
         v: entry.version || '0.9.0',
         op: entry.op || 'generate',
+        session: entry.session || process.env.SIGMAP_SESSION || ts.slice(0, 10),
         baselineTokens: baseline,
         actualTokens: actual,
         savedTokens: saved,
@@ -22043,6 +22232,8 @@ Usage:
   ${cmd} evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
   ${cmd} memory                            List cross-session stores (.context/) — entries, size, age
   ${cmd} memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
+  ${cmd} budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
+  ${cmd} budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -23491,6 +23682,36 @@ function main() {
       console.log(`  ${s.store.padEnd(9)} ${state}${s.clearable ? '' : '   (reset via its own command)'}`);
     }
     console.log('  clear: sigmap memory --clear <session|notes|weights|evidence|all>');
+    process.exit(0);
+  }
+
+  if (args[0] === 'budget') {
+    const jsonOut = args.includes('--json');
+    const { budgetStatus } = requireSourceOrBundled('./src/tracking/budget');
+    let config = {};
+    try { config = requireSourceOrBundled('./src/config/loader').loadConfig(cwd) || {}; } catch (_) {}
+    const opts = { config };
+    const sIdx = args.indexOf('--session');
+    if (sIdx !== -1 && args[sIdx + 1] && !args[sIdx + 1].startsWith('--')) opts.session = args[sIdx + 1];
+    const bIdx = args.indexOf('--budget');
+    if (bIdx !== -1 && args[bIdx + 1] && !args[bIdx + 1].startsWith('--')) opts.budgetTokens = Number(args[bIdx + 1]);
+    const st = budgetStatus(cwd, opts);
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(st) + '\n');
+      process.exit(0);
+    }
+    console.log('[sigmap] session spend (estimates — chars/4; SigMap-emitted tokens only)');
+    console.log(`  session   ${st.session}`);
+    console.log(`  ops       ${st.ops}`);
+    console.log(`  spent     ~${st.spentTokens.toLocaleString()} tokens  (baseline ~${st.baselineTokens.toLocaleString()}, saved ~${st.savedTokens.toLocaleString()})`);
+    if (st.budgetTokens != null) {
+      console.log(`  budget    ${st.budgetTokens.toLocaleString()} → remaining ~${st.remainingTokens.toLocaleString()} (${st.pctUsed}% used)${st.overBudget ? '  ⚠ OVER BUDGET' : ''}`);
+    } else {
+      console.log('  budget    none set (config sessionBudgetTokens or --budget <tokens>)');
+    }
+    console.log(st.context.exists
+      ? `  context   ${st.context.ageDays} day(s) old${st.context.stale ? `  ⚠ STALE (> ${st.context.ttlDays}d TTL) — re-run sigmap` : ''}`
+      : '  context   none generated yet — run sigmap first');
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,7 +26,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 | Task-success proxy (modeled) | — | 64.8% |
 | Prompts per task | 2.84 | 1.53 (46.1% fewer) |
 | Supported languages | — | 33 |
-| MCP tools | — | 20 |
+| MCP tools | — | 21 |
 | npm runtime dependencies | — | 0 |
 
 ---
@@ -125,6 +125,8 @@ sigmap evidence "<query>" --markdown     Emit the Markdown handoff rendering to 
 sigmap evidence "<query>" --top <n> --budget <n> --out <path>   Tune ranked files / token budget / write rendered output
 sigmap memory                            List cross-session stores (.context/) — entries, size, age
 sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
+sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
+sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes
@@ -138,7 +140,7 @@ sigmap --version                         Show version
 
 ---
 
-## MCP server — 20 tools
+## MCP server — 21 tools
 
 Start with `sigmap --mcp` (stdio JSON-RPC). Configure once:
 
@@ -306,6 +308,14 @@ Compress noisy tool, command, or agent output before it enters context — a sta
 Input:  { content: string }
 ```
 
+### get_budget
+
+Session spend ledger — estimated tokens SigMap has emitted this session (chars/4 estimates from the local gain log), optional budget remaining, and context freshness. Scope honesty: counts only SigMap output, NOT the whole chat's spend. Check this mid-session and degrade gracefully when near budget: prefer terse encoding, squeeze large outputs, summarize-then-drop context. Local-only; no LLM, no network.
+
+```
+Input:  { session?: string, budgetTokens?: number }
+```
+
 ---
 
 ## Configuration (gen-context.config.json)
@@ -334,6 +344,8 @@ watchDebounce = 300
 routing = false
 format = default
 tracking = false
+sessionBudgetTokens = null
+contextTtlDays = null
 mcp = {"autoRegister":true}
 depMap = true
 versionPins = true

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Cursor, GitHub Copilot, Aider, Windsurf, local LLMs, and MCP.
 - Token reduction: 96.8% average across benchmark repos
 - Task-success proxy: 64.8% (modeled from retrieval tiers, not measured LLM sessions)
 - Prompts per task: 1.53 vs 2.84 baseline (46.1% fewer, modeled)
-- Languages: 33 supported · MCP tools: 20
+- Languages: 33 supported · MCP tools: 21
 - Dependencies: zero npm runtime dependencies · fully offline
 
 ## Quick start

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -106,6 +106,14 @@ const DEFAULTS = {
   // Append run metrics to .context/usage.ndjson after each generate
   tracking: false,
 
+  // Session spend ledger (`sigmap budget` / MCP get_budget). Estimates only —
+  // counts tokens SigMap emitted (chars/4), not the host chat's total spend.
+  // Number → warn threshold for estimated SigMap-emitted tokens per session.
+  sessionBudgetTokens: null,
+
+  // Number of days before generated context counts as stale in budget output.
+  contextTtlDays: null,
+
   // MCP server configuration
   mcp: {
     autoRegister: true,

--- a/src/mcp/handlers.js
+++ b/src/mcp/handlers.js
@@ -587,6 +587,41 @@ function readMemory(args, cwd) {
 }
 
 /**
+ * get_budget({ session?, budgetTokens? }) → string
+ *
+ * Session spend ledger (F1): estimated tokens SigMap emitted this session,
+ * optional budget remaining, and context freshness. Estimates only (chars/4);
+ * does NOT see the host chat's total spend.
+ */
+function getBudget(args, cwd) {
+  const { budgetStatus } = require('../tracking/budget');
+  let config = {};
+  try { config = require('../config/loader').loadConfig(cwd) || {}; } catch (_) {}
+  const opts = { config };
+  if (args && args.session) opts.session = String(args.session);
+  if (args && args.budgetTokens != null) opts.budgetTokens = Number(args.budgetTokens);
+  const s = budgetStatus(cwd, opts);
+
+  const out = ['# SigMap session spend (estimates — chars/4; SigMap-emitted tokens only)'];
+  out.push('');
+  out.push(`Session   : ${s.session}`);
+  out.push(`Ops       : ${s.ops}`);
+  out.push(`Spent     : ~${s.spentTokens.toLocaleString()} tokens (baseline ~${s.baselineTokens.toLocaleString()}, saved ~${s.savedTokens.toLocaleString()})`);
+  if (s.budgetTokens != null) {
+    out.push(`Budget    : ${s.budgetTokens.toLocaleString()} → remaining ~${s.remainingTokens.toLocaleString()} (${s.pctUsed}% used)${s.overBudget ? '  ⚠ OVER BUDGET' : ''}`);
+    if (s.overBudget || (s.pctUsed != null && s.pctUsed >= 80)) {
+      out.push('Advice    : prefer terse output, squeeze large inputs, summarize-then-drop context.');
+    }
+  } else {
+    out.push('Budget    : none set (config sessionBudgetTokens or budgetTokens arg)');
+  }
+  out.push(s.context.exists
+    ? `Context   : ${s.context.ageDays} day(s) old${s.context.stale ? ` — STALE (> ${s.context.ttlDays}d TTL); re-run sigmap` : ''}`
+    : 'Context   : no generated context found — run sigmap first');
+  return out.join('\n');
+}
+
+/**
  * get_callee_signatures — return the exact defining signature(s) of named
  * symbols from the index, so an agent never guesses a callee's parameter types.
  * Unknown names get a closest-match suggestion.
@@ -979,4 +1014,4 @@ function squeezeOutput(args, cwd) {
   return header + sq.squeezed;
 }
 
-module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput };
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput, getBudget };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -14,7 +14,7 @@
 
 const readline = require('readline');
 const { TOOLS } = require('./tools');
-const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput } = require('./handlers');
+const { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput, getBudget } = require('./handlers');
 
 const SERVER_INFO = {
   name: 'sigmap',
@@ -86,6 +86,7 @@ function dispatch(msg, cwd) {
       else if (name === 'get_architecture_overview') text = getArchitectureOverview(args, cwd);
       else if (name === 'verify_suggestion') text = verifySuggestion(args, cwd);
       else if (name === 'squeeze_output') text = squeezeOutput(args, cwd);
+      else if (name === 'get_budget') text = getBudget(args, cwd);
       else {
         respondError(id, -32601, `Unknown tool: ${name}`);
         return;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -387,6 +387,32 @@ const TOOLS = [
       required: ['content'],
     },
   },
+  {
+    name: 'get_budget',
+    description:
+      'Session spend ledger — estimated tokens SigMap has emitted this session ' +
+      '(chars/4 estimates from the local gain log), optional budget remaining, and ' +
+      'context freshness. Scope honesty: counts only SigMap output, NOT the whole ' +
+      "chat's spend. Check this mid-session and degrade gracefully when near budget: " +
+      'prefer terse encoding, squeeze large outputs, summarize-then-drop context. ' +
+      'Local-only; no LLM, no network.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session: {
+          type: 'string',
+          description:
+            'Session key to report on (default: SIGMAP_SESSION env or the UTC day bucket).',
+        },
+        budgetTokens: {
+          type: 'number',
+          description:
+            'Budget override in estimated tokens (default: config sessionBudgetTokens).',
+        },
+      },
+      required: [],
+    },
+  },
 ];
 
 module.exports = { TOOLS };

--- a/src/tracking/budget.js
+++ b/src/tracking/budget.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Session spend ledger (v8.23 F1) — a queryable view over the existing gain
+ * log (.context/gain.ndjson, written by recordUsage).
+ *
+ * Honesty scope: this ledger counts tokens **SigMap emitted** (chars/4
+ * estimates), not the host chat's total spend — conversation history, model
+ * output, and other tools are invisible to a CLI. Every number here is an
+ * estimate and is labeled as such in output.
+ *
+ * Session identity: `SIGMAP_SESSION` env var when the host sets one, else a
+ * UTC day bucket (YYYY-MM-DD). Legacy gain entries (written before the
+ * `session` field existed) match day-bucket sessions by timestamp prefix.
+ *
+ * Zero dependencies; local JSON only.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { readGainLog } = require('./logger');
+
+// Same generated-context surfaces cache/freshen.js watches.
+const CONTEXT_PATHS = [
+  ['.github', 'copilot-instructions.md'],
+  ['CLAUDE.md'], ['AGENTS.md'], ['.github', 'context-cold.md'],
+];
+
+/** Session key: SIGMAP_SESSION override, else UTC day bucket. */
+function sessionKey(env) {
+  const e = env || process.env;
+  if (e.SIGMAP_SESSION) return String(e.SIGMAP_SESSION);
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Newest mtime (ms) among generated context files, or 0 if none exist. */
+function contextMtime(cwd) {
+  let newest = 0;
+  for (const parts of CONTEXT_PATHS) {
+    try { newest = Math.max(newest, fs.statSync(path.join(cwd, ...parts)).mtimeMs); } catch (_) {}
+  }
+  return newest;
+}
+
+/** Does a gain-log entry belong to this session? */
+function entryInSession(entry, session) {
+  if (entry.session) return entry.session === session;
+  // Legacy entry: match day-bucket sessions on the timestamp date.
+  return /^\d{4}-\d{2}-\d{2}$/.test(session) && String(entry.ts || '').startsWith(session);
+}
+
+/**
+ * Session spend status.
+ * @param {string} cwd
+ * @param {object} [opts]
+ * @param {string} [opts.session]          session key (default: sessionKey())
+ * @param {number} [opts.budgetTokens]     budget override (else config sessionBudgetTokens)
+ * @param {number} [opts.contextTtlDays]   TTL override (else config contextTtlDays)
+ * @param {object} [opts.config]           loaded config (for the two keys above)
+ * @param {number} [opts.now]              clock override for tests (ms)
+ * @returns {{
+ *   session: string, unit: 'estimated-tokens', ops: number,
+ *   spentTokens: number, baselineTokens: number, savedTokens: number,
+ *   budgetTokens: number|null, remainingTokens: number|null, pctUsed: number|null,
+ *   overBudget: boolean,
+ *   context: { exists: boolean, ageMs: number|null, ageDays: number|null,
+ *              ttlDays: number|null, stale: boolean }
+ * }}
+ */
+function budgetStatus(cwd, opts = {}) {
+  const session = opts.session || sessionKey();
+  const cfg = opts.config || {};
+  const budget = opts.budgetTokens != null ? Number(opts.budgetTokens)
+    : (Number.isFinite(cfg.sessionBudgetTokens) ? cfg.sessionBudgetTokens : null);
+  const ttlDays = opts.contextTtlDays != null ? Number(opts.contextTtlDays)
+    : (Number.isFinite(cfg.contextTtlDays) ? cfg.contextTtlDays : null);
+  const now = opts.now != null ? opts.now : Date.now();
+
+  let ops = 0, spent = 0, baseline = 0, saved = 0;
+  for (const e of readGainLog(cwd)) {
+    if (!entryInSession(e, session)) continue;
+    ops++;
+    spent += Number(e.actualTokens) || 0;
+    baseline += Number(e.baselineTokens) || 0;
+    saved += Number(e.savedTokens) || 0;
+  }
+
+  const mtime = contextMtime(cwd);
+  const ageMs = mtime > 0 ? Math.max(0, now - mtime) : null;
+  const ageDays = ageMs != null ? ageMs / 86400000 : null;
+
+  return {
+    session,
+    unit: 'estimated-tokens',
+    ops,
+    spentTokens: spent,
+    baselineTokens: baseline,
+    savedTokens: saved,
+    budgetTokens: budget,
+    remainingTokens: budget != null ? Math.max(0, budget - spent) : null,
+    pctUsed: budget > 0 ? Math.round((spent / budget) * 1000) / 10 : null,
+    overBudget: budget != null && spent > budget,
+    context: {
+      exists: mtime > 0,
+      ageMs,
+      ageDays: ageDays != null ? Math.round(ageDays * 10) / 10 : null,
+      ttlDays,
+      stale: ttlDays != null && ageDays != null && ageDays > ttlDays,
+    },
+  };
+}
+
+module.exports = { sessionKey, budgetStatus, contextMtime, entryInSession };

--- a/src/tracking/logger.js
+++ b/src/tracking/logger.js
@@ -175,10 +175,12 @@ function recordUsage(entry, cwd) {
     const baseline = Math.max(0, Number(entry.baselineTokens) || 0);
     const actual = Math.max(0, Number(entry.actualTokens) || 0);
     const saved = Math.max(0, baseline - actual);
+    const ts = new Date().toISOString();
     const record = {
-      ts: new Date().toISOString(),
+      ts,
       v: entry.version || '0.9.0',
       op: entry.op || 'generate',
+      session: entry.session || process.env.SIGMAP_SESSION || ts.slice(0, 10),
       baselineTokens: baseline,
       actualTokens: actual,
       savedTokens: saved,

--- a/test/integration/budget.test.js
+++ b/test/integration/budget.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * Integration tests for the v8.23 F1 session spend ledger.
+ *
+ * Tests:
+ *  1.  recordUsage stamps a session field (day bucket by default)
+ *  2.  recordUsage respects SIGMAP_SESSION
+ *  3.  budgetStatus sums only the requested session (incl. legacy entries by ts prefix)
+ *  4.  budgetStatus computes remaining/pct with a budget; nulls without
+ *  5.  budgetStatus reports context age and stale vs contextTtlDays
+ *  6.  CLI `budget --json` returns valid JSON with expected keys
+ *  7.  MCP get_budget handler returns the ledger text; TOOLS has 21 entries
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+const { recordUsage, readGainLog } = require(path.join(ROOT, 'src', 'tracking', 'logger'));
+const { budgetStatus, sessionKey } = require(path.join(ROOT, 'src', 'tracking', 'budget'));
+const { TOOLS } = require(path.join(ROOT, 'src', 'mcp', 'tools'));
+const { getBudget } = require(path.join(ROOT, 'src', 'mcp', 'handlers'));
+
+function tmpCwd() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-budget-'));
+}
+
+console.log('[budget.test.js] v8.23 F1 session spend ledger');
+console.log('');
+
+test('recordUsage stamps a session field (day bucket default)', () => {
+  const cwd = tmpCwd();
+  recordUsage({ op: 'ask', baselineTokens: 100, actualTokens: 10 }, cwd);
+  const [e] = readGainLog(cwd);
+  assert.ok(e, 'no gain entry written');
+  assert.strictEqual(e.session, new Date().toISOString().slice(0, 10));
+});
+
+test('recordUsage respects SIGMAP_SESSION', () => {
+  const cwd = tmpCwd();
+  process.env.SIGMAP_SESSION = 'chat-42';
+  try {
+    recordUsage({ op: 'ask', baselineTokens: 100, actualTokens: 10 }, cwd);
+  } finally {
+    delete process.env.SIGMAP_SESSION;
+  }
+  const [e] = readGainLog(cwd);
+  assert.strictEqual(e.session, 'chat-42');
+  assert.strictEqual(sessionKey({ SIGMAP_SESSION: 'x' }), 'x');
+});
+
+test('budgetStatus sums only the requested session (legacy ts-prefix match)', () => {
+  const cwd = tmpCwd();
+  const dir = path.join(cwd, '.context');
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = [
+    { ts: '2026-07-28T01:00:00.000Z', op: 'ask', actualTokens: 10, baselineTokens: 100, savedTokens: 90, session: 's1' },
+    { ts: '2026-07-28T02:00:00.000Z', op: 'ask', actualTokens: 20, baselineTokens: 200, savedTokens: 180, session: 's2' },
+    // legacy entry: no session field — matches day-bucket '2026-07-28'
+    { ts: '2026-07-28T03:00:00.000Z', op: 'ask', actualTokens: 40, baselineTokens: 400, savedTokens: 360 },
+  ];
+  fs.writeFileSync(path.join(dir, 'gain.ndjson'), lines.map(JSON.stringify).join('\n') + '\n');
+  const s1 = budgetStatus(cwd, { session: 's1' });
+  assert.strictEqual(s1.ops, 1);
+  assert.strictEqual(s1.spentTokens, 10);
+  const day = budgetStatus(cwd, { session: '2026-07-28' });
+  assert.strictEqual(day.ops, 1, 'day bucket should match only the legacy entry');
+  assert.strictEqual(day.spentTokens, 40);
+});
+
+test('budgetStatus budget math: remaining/pct with, nulls without', () => {
+  const cwd = tmpCwd();
+  const dir = path.join(cwd, '.context');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'gain.ndjson'),
+    JSON.stringify({ ts: '2026-01-01T00:00:00.000Z', op: 'ask', actualTokens: 250, baselineTokens: 1000, savedTokens: 750, session: 's' }) + '\n');
+  const withB = budgetStatus(cwd, { session: 's', budgetTokens: 1000 });
+  assert.strictEqual(withB.remainingTokens, 750);
+  assert.strictEqual(withB.pctUsed, 25);
+  assert.strictEqual(withB.overBudget, false);
+  assert.strictEqual(withB.unit, 'estimated-tokens');
+  const noB = budgetStatus(cwd, { session: 's' });
+  assert.strictEqual(noB.budgetTokens, null);
+  assert.strictEqual(noB.remainingTokens, null);
+  assert.strictEqual(noB.pctUsed, null);
+});
+
+test('budgetStatus context age + stale vs contextTtlDays', () => {
+  const cwd = tmpCwd();
+  const ctx = path.join(cwd, 'CLAUDE.md');
+  fs.writeFileSync(ctx, '# ctx');
+  const threeDaysAgo = Date.now() - 3 * 86400000;
+  fs.utimesSync(ctx, threeDaysAgo / 1000, threeDaysAgo / 1000);
+  const fresh = budgetStatus(cwd, { session: 's', contextTtlDays: 7 });
+  assert.strictEqual(fresh.context.exists, true);
+  assert.strictEqual(fresh.context.stale, false);
+  assert.ok(Math.abs(fresh.context.ageDays - 3) < 0.2, `ageDays=${fresh.context.ageDays}`);
+  const stale = budgetStatus(cwd, { session: 's', contextTtlDays: 2 });
+  assert.strictEqual(stale.context.stale, true);
+  const none = budgetStatus(tmpCwd(), { session: 's' });
+  assert.strictEqual(none.context.exists, false);
+  assert.strictEqual(none.context.stale, false);
+});
+
+test('CLI budget --json returns valid JSON with expected keys', () => {
+  const cwd = tmpCwd();
+  const r = spawnSync(process.execPath, [SCRIPT, 'budget', '--json', '--budget', '5000'], { cwd, encoding: 'utf8' });
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`);
+  const j = JSON.parse(r.stdout);
+  for (const k of ['session', 'unit', 'ops', 'spentTokens', 'budgetTokens', 'remainingTokens', 'context']) {
+    assert.ok(k in j, `missing key ${k}`);
+  }
+  assert.strictEqual(j.budgetTokens, 5000);
+});
+
+test('MCP get_budget returns ledger text; TOOLS has 21 entries', () => {
+  assert.strictEqual(TOOLS.length, 21);
+  assert.strictEqual(TOOLS[TOOLS.length - 1].name, 'get_budget');
+  const cwd = tmpCwd();
+  const text = getBudget({ budgetTokens: 100 }, cwd);
+  assert.ok(text.includes('SigMap session spend'), text.slice(0, 80));
+  assert.ok(text.includes('estimates'), 'must label values as estimates');
+  assert.ok(text.includes('Budget'), 'must show budget line');
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('');
+console.log(`[budget.test.js] ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/test/integration/features/docs-sync.test.js
+++ b/test/integration/features/docs-sync.test.js
@@ -120,10 +120,10 @@ test('docs/index.html: structured-data description uses 29 languages', () => {
 
 // ── MCP tool count ────────────────────────────────────────────────────────────
 
-test('mcp.md: description mentions 20 tools (not 12)', () => {
+test('mcp.md: description mentions 21 tools (not 12)', () => {
   const src = readGuide('mcp.md');
   assert.ok(!src.includes('with 9 tools'), 'found "9 tools" in mcp.md description');
-  assert.ok(src.includes('20 tools'), 'missing "20 tools" in mcp.md');
+  assert.ok(src.includes('21 tools'), 'missing "21 tools" in mcp.md');
 });
 
 // ── Troubleshooting v5.5 coverage entry ───────────────────────────────────────

--- a/test/integration/features/version-json.test.js
+++ b/test/integration/features/version-json.test.js
@@ -79,7 +79,7 @@ test('version.json: extractors field is derived (>= languages)', () => {
 
 test('version.json: mcp_tools is 20', () => {
   const v = JSON.parse(readRoot('version.json'));
-  assert.strictEqual(v.mcp_tools, 20);
+  assert.strictEqual(v.mcp_tools, 21);
 });
 
 // ── Fix 1a: canonical benchmark headers on all 5 benchmark pages ──────────────

--- a/test/integration/impact.test.js
+++ b/test/integration/impact.test.js
@@ -343,14 +343,14 @@ test('CLI --impact unknown file: exits 0 with zero-impact message or valid outpu
 // MCP tests
 // ---------------------------------------------------------------------------
 
-test('MCP tools/list: returns 20 tools including get_impact', () => {
+test('MCP tools/list: returns 21 tools including get_impact', () => {
   const msgs = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(msgs.length > 0, 'should get at least one response');
   const res = msgs[0];
   assert.ok(res.result && Array.isArray(res.result.tools), 'should have tools array');
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('get_impact'), `expected get_impact in tools, got: ${names}`);
-  assert.strictEqual(names.length, 20, `expected 20 tools, got ${names.length}: ${names}`);
+  assert.strictEqual(names.length, 21, `expected 21 tools, got ${names.length}: ${names}`);
 });
 
 test('MCP get_impact: returns string result for known file', () => {

--- a/test/integration/mcp/diff-architecture-tools.test.js
+++ b/test/integration/mcp/diff-architecture-tools.test.js
@@ -61,12 +61,12 @@ function seedContext(dir) {
 
 // ── tools/list registration ────────────────────────────────────────────────
 
-test('tools/list registers 20 tools including both new ones', () => {
+test('tools/list registers 21 tools including both new ones', () => {
   withGitProject((dir) => {
     const res = mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, dir);
     const tools = res.find((r) => r.id === 1).result.tools;
     assert.strictEqual(tools.length, TOOLS.length, 'server list matches TOOLS');
-    assert.strictEqual(tools.length, 20, 'exactly 20 tools');
+    assert.strictEqual(tools.length, 21, 'exactly 21 tools');
     assert.ok(tools.some((t) => t.name === 'get_diff_context'), 'get_diff_context registered');
     assert.ok(tools.some((t) => t.name === 'get_architecture_overview'), 'get_architecture_overview registered');
   });

--- a/test/integration/mcp/get-lines.test.js
+++ b/test/integration/mcp/get-lines.test.js
@@ -56,11 +56,11 @@ function callTool(dir, name, args) {
 
 console.log('\nmcp get_lines: Surgical Context demand-driven fetch\n');
 
-test('get_lines is registered (20 tools total)', () => {
+test('get_lines is registered (21 tools total)', () => {
   withTempProject((dir) => {
     const responses = mcpCall({ jsonrpc: '2.0', id: 9, method: 'tools/list' }, dir);
     const list = responses.find((r) => r.id === 9).result.tools;
-    assert.strictEqual(list.length, 20, `expected 20 tools, got ${list.length}`);
+    assert.strictEqual(list.length, 21, `expected 21 tools, got ${list.length}`);
     assert.ok(list.some((t) => t.name === 'get_lines'), 'get_lines must be in tools/list');
     const tool = list.find((t) => t.name === 'get_lines');
     assert.deepStrictEqual(tool.inputSchema.required, ['file', 'start', 'end']);

--- a/test/integration/mcp/server.test.js
+++ b/test/integration/mcp/server.test.js
@@ -101,12 +101,12 @@ test('initialize returns serverInfo', () => {
 // ─────────────────────────────────────────────────────────────
 // Gate 2: tools/list returns 12 tools
 // ─────────────────────────────────────────────────────────────
-test('tools/list returns exactly 20 tools', () => {
+test('tools/list returns exactly 21 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 2 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 20);
+    assert.strictEqual(res.result.tools.length, 21);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('read_context'), 'Should have read_context');
     assert.ok(names.includes('search_signatures'), 'Should have search_signatures');

--- a/test/integration/mcp/tools-v14.test.js
+++ b/test/integration/mcp/tools-v14.test.js
@@ -83,12 +83,12 @@ function seedContextFile(dir) {
 
 console.log('\nMCP v1.4 — tools/list\n');
 
-test('tools/list returns exactly 20 tools', () => {
+test('tools/list returns exactly 21 tools', () => {
   withTempProject((dir) => {
     const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 }, dir);
     assert.ok(res.result, 'Should have result');
     assert.ok(Array.isArray(res.result.tools), 'tools should be array');
-    assert.strictEqual(res.result.tools.length, 20, `Expected 20 tools, got ${res.result.tools.length}`);
+    assert.strictEqual(res.result.tools.length, 21, `Expected 21 tools, got ${res.result.tools.length}`);
     const names = res.result.tools.map((t) => t.name);
     assert.ok(names.includes('explain_file'), 'Should have explain_file');
     assert.ok(names.includes('list_modules'), 'Should have list_modules');

--- a/test/integration/memory-tools.test.js
+++ b/test/integration/memory-tools.test.js
@@ -177,7 +177,7 @@ test('read_memory is registered as the 11th MCP tool (bundle path)', () => {
   const res = spawnSync('node', [SCRIPT, '--mcp', '--cwd', dir], { input: reqs, cwd: ROOT, encoding: 'utf8' });
   const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
   const tools = lines.find((l) => l.id === 1).result.tools;
-  assert.strictEqual(tools.length, 20);
+  assert.strictEqual(tools.length, 21);
   assert.ok(tools.some((t) => t.name === 'read_memory'));
   const text = lines.find((l) => l.id === 2).result.content[0].text;
   assert.ok(/seed note/.test(text));

--- a/test/integration/method-blast-radius.test.js
+++ b/test/integration/method-blast-radius.test.js
@@ -177,7 +177,7 @@ test('get_method_impact direction callees + unknown symbol + missing arg', () =>
 });
 
 test('get_method_impact is registered as the 20th MCP tool', () => {
-  assert.strictEqual(TOOLS.length, 20, `expected 20 tools, got ${TOOLS.length}`);
+  assert.strictEqual(TOOLS.length, 21, `expected 21 tools, got ${TOOLS.length}`);
   const tool = TOOLS.find((t) => t.name === 'get_method_impact');
   assert.ok(tool, 'tool definition missing');
   assert.deepStrictEqual(tool.inputSchema.required, ['symbol']);

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -269,10 +269,10 @@ test('CLI --version: returns current package version', () => {
 // ---------------------------------------------------------------------------
 // MCP tests — query_context  (8th tool) + get_impact (9th tool)
 // ---------------------------------------------------------------------------
-test('MCP tools/list: returns 20 tools including query_context', () => {
+test('MCP tools/list: returns 21 tools including query_context', () => {
   const [res] = mcpCall({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
   assert.ok(res.result, 'should have result');
-  assert.strictEqual(res.result.tools.length, 20, `expected 20 tools, got ${res.result.tools.length}`);
+  assert.strictEqual(res.result.tools.length, 21, `expected 21 tools, got ${res.result.tools.length}`);
   const names = res.result.tools.map((t) => t.name);
   assert.ok(names.includes('query_context'), 'should include query_context');
   assert.ok(names.includes('get_impact'), 'should include get_impact');

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "benchmark_id": "sigmap-v8.22-main",
   "languages": 33,
   "extractors": 42,
-  "mcp_tools": 20,
-  "tests": 128,
+  "mcp_tools": 21,
+  "tests": 129,
   "metrics": {
     "hit_at_5": 0.822,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #508. First item of plan v8.23 **"Agent Economy"** — F1.

## What
- **`src/tracking/budget.js`** — `budgetStatus()`: per-session estimated SigMap-emitted tokens (spent/baseline/saved) from the existing gain log, optional budget (remaining, pct, over-budget flag), context freshness (age + stale vs `contextTtlDays`).
- **Session identity**: `SIGMAP_SESSION` env override, else UTC day bucket; `recordUsage` now stamps every entry; legacy entries match day buckets by timestamp prefix.
- **CLI** `sigmap budget [--json] [--session] [--budget]` (memory-command pattern) · **MCP** `get_budget` (21st tool) with degrade-gracefully advice at ≥80% budget.
- **Config**: `sessionBudgetTokens` / `contextTtlDays`, both opt-in null defaults.

## Honesty scope (deliberate, per the improvement-plan audit)
This is a **SigMap-spend ledger**, not a chat budget — a CLI cannot see conversation history or model output. All values are chars/4 **estimates** and labeled as such in every surface (`unit: estimated-tokens`). No prompt-cache/injection-TTL claims — context freshness only.

## Tests
- 7 new tests in `test/integration/budget.test.js` (session stamping, filtering, budget math, TTL staleness, CLI JSON, MCP handler + tool count)
- Tool-count guards advanced 20→21 in 9 test files + README + mcp.md
- Full suite: **123 passed, 0 failed** (129 files) · supply-chain local audit PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)