### PR TITLE
feat: sigmap tune — config optimizer from the discovery stack (F2)

### DIFF
--- a/docs-vp/public/llms-full.txt
+++ b/docs-vp/public/llms-full.txt
@@ -128,6 +128,8 @@ sigmap memory --clear <store>            Clear one store: session|notes|weights|
 sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
 sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
 sigmap redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
+sigmap tune                              Recommend config from repo detection — srcDirs, monorepo, adapters, exclude, budget (--json)
+sigmap tune --apply                      Write the recommendations into gen-context.config.json (merges; your keys preserved)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/gen-context.js
+++ b/gen-context.js
@@ -1877,6 +1877,220 @@ __factories["./src/config/loader"] = function(module, exports) {
   
 };
 
+// ── ./src/config/tune ──
+__factories["./src/config/tune"] = function(module, exports) {
+  
+  /**
+   * sigmap tune — deterministic config optimizer (F2, #514).
+   *
+   * Packages the existing discovery stack (source-root-resolver, monorepo
+   * markers, client-artifact probes) into a recommended config diff with a
+   * one-line reason per change. Read-only by default; `applyTuneProposal`
+   * merges accepted changes into gen-context.config.json, preserving every
+   * user key. Explicit user choices are never proposed against.
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+  const { loadConfig } = __require('./src/config/loader');
+  const { resolveSourceRoots } = __require('./src/discovery/source-root-resolver');
+
+  // Workspace markers, in probe order (reason names the first one found).
+  const MONOREPO_MARKERS = ['pnpm-workspace.yaml', 'turbo.json', 'nx.json', 'lerna.json'];
+
+  // Client artifacts → adapter names (additive only).
+  const ADAPTER_MARKERS = [
+    { adapter: 'claude',   files: ['CLAUDE.md'] },
+    { adapter: 'cursor',   files: ['.cursorrules', '.cursor'] },
+    { adapter: 'windsurf', files: ['.windsurfrules', '.windsurf'] },
+    { adapter: 'codex',    files: ['AGENTS.md'] },
+  ];
+
+  // Root-level dirs that are typically vendored/generated when present.
+  const JUNK_DIRS = [
+    'third_party', 'thirdparty', 'external', 'externals',
+    'generated', 'testdata', 'snapshots', 'tmp', 'temp', '.cache',
+  ];
+
+  // Rough signature cost per source file (chars/4 world) for the budget check.
+  const TOKENS_PER_FILE = 25;
+
+  const SOURCE_EXTS = new Set([
+    '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.py', '.rb', '.go', '.rs',
+    '.java', '.kt', '.cs', '.cpp', '.c', '.h', '.hpp', '.swift', '.dart',
+    '.scala', '.php', '.gd', '.r', '.R',
+  ]);
+
+  /** Raw user config file content, or null when absent/unparsable. */
+  function _readUserConfig(cwd) {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /** Count source files under `roots` (relative to cwd), depth-capped, deterministic. */
+  function _countSourceFiles(cwd, roots, exclude, depth = 5) {
+    const excSet = new Set(exclude || []);
+    let count = 0;
+    const walk = (dir, d) => {
+      if (d <= 0 || count > 20000) return;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+      for (const e of entries) {
+        if (excSet.has(e.name)) continue;
+        if (e.isDirectory()) walk(path.join(dir, e.name), d - 1);
+        else if (e.isFile() && SOURCE_EXTS.has(path.extname(e.name))) count++;
+      }
+    };
+    for (const r of roots) {
+      const full = path.join(cwd, r);
+      if (fs.existsSync(full)) walk(full, depth);
+    }
+    return count;
+  }
+
+  /** The workspace marker present at cwd, or null. */
+  function _monorepoMarker(cwd) {
+    for (const m of MONOREPO_MARKERS) {
+      if (fs.existsSync(path.join(cwd, m))) return m;
+    }
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+      if (pkg.workspaces) return 'package.json workspaces';
+    } catch (_) {}
+    return null;
+  }
+
+  /**
+   * Build the recommended config diff for a repo.
+   *
+   * @param {string} cwd
+   * @returns {{ changes: Array<{key:string, current:*, recommended:*, reason:string}>,
+   *             detection: { roots:string[], confidence:string, isMonorepo:boolean },
+   *             configExists: boolean }}
+   */
+  function buildTuneProposal(cwd) {
+    const userConfig = _readUserConfig(cwd);
+    const config = loadConfig(cwd);
+    const detection = resolveSourceRoots(cwd, { exclude: config.exclude });
+    const changes = [];
+
+    // 1. srcDirs — recommend pinning the detected roots when the user hasn't.
+    // Pinned srcDirs make generation explicit/stable and are protected from
+    // token-budget drops; user-pinned srcDirs are never proposed against.
+    const userPinnedSrcDirs = !!(userConfig && Array.isArray(userConfig.srcDirs));
+    if (!userPinnedSrcDirs && detection.roots.length > 0 && detection.confidence !== 'low') {
+      changes.push({
+        key: 'srcDirs',
+        current: null,
+        recommended: detection.roots,
+        reason: `pin the ${detection.roots.length} detected source root(s) [confidence ${detection.confidence}] — explicit srcDirs are stable across runs and protected from budget drops`,
+      });
+    }
+
+    // 2. monorepo — a workspace marker exists but the mode is off.
+    const marker = _monorepoMarker(cwd);
+    if (marker && config.monorepo !== true) {
+      changes.push({
+        key: 'monorepo',
+        current: config.monorepo,
+        recommended: true,
+        reason: `workspace marker found: ${marker}`,
+      });
+    }
+
+    // 3. adapters — client artifacts present that the adapter list doesn't cover.
+    const currentAdapters = Array.isArray(config.adapters) ? config.adapters
+      : (Array.isArray(config.outputs) ? config.outputs : ['copilot']);
+    const found = [];
+    for (const { adapter, files } of ADAPTER_MARKERS) {
+      if (currentAdapters.includes(adapter)) continue;
+      const hit = files.find((f) => fs.existsSync(path.join(cwd, f)));
+      if (hit) found.push({ adapter, hit });
+    }
+    if (found.length > 0) {
+      changes.push({
+        key: 'adapters',
+        current: currentAdapters,
+        recommended: [...currentAdapters, ...found.map((f) => f.adapter)],
+        reason: `client files present: ${found.map((f) => f.hit).join(', ')}`,
+      });
+    }
+
+    // 4. exclude — root-level vendored/generated dirs not excluded yet.
+    const junkFound = JUNK_DIRS.filter((d) => {
+      if ((config.exclude || []).includes(d)) return false;
+      try { return fs.statSync(path.join(cwd, d)).isDirectory(); } catch (_) { return false; }
+    });
+    if (junkFound.length > 0) {
+      changes.push({
+        key: 'exclude',
+        current: userConfig && userConfig.exclude ? userConfig.exclude : null,
+        recommended: [...((userConfig && userConfig.exclude) || config.exclude), ...junkFound],
+        reason: `present at root and typically vendored/generated: ${junkFound.join(', ')}`,
+      });
+    }
+
+    // 5. autoMaxTokens — a pinned budget that the repo's size will overflow.
+    if (config.autoMaxTokens === false) {
+      const roots = detection.roots.length > 0 ? detection.roots : config.srcDirs;
+      const files = _countSourceFiles(cwd, roots, config.exclude);
+      const estTokens = files * TOKENS_PER_FILE;
+      if (estTokens > config.maxTokens) {
+        changes.push({
+          key: 'autoMaxTokens',
+          current: false,
+          recommended: true,
+          reason: `~${files} source files need ~${estTokens} tokens (heuristic) but maxTokens is pinned at ${config.maxTokens} — auto-scaling targets ${Math.round((config.coverageTarget || 0.8) * 100)}% coverage`,
+        });
+      }
+    }
+
+    return {
+      changes,
+      detection: { roots: detection.roots, confidence: detection.confidence, isMonorepo: detection.isMonorepo },
+      configExists: userConfig !== null,
+    };
+  }
+
+  /**
+   * Merge a proposal's changes into gen-context.config.json (create if absent).
+   * Preserves every existing user key; only the proposed keys are written.
+   *
+   * @returns {{ path: string, applied: string[] }}
+   */
+  function applyTuneProposal(cwd, proposal) {
+    const cfgPath = path.join(cwd, 'gen-context.config.json');
+    const existing = _readUserConfig(cwd) || {};
+    for (const c of proposal.changes) existing[c.key] = c.recommended;
+    fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2) + '\n');
+    return { path: cfgPath, applied: proposal.changes.map((c) => c.key) };
+  }
+
+  /** Human rendering of a proposal (one block per change, reason indented). */
+  function formatTuneProposal(proposal) {
+    const lines = [];
+    if (proposal.changes.length === 0) {
+      lines.push('[sigmap] tune: config already matches detection — no changes recommended');
+    } else {
+      lines.push(`[sigmap] tune: ${proposal.changes.length} recommended change(s)`);
+      for (const c of proposal.changes) {
+        lines.push(`  ${c.key.padEnd(14)} ${JSON.stringify(c.current)} → ${JSON.stringify(c.recommended)}`);
+        lines.push(`  ${''.padEnd(14)} reason: ${c.reason}`);
+      }
+      lines.push('');
+      lines.push('  apply with: sigmap tune --apply   (then: sigmap validate)');
+    }
+    lines.push(`  detection: roots [${proposal.detection.roots.join(', ')}] · confidence ${proposal.detection.confidence} · monorepo ${proposal.detection.isMonorepo ? 'yes' : 'no'}`);
+    return lines.join('\n');
+  }
+
+  module.exports = { buildTuneProposal, applyTuneProposal, formatTuneProposal, JUNK_DIRS, TOKENS_PER_FILE };
+  
+};
+
 // ── ./src/conventions/ci ──
 __factories["./src/conventions/ci"] = function(module, exports) {
   
@@ -22295,6 +22509,8 @@ Usage:
   ${cmd} budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
   ${cmd} budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
   ${cmd} redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
+  ${cmd} tune                              Recommend config from repo detection — srcDirs, monorepo, adapters, exclude, budget (--json)
+  ${cmd} tune --apply                      Write the recommendations into gen-context.config.json (merges; your keys preserved)
   ${cmd} note "<text>"                     Append a note to the cross-session decision log
   ${cmd} note                              List recent notes (also: note --list <N>)
   ${cmd} status                            Show repo state — branch, dirty files, index freshness, notes
@@ -23691,6 +23907,36 @@ function main() {
     });
     console.log('\nMonorepo:', result.isMonorepo ? 'yes' : 'no');
     console.log('Confidence:', result.confidence);
