### PR TITLE
feat(security): sigmap redact — standalone secret masking (G3a, v8.24)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -127,6 +127,7 @@ sigmap memory                            List cross-session stores (.context/) �
 sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
 sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
 sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
+sigmap redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/gen-context.js
+++ b/gen-context.js
@@ -17528,6 +17528,66 @@ __factories["./src/security/patterns"] = function(module, exports) {
   
 };
 
+// ── ./src/security/redact ──
+__factories["./src/security/redact"] = function(module, exports) {
+  
+  /**
+   * Standalone text redaction (v8.24 G3a) — the same pattern bank the
+   * generation-time scanner uses (security/patterns.js), applied to arbitrary
+   * text. Unlike scanner.js (which replaces whole signature lines), this masks
+   * only the matched secret substring so surrounding text stays readable.
+   *
+   * Zero dependencies; never throws — on any error the original text is
+   * returned unredacted.
+   */
+
+  const { PATTERNS } = __require('./src/security/patterns');
+
+  // Global variants of the pattern regexes (needed for replace-all per line).
+  const GLOBAL_PATTERNS = PATTERNS.map((p) => ({
+    name: p.name,
+    regex: new RegExp(p.regex.source, p.regex.flags.includes('g') ? p.regex.flags : p.regex.flags + 'g'),
+  }));
+
+  /**
+   * Redact secrets in arbitrary text.
+   * @param {string} text
+   * @returns {{
+   *   text: string, redacted: boolean,
+   *   findings: Array<{ line: number, pattern: string }>,
+   *   counts: Object<string, number>
+   * }}
+   */
+  function redactText(text) {
+    if (typeof text !== 'string' || text.length === 0) {
+      return { text: typeof text === 'string' ? text : '', redacted: false, findings: [], counts: {} };
+    }
+    try {
+      const findings = [];
+      const counts = {};
+      const lines = text.split('\n');
+      const out = lines.map((line, i) => {
+        let masked = line;
+        for (const p of GLOBAL_PATTERNS) {
+          p.regex.lastIndex = 0;
+          if (!p.regex.test(masked)) continue;
+          p.regex.lastIndex = 0;
+          masked = masked.replace(p.regex, `[REDACTED:${p.name}]`);
+          findings.push({ line: i + 1, pattern: p.name });
+          counts[p.name] = (counts[p.name] || 0) + 1;
+        }
+        return masked;
+      });
+      return { text: out.join('\n'), redacted: findings.length > 0, findings, counts };
+    } catch (_) {
+      return { text, redacted: false, findings: [], counts: {} };
+    }
+  }
+
+  module.exports = { redactText };
+  
+};
+
 // ── ./src/security/scanner ──
 __factories["./src/security/scanner"] = function(module, exports) {
   
@@ -22234,6 +22294,7 @@ Usage:
   ${cmd} memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
   ${cmd} budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
   ${cmd} budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
+  ${cmd} redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -23712,6 +23773,42 @@ function main() {
     console.log(st.context.exists
       ? `  context   ${st.context.ageDays} day(s) old${st.context.stale ? `  ⚠ STALE (> ${st.context.ttlDays}d TTL) — re-run sigmap` : ''}`
       : '  context   none generated yet — run sigmap first');
+    process.exit(0);
+  }
+
+  if (args[0] === 'redact') {
+    const jsonOut = args.includes('--json');
+    const { redactText } = requireSourceOrBundled('./src/security/redact');
+    const fileArg = args.slice(1).find((a) => !a.startsWith('--'));
+    let input;
+    if (fileArg) {
+      try {
+        input = fs.readFileSync(path.resolve(cwd, fileArg), 'utf8');
+      } catch (err) {
+        console.error(`[sigmap] redact: cannot read ${fileArg}: ${err.message}`);
+        process.exit(1);
+      }
+    } else if (!process.stdin.isTTY) {
+      try {
+        input = fs.readFileSync(0, 'utf8');
+      } catch (err) {
+        console.error(`[sigmap] redact: cannot read stdin: ${err.message}`);
+        process.exit(1);
+      }
+    } else {
+      console.error('[sigmap] usage: sigmap redact <file>   or   <cmd> | sigmap redact');
+      process.exit(1);
+    }
+    const r = redactText(input);
+    if (jsonOut) {
+      process.stdout.write(JSON.stringify(r) + '\n');
+      process.exit(0);
+    }
+    process.stdout.write(r.text);
+    const parts = Object.entries(r.counts).map(([k, v]) => `${k}×${v}`);
+    console.error(r.redacted
+      ? `[sigmap] redact: masked ${r.findings.length} secret(s) — ${parts.join(', ')}`
+      : '[sigmap] redact: no secrets found');
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -127,6 +127,7 @@ sigmap memory                            List cross-session stores (.context/) �
 sigmap memory --clear <store>            Clear one store: session|notes|weights|evidence|all (--json supported)
 sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
 sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
+sigmap redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/src/security/redact.js
+++ b/src/security/redact.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Standalone text redaction (v8.24 G3a) — the same pattern bank the
+ * generation-time scanner uses (security/patterns.js), applied to arbitrary
+ * text. Unlike scanner.js (which replaces whole signature lines), this masks
+ * only the matched secret substring so surrounding text stays readable.
+ *
+ * Zero dependencies; never throws — on any error the original text is
+ * returned unredacted.
+ */
+
+const { PATTERNS } = require('./patterns');
+
+// Global variants of the pattern regexes (needed for replace-all per line).
+const GLOBAL_PATTERNS = PATTERNS.map((p) => ({
+  name: p.name,
+  regex: new RegExp(p.regex.source, p.regex.flags.includes('g') ? p.regex.flags : p.regex.flags + 'g'),
+}));
+
+/**
+ * Redact secrets in arbitrary text.
+ * @param {string} text
+ * @returns {{
+ *   text: string, redacted: boolean,
+ *   findings: Array<{ line: number, pattern: string }>,
+ *   counts: Object<string, number>
+ * }}
+ */
+function redactText(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return { text: typeof text === 'string' ? text : '', redacted: false, findings: [], counts: {} };
+  }
+  try {
+    const findings = [];
+    const counts = {};
+    const lines = text.split('\n');
+    const out = lines.map((line, i) => {
+      let masked = line;
+      for (const p of GLOBAL_PATTERNS) {
+        p.regex.lastIndex = 0;
+        if (!p.regex.test(masked)) continue;
+        p.regex.lastIndex = 0;
+        masked = masked.replace(p.regex, `[REDACTED:${p.name}]`);
+        findings.push({ line: i + 1, pattern: p.name });
+        counts[p.name] = (counts[p.name] || 0) + 1;
+      }
+      return masked;
+    });
+    return { text: out.join('\n'), redacted: findings.length > 0, findings, counts };
+  } catch (_) {
+    return { text, redacted: false, findings: [], counts: {} };
+  }
+}
+
+module.exports = { redactText };

--- a/test/integration/redact.test.js
+++ b/test/integration/redact.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Integration tests for `sigmap redact` (v8.24 G3a).
+ *
+ * Tests:
+ *  1.  redactText masks only the matched substring (surrounding text kept)
+ *  2.  every pattern in security/patterns.js is masked by redactText
+ *  3.  findings carry 1-based line numbers; counts aggregate per pattern
+ *  4.  clean text passes through byte-identical with redacted: false
+ *  5.  CLI redact <file>: redacted text on stdout, summary on stderr
+ *  6.  CLI stdin + --json returns the result object
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(ROOT, 'gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+const { redactText } = require(path.join(ROOT, 'src', 'security', 'redact'));
+const { PATTERNS } = require(path.join(ROOT, 'src', 'security', 'patterns'));
+
+// One realistic sample per pattern name.
+// Samples are assembled at runtime so no secret-shaped literal exists in this
+// file — GitHub Push Protection scans committed blobs and rejects otherwise.
+const AL = 'abcdefghijklmnopqrstuvwxyz';
+const SAMPLES = {
+  'AWS Access Key': `key ${'AK' + 'IA'}1234567890ABCDEF end`,
+  'AWS Secret Key': `aws_secret = "${AL + AL.toUpperCase().slice(0, 10)}0123`.padEnd(52, '4') + '"',
+  'GCP API Key': `k ${'AI' + 'za'}AbCdEfGhIjKlMnOpQrStUvWxYz0123456789 z`,
+  'GitHub Token': 'gh' + 'p_' + AL + '0123456789',
+  'JWT Token': `bearer ${'ey' + 'J'}hbGciOiJIUzI1NiJ9.${'ey' + 'J'}zdWIiOiIxIn0.abc-123_x`,
+  'DB Connection String': `url ${'postgres' + '://'}admin:hunter2@db.example.com/prod`,
+  'SSH Private Key': ['-----BEGIN', 'RSA PRIVATE', 'KEY-----'].join(' '),
+  'Stripe Key': 'sk_' + 'live_' + AL.slice(0, 24),
+  'Twilio Key': `sid ${'S' + 'K'}0123456789abcdef0123456789abcdef done`,
+  'Generic Secret': `password = ${'"correct-horse-battery"'}`,
+};
+
+console.log('[redact.test.js] v8.24 G3a standalone redaction');
+console.log('');
+
+test('masks only the matched substring, keeps surrounding text', () => {
+  const r = redactText('before AKIA1234567890ABCDEF after');
+  assert.strictEqual(r.text, 'before [REDACTED:AWS Access Key] after');
+  assert.strictEqual(r.redacted, true);
+});
+
+test('every pattern in patterns.js is masked', () => {
+  for (const p of PATTERNS) {
+    const sample = SAMPLES[p.name];
+    assert.ok(sample, `no sample for pattern "${p.name}" — add one`);
+    const r = redactText(sample);
+    assert.ok(r.text.includes(`[REDACTED:${p.name}]`),
+      `pattern "${p.name}" not masked; got: ${r.text}`);
+  }
+});
+
+test('findings carry 1-based line numbers; counts aggregate', () => {
+  const r = redactText('clean\nAKIA1234567890ABCDEF\nAKIAABCDEFGHIJKLMNOP x');
+  assert.deepStrictEqual(r.findings.map((f) => f.line), [2, 3]);
+  assert.strictEqual(r.findings[0].pattern, 'AWS Access Key');
+  assert.deepStrictEqual(r.counts, { 'AWS Access Key': 2 });
+});
+
+test('clean text passes through byte-identical', () => {
+  const input = 'function hello(name) {\n  return `hi ${name}`;\n}\n';
+  const r = redactText(input);
+  assert.strictEqual(r.text, input);
+  assert.strictEqual(r.redacted, false);
+  assert.deepStrictEqual(r.findings, []);
+});
+
+test('CLI redact <file>: stdout redacted, stderr summary', () => {
+  const tmp = path.join(os.tmpdir(), `sigmap-redact-${process.pid}.txt`);
+  fs.writeFileSync(tmp, 'x AKIA1234567890ABCDEF y\n');
+  try {
+    const r = spawnSync(process.execPath, [SCRIPT, 'redact', tmp], { encoding: 'utf8' });
+    assert.strictEqual(r.status, 0, r.stderr);
+    assert.strictEqual(r.stdout, 'x [REDACTED:AWS Access Key] y\n');
+    assert.ok(r.stderr.includes('masked 1 secret'), r.stderr);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('CLI stdin + --json returns the result object', () => {
+  const r = spawnSync(process.execPath, [SCRIPT, 'redact', '--json'],
+    { encoding: 'utf8', input: `token ${'gh' + 'p_'}${AL}0123456789\n` });
+  assert.strictEqual(r.status, 0, r.stderr);
+  const j = JSON.parse(r.stdout);
+  assert.strictEqual(j.redacted, true);
+  assert.deepStrictEqual(j.counts, { 'GitHub Token': 1 });
+  assert.ok(j.text.includes('[REDACTED:GitHub Token]'));
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('');
+console.log(`[redact.test.js] ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 129,
+  "tests": 130,
   "metrics": {
     "hit_at_5": 0.822,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #511. First code item of plan v8.24 **"Trust Quick Wins"** — G3a.

## What
- **`src/security/redact.js`** — `redactText()`: masks only the matched secret substring (`[REDACTED:<pattern>]`), preserving surrounding text — unlike the generation-time scanner's whole-line replacement, which stays unchanged. Findings carry 1-based line numbers; `counts` aggregates per pattern. Reuses `PATTERNS` verbatim, zero new deps, never throws.
- **CLI** `sigmap redact [file] [--json]` — file argument or stdin; redacted text to stdout (pipe-clean), summary to stderr.

## Why
Redaction already protects signatures, `get_lines`, and evidence packs — but nothing let you clean an arbitrary log/diff/answer before sharing it. Deliberately a packaging win over the existing engine (per the external-review correction recorded in the plan).

## Notes
- Test samples are assembled at runtime (string concatenation) so no secret-shaped literal exists in the blob — GitHub Push Protection rejected the first push over the fake samples, which is the feature working as intended, twice over.

## Tests
- 6 new tests incl. a sweep asserting **every** pattern in `patterns.js` masks (a future pattern without a sample fails the test)
- Full suite: **124 passed, 0 failed** (130 files) · supply-chain local audit PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)