### PR TITLE
docs: KNOWN_LIMITATIONS.md + extractor honesty tiers (G1)

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,0 +1,40 @@
+# Known limitations
+
+SigMap's benchmark claims are honesty-audited (measured grep-agent baseline, retrieval-tier proxies labeled as proxies, leakage-gated hard corpus). This page extends the same standard to the **extraction layer**: what each extractor tier actually does, where it truncates, and what that means for verification. Every claim here is checkable against the code.
+
+Currently: **42 extractor modules covering 33 languages**. Counts are guarded against drift by `test/integration/known-limitations.test.js` (they must match `version.json`).
+
+## Extractor tiers
+
+| Tier | Languages | How it works | What it can miss |
+|------|-----------|--------------|------------------|
+| **1 — AST** | Python | Native CPython AST parse via `src/extractors/python_ast.py` when `python3` is on PATH; falls back to Tier-2-style regex when it is not | With the fallback active: same gaps as Tier 2 |
+| **2 — anchored regex** | JavaScript, TypeScript, Go, Rust, Java, Kotlin, Swift, PHP, Scala, Dart, C# (11) | Newline-preserving comment strip → declaration regexes → brace-depth block matching. Signatures carry `:start-end` line anchors; 6 languages (Python, JS, TS, Go, Rust, Java) also carry first-sentence doc-comment hints | Exotic declaration syntax the regexes don't cover (see gaps below); no type resolution — signatures are textual |
+| **3 — pattern/heuristic** | Everything else — Ruby, C/C++, GDScript, Vue/Svelte SFCs, SQL, GraphQL, Terraform, Protobuf, shell, config formats (YAML/TOML/XML/HTML/CSS/Markdown/properties/Dockerfile), and a generic fallback | Line-oriented pattern matching tuned per format | Anything structurally nested or syntactically unusual; no anchors, no doc hints |
+
+All tiers are **deterministic** (same input → byte-identical output) and zero-dependency at runtime. There is no tree-sitter and no language server — that is a design constraint, not an accident, and it is exactly why the tiers above exist.
+
+## Truncation caps
+
+- **25 signatures per file** — files with more symbols are cut with a `… +N more signatures` notice; the least-informative entries fall off first.
+- **8 members per class/impl/interface block** — same notice pattern (`… +N more methods`).
+
+Large god-files are therefore **under-represented by design**: the caps are what keep the whole-repo map inside a model's context window.
+
+## Known regex gaps (Tier 2)
+
+- **Nested parentheses in parameter lists truncate at the first `)`** — `function f(a, b = g(x))` captures `(a, b = g(x` incorrectly. This is the documented precondition for the planned hand-rolled tokenizer core (G4) and the arity-check verifier that depends on it (D1).
+- Multi-line declaration headers that break between the name and the parameter list can be missed entirely.
+- Generic/type-parameter soup (deeply nested `<>`) is normalized textually, not parsed.
+
+## What this means for `verify` / `verify_suggestion`
+
+The Hallucination Guard builds its symbol index **from extracted signatures**. A real symbol that fell to the caps or slipped past a Tier-2/3 regex is absent from the index, so verifying code that references it produces a **`fake-symbol` flag at medium confidence** — a conservative false positive, not a silent pass. Mitigations already in place: language/runtime builtin allowlists, closest-match suggestions on every flag, and confidence capped at `medium` for exactly this class of miss. Treat medium-confidence symbol flags on very large files as "check the file" rather than "the AI hallucinated".
+
+## Not limitations (frequently asked)
+
+- **Byte-stability** — regenerating on an unchanged repo produces byte-identical output; drift is a bug, not an expectation.
+- **Offline** — nothing here calls a network or an LLM.
+- **Secret redaction** — signatures, `get_lines` output, evidence packs, and `sigmap redact` all pass through the same 10-pattern scanner; patterns are listed in the [CLI reference](https://sigmap.io/guide/cli#redact).
+
+<sub>Maintained alongside the code — if you find a claim here that the code contradicts, that is a bug: [open an issue](https://github.com/manojmallick/sigmap/issues).</sub>

--- a/README.md
+++ b/README.md
@@ -397,6 +397,18 @@ All implemented with zero external dependencies.
 
 [Full language table →](https://sigmap.io/guide/generalization.html)
 
+### Extraction honesty
+
+Not all 33 languages get the same depth — and we say so plainly:
+
+| Tier | Coverage | Depth |
+|------|----------|-------|
+| **AST** | Python (`python3` on PATH; regex fallback without) | Full parse |
+| **Anchored regex** | 11 brace languages (JS, TS, Go, Rust, Java, Kotlin, Swift, PHP, Scala, Dart, C#) | Declarations + `:start-end` line anchors; doc hints on 6 |
+| **Pattern/heuristic** | Everything else + generic fallback | Line-oriented patterns |
+
+Caps: 25 signatures/file · 8 members/block. Full details, known regex gaps, and what they mean for `verify`: **[KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md)**.
+
 ---
 
 ## License

--- a/test/integration/known-limitations.test.js
+++ b/test/integration/known-limitations.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * KNOWN_LIMITATIONS.md + README extraction-honesty tier label (G1, #520).
+ * Guards that the honesty page exists, states the tiers/caps/gaps, and that
+ * its quoted counts never drift from version.json or the actual extractors.
+ * Run: node test/integration/known-limitations.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DOC = fs.existsSync(path.join(ROOT, 'KNOWN_LIMITATIONS.md'))
+  ? fs.readFileSync(path.join(ROOT, 'KNOWN_LIMITATIONS.md'), 'utf8') : '';
+const README = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+const versionJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'version.json'), 'utf8'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+test('KNOWN_LIMITATIONS.md exists and names all three tiers', () => {
+  assert.ok(DOC.length > 0, 'KNOWN_LIMITATIONS.md missing');
+  assert.ok(/1 — AST/.test(DOC), 'Tier 1 (AST) missing');
+  assert.ok(/2 — anchored regex/.test(DOC), 'Tier 2 (anchored regex) missing');
+  assert.ok(/3 — pattern\/heuristic/.test(DOC), 'Tier 3 (pattern/heuristic) missing');
+});
+
+test('doc states both truncation caps and the nested-paren gap', () => {
+  assert.ok(/25 signatures per file/.test(DOC), '25 sigs/file cap missing');
+  assert.ok(/8 members per class/.test(DOC), '8 members/block cap missing');
+  assert.ok(/first `\)`/.test(DOC), 'nested-paren gap missing');
+});
+
+test('doc states the verify implication (fake-symbol at medium confidence)', () => {
+  assert.ok(DOC.includes('fake-symbol'), 'fake-symbol implication missing');
+  assert.ok(/medium confidence/.test(DOC), 'medium-confidence framing missing');
+  assert.ok(/false positive/.test(DOC), 'conservative false-positive framing missing');
+});
+
+test('doc counts match version.json (drift guard)', () => {
+  const m = DOC.match(/(\d+) extractor modules covering (\d+) languages/);
+  assert.ok(m, 'counts line missing from doc');
+  assert.strictEqual(Number(m[1]), versionJson.extractors, `doc says ${m[1]} extractors, version.json says ${versionJson.extractors}`);
+  assert.strictEqual(Number(m[2]), versionJson.languages, `doc says ${m[2]} languages, version.json says ${versionJson.languages}`);
+});
+
+test('Tier-2 anchored-language count matches the extractors that use withAnchor', () => {
+  const dir = path.join(ROOT, 'src', 'extractors');
+  const anchored = fs.readdirSync(dir).filter((f) =>
+    f.endsWith('.js') && f !== 'line-anchor.js' &&
+    fs.readFileSync(path.join(dir, f), 'utf8').includes('withAnchor'));
+  const m = DOC.match(/C# \((\d+)\)/);
+  assert.ok(m, 'Tier-2 count missing from doc');
+  assert.strictEqual(Number(m[1]), anchored.length,
+    `doc says ${m[1]} anchored languages, code has ${anchored.length}: ${anchored.join(', ')}`);
+});
+
+test('README carries the tier label and links KNOWN_LIMITATIONS.md', () => {
+  assert.ok(README.includes('### Extraction honesty'), 'README tier-label section missing');
+  assert.ok(README.includes('](KNOWN_LIMITATIONS.md)'), 'README link to KNOWN_LIMITATIONS.md missing');
+  assert.ok(/25 signatures\/file/.test(README), 'README caps summary missing');
+});
+
+console.log(`\n  known-limitations: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 132,
+  "tests": 133,
   "metrics": {
     "hit_at_5": 0.822,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #520

## Summary
- G1 "Trust Quick Wins" — the extraction layer gets the same honesty treatment the benchmarks got in v8.19: one page stating plainly what each extractor tier can and cannot do, mirrored as a compact tier label in README, drift-locked by a guard test.

## Changes
- `KNOWN_LIMITATIONS.md`: three-tier table (AST / anchored regex ×11 / pattern-heuristic), truncation caps (25 sigs/file · 8 members/block), the nested-paren regex gap (stated G4/D1 precondition), and the verify implication — index-missing real symbols flag `fake-symbol` at medium confidence (conservative false positive, never a silent pass)
- `README.md`: "Extraction honesty" tier label under the languages section, linking the full page
- `test/integration/known-limitations.test.js`: 6 guards, including counts drift-locked to `version.json` and the Tier-2 count cross-checked against the extractors that actually use `withAnchor`
- version.json tests 132 → 133 (llms unchanged — no CLI surface changed)

## Test plan
- [x] `node test/integration/known-limitations.test.js` — 6/6
- [x] `node test/integration/all.js` — 127 files, 0 failed
- [x] Supply-chain local audit PASS (docs-only; tarball unchanged, 166 files)