+    process.exit(0);
+  }
+
+  // `sigmap tune [--apply|--dry-run] [--json]` — deterministic config optimizer:
+  // recommend srcDirs/monorepo/adapters/exclude/autoMaxTokens from the existing
+  // discovery stack, one reason per change. Read-only unless --apply.
+  if (args[0] === 'tune') {
+    const { buildTuneProposal, applyTuneProposal, formatTuneProposal } = requireSourceOrBundled('./src/config/tune');
+    let proposal;
+    try {
+      proposal = buildTuneProposal(cwd);
+    } catch (err) {
+      console.error(`[sigmap] tune failed: ${err.message}`);
+      process.exit(1);
+    }
+    if (args.includes('--apply') && proposal.changes.length > 0) {
+      const res = applyTuneProposal(cwd, proposal);
+      if (args.includes('--json')) {
+        process.stdout.write(JSON.stringify({ ...proposal, applied: res.applied, path: res.path }) + '\n');
+      } else {
+        console.log(formatTuneProposal(proposal));
+        console.log(`[sigmap] tune: wrote ${res.applied.join(', ')} → ${path.relative(cwd, res.path)} — run: sigmap validate`);
+      }
+      process.exit(0);
+    }
+    if (args.includes('--json')) {
+      process.stdout.write(JSON.stringify(proposal) + '\n');
+    } else {
+      console.log(formatTuneProposal(proposal));
+    }
     process.exit(0);
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -128,6 +128,8 @@ sigmap memory --clear <store>            Clear one store: session|notes|weights|
 sigmap budget                            Session spend ledger — estimated SigMap-emitted tokens, budget, context age (--json)
 sigmap budget --budget <tokens>          One-off budget override (config: sessionBudgetTokens, contextTtlDays)
 sigmap redact [file]                     Mask secrets in a file or stdin (10-pattern bank); redacted text to stdout (--json)
+sigmap tune                              Recommend config from repo detection — srcDirs, monorepo, adapters, exclude, budget (--json)
+sigmap tune --apply                      Write the recommendations into gen-context.config.json (merges; your keys preserved)
 sigmap note "<text>"                     Append a note to the cross-session decision log
 sigmap note                              List recent notes (also: note --list <N>)
 sigmap status                            Show repo state — branch, dirty files, index freshness, notes

--- a/src/config/tune.js
+++ b/src/config/tune.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * sigmap tune — deterministic config optimizer (F2, #514).
+ *
+ * Packages the existing discovery stack (source-root-resolver, monorepo
+ * markers, client-artifact probes) into a recommended config diff with a
+ * one-line reason per change. Read-only by default; `applyTuneProposal`
+ * merges accepted changes into gen-context.config.json, preserving every
+ * user key. Explicit user choices are never proposed against.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadConfig } = require('./loader');
+const { resolveSourceRoots } = require('../discovery/source-root-resolver');
+
+// Workspace markers, in probe order (reason names the first one found).
+const MONOREPO_MARKERS = ['pnpm-workspace.yaml', 'turbo.json', 'nx.json', 'lerna.json'];
+
+// Client artifacts → adapter names (additive only).
+const ADAPTER_MARKERS = [
+  { adapter: 'claude',   files: ['CLAUDE.md'] },
+  { adapter: 'cursor',   files: ['.cursorrules', '.cursor'] },
+  { adapter: 'windsurf', files: ['.windsurfrules', '.windsurf'] },
+  { adapter: 'codex',    files: ['AGENTS.md'] },
+];
+
+// Root-level dirs that are typically vendored/generated when present.
+const JUNK_DIRS = [
+  'third_party', 'thirdparty', 'external', 'externals',
+  'generated', 'testdata', 'snapshots', 'tmp', 'temp', '.cache',
+];
+
+// Rough signature cost per source file (chars/4 world) for the budget check.
+const TOKENS_PER_FILE = 25;
+
+const SOURCE_EXTS = new Set([
+  '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.py', '.rb', '.go', '.rs',
+  '.java', '.kt', '.cs', '.cpp', '.c', '.h', '.hpp', '.swift', '.dart',
+  '.scala', '.php', '.gd', '.r', '.R',
+]);
+
+/** Raw user config file content, or null when absent/unparsable. */
+function _readUserConfig(cwd) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+  } catch (_) {
+    return null;
+  }
+}
+
+/** Count source files under `roots` (relative to cwd), depth-capped, deterministic. */
+function _countSourceFiles(cwd, roots, exclude, depth = 5) {
+  const excSet = new Set(exclude || []);
+  let count = 0;
+  const walk = (dir, d) => {
+    if (d <= 0 || count > 20000) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
+    for (const e of entries) {
+      if (excSet.has(e.name)) continue;
+      if (e.isDirectory()) walk(path.join(dir, e.name), d - 1);
+      else if (e.isFile() && SOURCE_EXTS.has(path.extname(e.name))) count++;
+    }
+  };
+  for (const r of roots) {
+    const full = path.join(cwd, r);
+    if (fs.existsSync(full)) walk(full, depth);
+  }
+  return count;
+}
+
+/** The workspace marker present at cwd, or null. */
+function _monorepoMarker(cwd) {
+  for (const m of MONOREPO_MARKERS) {
+    if (fs.existsSync(path.join(cwd, m))) return m;
+  }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    if (pkg.workspaces) return 'package.json workspaces';
+  } catch (_) {}
+  return null;
+}
+
+/**
+ * Build the recommended config diff for a repo.
+ *
+ * @param {string} cwd
+ * @returns {{ changes: Array<{key:string, current:*, recommended:*, reason:string}>,
+ *             detection: { roots:string[], confidence:string, isMonorepo:boolean },
+ *             configExists: boolean }}
+ */
+function buildTuneProposal(cwd) {
+  const userConfig = _readUserConfig(cwd);
+  const config = loadConfig(cwd);
+  const detection = resolveSourceRoots(cwd, { exclude: config.exclude });
+  const changes = [];
+
+  // 1. srcDirs — recommend pinning the detected roots when the user hasn't.
+  // Pinned srcDirs make generation explicit/stable and are protected from
+  // token-budget drops; user-pinned srcDirs are never proposed against.
+  const userPinnedSrcDirs = !!(userConfig && Array.isArray(userConfig.srcDirs));
+  if (!userPinnedSrcDirs && detection.roots.length > 0 && detection.confidence !== 'low') {
+    changes.push({
+      key: 'srcDirs',
+      current: null,
+      recommended: detection.roots,
+      reason: `pin the ${detection.roots.length} detected source root(s) [confidence ${detection.confidence}] — explicit srcDirs are stable across runs and protected from budget drops`,
+    });
+  }
+
+  // 2. monorepo — a workspace marker exists but the mode is off.
+  const marker = _monorepoMarker(cwd);
+  if (marker && config.monorepo !== true) {
+    changes.push({
+      key: 'monorepo',
+      current: config.monorepo,
+      recommended: true,
+      reason: `workspace marker found: ${marker}`,
+    });
+  }
+
+  // 3. adapters — client artifacts present that the adapter list doesn't cover.
+  const currentAdapters = Array.isArray(config.adapters) ? config.adapters
+    : (Array.isArray(config.outputs) ? config.outputs : ['copilot']);
+  const found = [];
+  for (const { adapter, files } of ADAPTER_MARKERS) {
+    if (currentAdapters.includes(adapter)) continue;
+    const hit = files.find((f) => fs.existsSync(path.join(cwd, f)));
+    if (hit) found.push({ adapter, hit });
+  }
+  if (found.length > 0) {
+    changes.push({
+      key: 'adapters',
+      current: currentAdapters,
+      recommended: [...currentAdapters, ...found.map((f) => f.adapter)],
+      reason: `client files present: ${found.map((f) => f.hit).join(', ')}`,
+    });
+  }
+
+  // 4. exclude — root-level vendored/generated dirs not excluded yet.
+  const junkFound = JUNK_DIRS.filter((d) => {
+    if ((config.exclude || []).includes(d)) return false;
+    try { return fs.statSync(path.join(cwd, d)).isDirectory(); } catch (_) { return false; }
+  });
+  if (junkFound.length > 0) {
+    changes.push({
+      key: 'exclude',
+      current: userConfig && userConfig.exclude ? userConfig.exclude : null,
+      recommended: [...((userConfig && userConfig.exclude) || config.exclude), ...junkFound],
+      reason: `present at root and typically vendored/generated: ${junkFound.join(', ')}`,
+    });
+  }
+
+  // 5. autoMaxTokens — a pinned budget that the repo's size will overflow.
+  if (config.autoMaxTokens === false) {
+    const roots = detection.roots.length > 0 ? detection.roots : config.srcDirs;
+    const files = _countSourceFiles(cwd, roots, config.exclude);
+    const estTokens = files * TOKENS_PER_FILE;
+    if (estTokens > config.maxTokens) {
+      changes.push({
+        key: 'autoMaxTokens',
+        current: false,
+        recommended: true,
+        reason: `~${files} source files need ~${estTokens} tokens (heuristic) but maxTokens is pinned at ${config.maxTokens} — auto-scaling targets ${Math.round((config.coverageTarget || 0.8) * 100)}% coverage`,
+      });
+    }
+  }
+
+  return {
+    changes,
+    detection: { roots: detection.roots, confidence: detection.confidence, isMonorepo: detection.isMonorepo },
+    configExists: userConfig !== null,
+  };
+}
+
+/**
+ * Merge a proposal's changes into gen-context.config.json (create if absent).
+ * Preserves every existing user key; only the proposed keys are written.
+ *
+ * @returns {{ path: string, applied: string[] }}
+ */
+function applyTuneProposal(cwd, proposal) {
+  const cfgPath = path.join(cwd, 'gen-context.config.json');
+  const existing = _readUserConfig(cwd) || {};
+  for (const c of proposal.changes) existing[c.key] = c.recommended;
+  fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2) + '\n');
+  return { path: cfgPath, applied: proposal.changes.map((c) => c.key) };
+}
+
+/** Human rendering of a proposal (one block per change, reason indented). */
+function formatTuneProposal(proposal) {
+  const lines = [];
+  if (proposal.changes.length === 0) {
+    lines.push('[sigmap] tune: config already matches detection — no changes recommended');
+  } else {
+    lines.push(`[sigmap] tune: ${proposal.changes.length} recommended change(s)`);
+    for (const c of proposal.changes) {
+      lines.push(`  ${c.key.padEnd(14)} ${JSON.stringify(c.current)} → ${JSON.stringify(c.recommended)}`);
+      lines.push(`  ${''.padEnd(14)} reason: ${c.reason}`);
+    }
+    lines.push('');
+    lines.push('  apply with: sigmap tune --apply   (then: sigmap validate)');
+  }
+  lines.push(`  detection: roots [${proposal.detection.roots.join(', ')}] · confidence ${proposal.detection.confidence} · monorepo ${proposal.detection.isMonorepo ? 'yes' : 'no'}`);
+  return lines.join('\n');
+}
+
+module.exports = { buildTuneProposal, applyTuneProposal, formatTuneProposal, JUNK_DIRS, TOKENS_PER_FILE };

