### PR TITLE
fix: benchmark cross-suite determinism — shared overrides + gate (#522)

### DIFF
--- a/benchmarks/config-overrides.json
+++ b/benchmarks/config-overrides.json
@@ -1,0 +1,117 @@
+{
+  "express": {
+    "srcDirs": [
+      "lib"
+    ]
+  },
+  "flask": {
+    "srcDirs": [
+      "src/flask"
+    ]
+  },
+  "spring-petclinic": {
+    "srcDirs": [
+      "src"
+    ]
+  },
+  "axios": {
+    "srcDirs": [
+      "lib"
+    ]
+  },
+  "serilog": {
+    "srcDirs": [
+      "src/Serilog"
+    ]
+  },
+  "gin": {
+    "srcDirs": [
+      "."
+    ]
+  },
+  "rails": {
+    "srcDirs": [
+      "activesupport/lib",
+      "actionpack/lib",
+      "railties/lib",
+      "activerecord/lib",
+      "actionview/lib",
+      "actionmailer/lib",
+      "activejob/lib"
+    ]
+  },
+  "rust-analyzer": {
+    "srcDirs": [
+      "crates"
+    ]
+  },
+  "abseil-cpp": {
+    "srcDirs": [
+      "absl"
+    ]
+  },
+  "riverpod": {
+    "srcDirs": [
+      "packages"
+    ]
+  },
+  "okhttp": {
+    "srcDirs": [
+      "okhttp/src/main/kotlin",
+      "okhttp-tls/src/main/kotlin",
+      "okhttp-logging-interceptor/src/main/kotlin"
+    ]
+  },
+  "laravel": {
+    "srcDirs": [
+      "src"
+    ]
+  },
+  "akka": {
+    "srcDirs": [
+      "akka-actor/src/main/scala",
+      "akka-stream/src/main/scala",
+      "akka-cluster/src/main/scala"
+    ]
+  },
+  "vapor": {
+    "srcDirs": [
+      "Sources"
+    ]
+  },
+  "vue-core": {
+    "srcDirs": [
+      "packages"
+    ]
+  },
+  "svelte": {
+    "srcDirs": [
+      "packages/svelte/src"
+    ]
+  },
+  "fastify": {
+    "srcDirs": [
+      "lib"
+    ]
+  },
+  "fastapi": {
+    "srcDirs": [
+      "fastapi"
+    ]
+  },
+  "ggplot2": {
+    "srcDirs": [
+      "R"
+    ]
+  },
+  "dplyr": {
+    "srcDirs": [
+      "R"
+    ]
+  },
+  "shiny": {
+    "srcDirs": [
+      "R"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "benchmark:centrality-blend": "node scripts/run-centrality-blend-benchmark.mjs --save",
     "benchmark:surface-enrichment": "node scripts/run-surface-enrichment-benchmark.mjs --save",
     "validate:squeeze": "node scripts/run-squeeze-benchmark.mjs --gate",
+    "validate:benchmark-determinism": "node scripts/check-benchmark-determinism.mjs --cross-suite",
     "health": "node gen-context.js --health",
     "map": "node gen-project-map.js",
     "mcp": "node gen-context.js --mcp",

--- a/scripts/check-benchmark-determinism.mjs
+++ b/scripts/check-benchmark-determinism.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-benchmark-determinism.mjs — the #522 reproducibility gate.
+ *
+ *   node scripts/check-benchmark-determinism.mjs                # two-run check
+ *   node scripts/check-benchmark-determinism.mjs --cross-suite  # + quality run between
+ *
+ * Two-run mode: runs `benchmark:honest` twice with nothing in between and
+ * fails unless the reports are identical (minus the `generated` timestamp).
+ *
+ * Cross-suite mode: additionally runs the quality suite between two honest
+ * runs and asserts the scores still match — proving the quality suite's
+ * context regeneration no longer skews the shared benchmark repos (the
+ * override-mismatch bug this gate exists for).
+ *
+ * Requires cached benchmark repos with generated context (run the retrieval
+ * benchmark first). Exit 1 on any divergence, with a per-repo diff.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const CROSS_SUITE = process.argv.includes('--cross-suite');
+
+function runJson(script, args = []) {
+  const res = spawnSync('node', [path.join(ROOT, 'scripts', script), ...args], {
+    cwd: ROOT, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024,
+  });
+  if (res.status !== 0) {
+    console.error(`[determinism] ${script} exited ${res.status}\n${(res.stderr || '').slice(0, 800)}`);
+    process.exit(1);
+  }
+  return JSON.parse(res.stdout);
+}
+
+function canonical(report) {
+  const { generated, ...rest } = report;
+  return JSON.stringify(rest, null, 2);
+}
+
+function diffRepos(a, b, label) {
+  const f = (x) => Object.fromEntries(x.repos.map((r) => [r.repo, r.sigmapHitAt5]));
+  const ra = f(a), rb = f(b);
+  let diverged = false;
+  for (const k of new Set([...Object.keys(ra), ...Object.keys(rb)])) {
+    if (ra[k] !== rb[k]) {
+      diverged = true;
+      console.error(`  DIVERGED [${label}] ${k}: ${ra[k]} → ${rb[k]}`);
+    }
+  }
+  return diverged;
+}
+
+console.log('[determinism] run 1: benchmark:honest');
+const run1 = runJson('run-honest-benchmark.mjs', ['--json']);
+
+if (CROSS_SUITE) {
+  console.log('[determinism] cross-suite: running the quality suite between honest runs');
+  const q = spawnSync('node', [path.join(ROOT, 'scripts', 'run-quality-benchmark.mjs')], {
+    cwd: ROOT, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024,
+  });
+  if (q.status !== 0) {
+    console.error(`[determinism] quality suite exited ${q.status} — cannot verify cross-suite stability`);
+    process.exit(1);
+  }
+}
+
+console.log('[determinism] run 2: benchmark:honest');
+const run2 = runJson('run-honest-benchmark.mjs', ['--json']);
+
+if (canonical(run1) === canonical(run2)) {
+  console.log(`[determinism] OK — ${CROSS_SUITE ? 'cross-suite ' : ''}runs identical`
+    + ` (hit@5 ${(run1.summary.sigmap.hitAt5 * 100).toFixed(1)}%, ${run1.summary.tasks} tasks)`);
+  process.exit(0);
+}
+
+console.error(`[determinism] FAIL — ${CROSS_SUITE ? 'the quality suite skewed the shared contexts' : 'consecutive runs diverged'}`);
+console.error(`  run 1 hit@5 ${(run1.summary.sigmap.hitAt5 * 100).toFixed(1)}%  →  run 2 hit@5 ${(run2.summary.sigmap.hitAt5 * 100).toFixed(1)}%`);
+diffRepos(run1, run2, CROSS_SUITE ? 'quality-skew' : 'rerun');
+process.exit(1);

--- a/scripts/run-honest-benchmark.mjs
+++ b/scripts/run-honest-benchmark.mjs
@@ -210,6 +210,11 @@ for (const f of taskFiles) {
     repo: name,
     tasks: tasks.length,
     bucket,
+    // The 'retrieval' task set scores against the LIVE SigMap repo (ROOT), so
+    // its context — and this row — legitimately drifts with every release.
+    // Labeled so cross-release comparisons never mistake it for harness
+    // instability (#522).
+    ...(repoPath === ROOT ? { selfRepo: true } : {}),
     sigmapHitAt5: round(row.sigHit / tasks.length),
     grepHitAt5: round(row.grepHit / tasks.length),
   });
@@ -256,7 +261,7 @@ if (JSON_OUT) {
   console.log('\n  repo                 tasks  SigMap  grep-agent');
   console.log('  -------------------- -----  ------  ----------');
   for (const r of perRepo) {
-    console.log(`  ${r.repo.padEnd(20)} ${String(r.tasks).padStart(5)}  ${pct(r.sigmapHitAt5)}  ${pct(r.grepHitAt5).padStart(9)}`);
+    console.log(`  ${(r.repo + (r.selfRepo ? '*' : '')).padEnd(20)} ${String(r.tasks).padStart(5)}  ${pct(r.sigmapHitAt5)}  ${pct(r.grepHitAt5).padStart(9)}`);
   }
   const s = report.summary;
   console.log(`\n  SigMap        hit@5 ${(s.sigmap.hitAt5 * 100).toFixed(1)}%   MRR ${s.sigmap.mrr.toFixed(3)}`);
@@ -269,6 +274,9 @@ if (JSON_OUT) {
   line('repos small', s.buckets.small);
   line('repos medium', s.buckets.medium);
   line('repos large', s.buckets.large);
+  if (perRepo.some((r) => r.selfRepo)) {
+    console.log('  * self-repo task set — scored against the live SigMap repo; drifts with development by design');
+  }
   for (const sk of skipped) console.log(`  [skipped] ${sk.repo}: ${sk.reason}`);
 }
 

--- a/scripts/run-quality-benchmark.mjs
+++ b/scripts/run-quality-benchmark.mjs
@@ -62,16 +62,27 @@ const tokenData = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
 function countGroundedSymbols(repoDir, configOverride) {
   const contextFile = path.join(repoDir, '.github', 'copilot-instructions.md');
   const configPath  = path.join(repoDir, 'gen-context.config.json');
-  const hadConfig   = fs.existsSync(configPath);
 
   if (!fs.existsSync(repoDir)) return 0;
 
-  if (!hadConfig && configOverride) {
+  // Mirror run-retrieval-benchmark.mjs exactly (#522): ALWAYS apply the shared
+  // override (even over a pre-existing config), regenerate, then restore the
+  // prior state. Regenerating with a different config than the retrieval
+  // harness silently rewrites the canonical context and skews every suite
+  // that reads it afterwards.
+  const existingConfig = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : null;
+  if (configOverride) {
     fs.writeFileSync(configPath, JSON.stringify(configOverride, null, 2));
   }
-  spawnSync('node', [GEN_CTX], { cwd: repoDir, encoding: 'utf8' });
-  if (!hadConfig && configOverride) {
-    try { fs.unlinkSync(configPath); } catch (_) {}
+  try {
+    spawnSync('node', [GEN_CTX], { cwd: repoDir, encoding: 'utf8' });
+  } finally {
+    if (configOverride) {
+      try {
+        if (existingConfig !== null) fs.writeFileSync(configPath, existingConfig);
+        else fs.unlinkSync(configPath);
+      } catch (_) {}
+    }
   }
 
   if (!fs.existsSync(contextFile)) return 0;
@@ -92,22 +103,13 @@ function countGroundedSymbols(repoDir, configOverride) {
   }).length;
 }
 
-// ─── Config overrides (same as run-benchmark.mjs) ────────────────────────────
-const CONFIG_OVERRIDES = {
-  'gin':              { srcDirs: ['.'] },
-  'rails':            { srcDirs: ['activesupport/lib','actionpack/lib','railties/lib','activerecord/lib','actionview/lib','actionmailer/lib','activejob/lib'] },
-  'rust-analyzer':    { srcDirs: ['crates'] },
-  'abseil-cpp':       { srcDirs: ['absl'] },
-  'riverpod':         { srcDirs: ['packages'] },
-  'okhttp':           { srcDirs: ['okhttp/src/main/kotlin','okhttp-tls/src/main/kotlin','okhttp-logging-interceptor/src/main/kotlin'] },
-  'laravel':          { srcDirs: ['src'] },
-  'akka':             { srcDirs: ['akka-actor/src/main/scala','akka-stream/src/main/scala','akka-cluster/src/main/scala'] },
-  'vapor':            { srcDirs: ['Sources'] },
-  'vue-core':         { srcDirs: ['packages'] },
-  'svelte':           { srcDirs: ['packages/svelte/src'] },
-  'fastify':          { srcDirs: ['lib'] },
-  'fastapi':          { srcDirs: ['fastapi'] },
-};
+// ─── Config overrides — shared single source of truth (#522) ─────────────────
+// The old local copy here was a 13-entry subset of the retrieval harness's
+// table; the missing entries (express, flask, spring-petclinic, serilog, …)
+// meant this suite regenerated those repos with default srcDirs, overwriting
+// the canonical contexts and decaying every later honest/retrieval score.
+const CONFIG_OVERRIDES = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'benchmarks', 'config-overrides.json'), 'utf8'));
 
 // ─── Per-repo analysis ────────────────────────────────────────────────────────
 function pad(s, w, right = false) {

--- a/scripts/run-retrieval-benchmark.mjs
+++ b/scripts/run-retrieval-benchmark.mjs
@@ -64,53 +64,12 @@ const REPOS = [
   { repo: 'shiny',            fileCount: 101  },
 ];
 
-const CONFIG_OVERRIDES = {
-  // Explicit srcDirs prevent test/, docs/, .idea/ etc. from polluting the index
-  express: { srcDirs: ['lib'] },
-  flask: { srcDirs: ['src/flask'] },
-  'spring-petclinic': { srcDirs: ['src'] },
-  axios: { srcDirs: ['lib'] },
-  serilog: { srcDirs: ['src/Serilog'] },
-  gin: { srcDirs: ['.'] },
-  rails: {
-    srcDirs: [
-      'activesupport/lib',
-      'actionpack/lib',
-      'railties/lib',
-      'activerecord/lib',
-      'actionview/lib',
-      'actionmailer/lib',
-      'activejob/lib',
-    ],
-  },
-  'rust-analyzer': { srcDirs: ['crates'] },
-  'abseil-cpp': { srcDirs: ['absl'] },
-  riverpod: { srcDirs: ['packages'] },
-  okhttp: {
-    srcDirs: [
-      'okhttp/src/main/kotlin',
-      'okhttp-tls/src/main/kotlin',
-      'okhttp-logging-interceptor/src/main/kotlin',
-    ],
-  },
-  laravel: { srcDirs: ['src'] },
-  akka: {
-    srcDirs: [
-      'akka-actor/src/main/scala',
-      'akka-stream/src/main/scala',
-      'akka-cluster/src/main/scala',
-    ],
-  },
-  vapor: { srcDirs: ['Sources'] },
-  'vue-core': { srcDirs: ['packages'] },
-  svelte: { srcDirs: ['packages/svelte/src'] },
-  fastify: { srcDirs: ['lib'] },
-  fastapi: { srcDirs: ['fastapi'] },
-  // R language (v6.10.10+)
-  ggplot2: { srcDirs: ['R'] },
-  dplyr: { srcDirs: ['R'] },
-  shiny: { srcDirs: ['R'] },
-};
+// Explicit srcDirs prevent test/, docs/, .idea/ etc. from polluting the index.
+// Single source of truth shared by every suite that regenerates repo contexts —
+// divergent copies caused the #522 cross-suite skew (a repo regenerated with a
+// different config scores differently in every later suite).
+const CONFIG_OVERRIDES = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'benchmarks', 'config-overrides.json'), 'utf8'));
 
 // ---------------------------------------------------------------------------
 // Ranking — identifier-aware BM25, shared with src/eval/runner.js (#395)