--- a/test/integration/tune.test.js
+++ b/test/integration/tune.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * `sigmap tune` — deterministic config optimizer (F2, #514).
+ * Run: node test/integration/tune.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const GEN_CONTEXT = path.join(ROOT, 'gen-context.js');
+const { buildTuneProposal, applyTuneProposal } = require(path.join(ROOT, 'src/config/tune.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+/** TS workspace fixture: src/ code, workspaces marker, client files, junk dir. */
+function fixture(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-tune-'));
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+    name: 'fx', devDependencies: { typescript: '^5' },
+    ...(opts.workspaces ? { workspaces: ['packages/*'] } : {}),
+  }));
+  for (let i = 0; i < 4; i++) {
+    fs.writeFileSync(path.join(dir, 'src', `f${i}.ts`), `export function fn${i}(a: string) { return a; }\n`);
+  }
+  if (opts.clientFiles) for (const f of opts.clientFiles) fs.writeFileSync(path.join(dir, f), '');
+  if (opts.junkDir) fs.mkdirSync(path.join(dir, opts.junkDir));
+  if (opts.config) fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify(opts.config, null, 2));
+  return dir;
+}
+const rm = (dir) => fs.rmSync(dir, { recursive: true, force: true });
+const changeFor = (p, key) => p.changes.find((c) => c.key === key);
+
+// ── proposal shape + determinism ────────────────────────────────────────────
+
+test('proposal has {key,current,recommended,reason} changes and is deterministic', () => {
+  const dir = fixture({ workspaces: true, clientFiles: ['CLAUDE.md'], junkDir: 'third_party' });
+  const a = buildTuneProposal(dir);
+  const b = buildTuneProposal(dir);
+  assert.ok(a.changes.length >= 3, `expected >=3 changes, got ${a.changes.length}`);
+  for (const c of a.changes) {
+    assert.ok(c.key && 'current' in c && 'recommended' in c && typeof c.reason === 'string' && c.reason.length > 0, JSON.stringify(c));
+  }
+  assert.deepStrictEqual(a, b, 'same repo must yield a deep-equal proposal');
+  rm(dir);
+});
+
+// ── srcDirs rule ────────────────────────────────────────────────────────────
+
+test('srcDirs: pin recommended when unpinned and detection is confident', () => {
+  const dir = fixture({});
+  const c = changeFor(buildTuneProposal(dir), 'srcDirs');
+  assert.ok(c, 'srcDirs pin missing');
+  assert.deepStrictEqual(c.recommended, ['src']);
+  assert.ok(/confidence (medium|high)/.test(c.reason), c.reason);
+  rm(dir);
+});
+
+test('srcDirs: user-pinned srcDirs are never proposed against', () => {
+  const dir = fixture({ config: { srcDirs: ['custom'] } });
+  assert.strictEqual(changeFor(buildTuneProposal(dir), 'srcDirs'), undefined);
+  rm(dir);
+});
+
+// ── monorepo / adapters / exclude rules ─────────────────────────────────────
+
+test('monorepo: fires on workspaces marker, reason names the marker', () => {
+  const dir = fixture({ workspaces: true });
+  const c = changeFor(buildTuneProposal(dir), 'monorepo');
+  assert.ok(c && c.recommended === true, 'monorepo change missing');
+  assert.ok(c.reason.includes('package.json workspaces'), c.reason);
+  const dir2 = fixture({});
+  assert.strictEqual(changeFor(buildTuneProposal(dir2), 'monorepo'), undefined, 'must not fire without a marker');
+  rm(dir); rm(dir2);
+});
+
+test('adapters: additive from client artifacts, reason names the files', () => {
+  const dir = fixture({ clientFiles: ['CLAUDE.md', '.cursorrules'] });
+  const c = changeFor(buildTuneProposal(dir), 'adapters');
+  assert.ok(c, 'adapters change missing');
+  assert.ok(c.recommended.includes('claude') && c.recommended.includes('cursor'), JSON.stringify(c.recommended));
+  assert.ok(c.recommended.includes('copilot'), 'existing adapters must be kept');
+  assert.ok(c.reason.includes('CLAUDE.md') && c.reason.includes('.cursorrules'), c.reason);
+  rm(dir);
+});
+
+test('exclude: junk dir at root is added, defaults preserved in the list', () => {
+  const dir = fixture({ junkDir: 'third_party' });
+  const c = changeFor(buildTuneProposal(dir), 'exclude');
+  assert.ok(c, 'exclude change missing');
+  assert.ok(c.recommended.includes('third_party') && c.recommended.includes('node_modules'), JSON.stringify(c.recommended));
+  assert.ok(c.reason.includes('third_party'), c.reason);
+  rm(dir);
+});
+
+test('autoMaxTokens: fires only when a pinned budget is below the repo estimate', () => {
+  const dir = fixture({ config: { autoMaxTokens: false, maxTokens: 10 } });
+  const c = changeFor(buildTuneProposal(dir), 'autoMaxTokens');
+  assert.ok(c && c.recommended === true, 'autoMaxTokens change missing');
+  assert.ok(/source files/.test(c.reason) && /heuristic/.test(c.reason), c.reason);
+  const dir2 = fixture({ config: { autoMaxTokens: false, maxTokens: 999999 } });
+  assert.strictEqual(changeFor(buildTuneProposal(dir2), 'autoMaxTokens'), undefined, 'ample pinned budget must not fire');
+  rm(dir); rm(dir2);
+});
+
+// ── apply: merge, preserve, idempotent ──────────────────────────────────────
+
+test('applyTuneProposal merges into config preserving unrelated user keys; then idempotent', () => {
+  const dir = fixture({ workspaces: true, config: { terse: true, srcDirs: ['src'] } });
+  applyTuneProposal(dir, buildTuneProposal(dir));
+  const cfg = JSON.parse(fs.readFileSync(path.join(dir, 'gen-context.config.json'), 'utf8'));
+  assert.strictEqual(cfg.terse, true, 'unrelated user key lost');
+  assert.deepStrictEqual(cfg.srcDirs, ['src'], 'pinned srcDirs must survive apply');
+  assert.strictEqual(cfg.monorepo, true);
+  assert.deepStrictEqual(buildTuneProposal(dir).changes, [], 'second proposal after apply must be empty');
+  rm(dir);
+});
+
+// ── CLI wiring ──────────────────────────────────────────────────────────────
+
+test('CLI: default tune writes nothing; --apply writes; --json is machine-readable', () => {
+  const dir = fixture({ workspaces: true });
+  execFileSync(process.execPath, [GEN_CONTEXT, 'tune'], { cwd: dir, encoding: 'utf8' });
+  assert.ok(!fs.existsSync(path.join(dir, 'gen-context.config.json')), 'default run must not write config');
+  const json = JSON.parse(execFileSync(process.execPath, [GEN_CONTEXT, 'tune', '--json'], { cwd: dir, encoding: 'utf8' }));
+  assert.ok(Array.isArray(json.changes) && json.detection, 'bad --json shape');
+  const out = execFileSync(process.execPath, [GEN_CONTEXT, 'tune', '--apply'], { cwd: dir, encoding: 'utf8' });
+  assert.ok(fs.existsSync(path.join(dir, 'gen-context.config.json')), '--apply must write config');
+  assert.ok(out.includes('sigmap validate'), 'apply output must point to validate');
+  rm(dir);
+});
+
+test('CLI: --help documents tune', () => {
+  const help = execFileSync(process.execPath, [GEN_CONTEXT, '--help'], { encoding: 'utf8' });
+  assert.ok(/tune\s+Recommend config from repo detection/.test(help), '--help missing tune');
+  assert.ok(help.includes('tune --apply'), '--help missing tune --apply');
+});
+
+console.log(`\n  tune: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 130,
+  "tests": 131,
   "metrics": {
     "hit_at_5": 0.822,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #514

## Summary
- `sigmap tune` — the F2 config-optimizer deferred out of the v8.23 row: a deterministic recommended-config diff built from the existing discovery stack, with one evidence-naming reason per change. Kills the #1 onboarding failure (bad/default config) without any new detection code.

## Changes
- `src/config/tune.js`: `buildTuneProposal` (5 rules: srcDirs pin · monorepo · adapters · exclude · autoMaxTokens), `applyTuneProposal` (merge, preserves user keys, idempotent), `formatTuneProposal`
- `gen-context.js`: CLI `tune` command (read-only default · `--apply` · `--json` · `--dry-run` alias) + `--help` lines; bundle rebuilt (148 modules)
- `test/integration/tune.test.js`: 10 tests — shape/determinism, every rule's positive + negative case, user-pin respect, apply merge/idempotence, CLI write-safety, `--help`
- version.json test count 130 → 131; llms files regenerated

## Rule semantics (all deterministic, explicit user choices never overridden)
| Rule | Fires when | Reason names |
|---|---|---|
| `srcDirs` | unpinned + resolver confidence ≥ medium | roots + confidence; pinned dirs are budget-drop-protected |
| `monorepo` | workspace marker present, mode off | the marker found |
| `adapters` | client artifact without its adapter | the files found (additive only) |
| `exclude` | curated junk dir at root, unexcluded | the dirs found (defaults preserved) |
| `autoMaxTokens` | pinned budget < ~25 tok/file estimate | file count + labeled heuristic |

## Test plan
- [x] `node test/integration/tune.test.js` — 10/10
- [x] `node test/integration/all.js` — 125 files, 0 failed
- [x] Supply-chain local audit PASS (no shell spawns · no install scripts · main exports API · no fingerprinting)