--- a/test/integration/benchmark-determinism.test.js
+++ b/test/integration/benchmark-determinism.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * #522 benchmark-determinism guards — source-level, CI-safe (no cloned repos).
+ * The full two-run/cross-suite gate is `npm run validate:benchmark-determinism`
+ * (needs cached benchmark repos); these guards keep the fix from regressing
+ * structurally: one shared override table, mirrored apply/restore semantics,
+ * the labeled self-repo set, and the gate itself staying wired.
+ * Run: node test/integration/benchmark-determinism.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+test('benchmarks/config-overrides.json exists, parses, and covers the skew repos', () => {
+  const overrides = JSON.parse(read('benchmarks/config-overrides.json'));
+  // The four repos whose absence from the quality suite's table caused the
+  // measured 11.2pt cross-suite decay (plus two sanity anchors).
+  for (const repo of ['express', 'flask', 'spring-petclinic', 'serilog', 'rails', 'gin']) {
+    assert.ok(overrides[repo] && Array.isArray(overrides[repo].srcDirs), `missing override: ${repo}`);
+  }
+});
+
+test('retrieval and quality suites both load the shared table — no local copies', () => {
+  for (const script of ['scripts/run-retrieval-benchmark.mjs', 'scripts/run-quality-benchmark.mjs']) {
+    const src = read(script);
+    assert.ok(src.includes("config-overrides.json"), `${script} must load the shared table`);
+    assert.ok(!/CONFIG_OVERRIDES = \{\s*\n\s+['"a-z]/.test(src), `${script} still defines a local override table`);
+  }
+});
+
+test('quality suite mirrors retrieval apply/restore semantics', () => {
+  const q = read('scripts/run-quality-benchmark.mjs');
+  assert.ok(q.includes('existingConfig'), 'quality must snapshot the pre-existing config');
+  assert.ok(!/!hadConfig && configOverride/.test(q), 'quality must ALWAYS apply the override, not only when no config exists');
+  assert.ok(/finally\s*\{/.test(q), 'quality must restore the prior config in finally');
+});
+
+test('honest benchmark labels the self-repo task set', () => {
+  const h = read('scripts/run-honest-benchmark.mjs');
+  assert.ok(h.includes('selfRepo'), 'selfRepo label missing from honest script');
+  assert.ok(h.includes('self-repo task set'), 'human-output note for the self-repo set missing');
+});
+
+test('determinism gate exists and is wired as an npm script', () => {
+  assert.ok(fs.existsSync(path.join(ROOT, 'scripts', 'check-benchmark-determinism.mjs')), 'gate script missing');
+  const pkg = JSON.parse(read('package.json'));
+  assert.ok(pkg.scripts['validate:benchmark-determinism'], 'validate:benchmark-determinism npm script missing');
+  assert.ok(pkg.scripts['validate:benchmark-determinism'].includes('--cross-suite'), 'gate must run in cross-suite mode');
+});
+
+console.log(`\n  benchmark-determinism: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 133,
+  "tests": 134,
   "metrics": {
     "hit_at_5": 0.822,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #522

## Summary
- The honest benchmark's instability is diagnosed and fixed. Both root causes were **measured, not guessed**, and the fix is proven by a new cross-suite gate that runs green.

## Diagnosis
| Symptom | Cause |
|---|---|
| 77.6% → 66.4% after a quality run (flask 0.875 → **0**) | Quality carried a 13-entry local copy of the retrieval harness's 21-entry override table and regenerated **all** repos unconditionally — express/flask/spring-petclinic/serilog got default-srcDirs contexts, overwriting the canonical ones |
| 82.4% → 77.6% across releases | The 20-task `retrieval` set scores against **ROOT (the live SigMap repo)** — legitimate development drift (0.85 → 0.55 over three releases), previously invisible |
| Back-to-back runs | Already byte-identical — the scorer was never the problem |

## Fixes
- `benchmarks/config-overrides.json`: single canonical table; both suites load it, local copies deleted
- Quality now mirrors retrieval's apply/restore semantics exactly (always apply · regenerate · restore in `finally`)
- Honest report labels the self-repo row (`selfRepo: true`, `*` + note in output)
- `npm run validate:benchmark-determinism`: honest → quality → honest must be identical. **Verified green post-fix: identical at 77.6% / 125 tasks**
- 5 CI-safe source-level guards (`benchmark-determinism.test.js`); tests 133 → 134

## Notes for the release chain
- Committed benchmark reports intentionally untouched here — the next `/update-docs` refreshes them on the stable harness; expect the honest headline to settle at the canonical post-retrieval value with the self-repo drift now labeled
- Tarball unaffected (nothing here is published surface)

## Test plan
- [x] `node test/integration/benchmark-determinism.test.js` — 5/5
- [x] `node test/integration/all.js` — 128 files, 0 failed
- [x] `npm run validate:benchmark-determinism` — cross-suite identical