### PR TITLE
feat: arity-checked verification for JS/TS + Python (D1)

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -31,6 +31,8 @@ Large god-files are therefore **under-represented by design**: the caps are what
 
 The Hallucination Guard builds its symbol index **from extracted signatures**. A real symbol that fell to the caps or slipped past a Tier-2/3 regex is absent from the index, so verifying code that references it produces a **`fake-symbol` flag at medium confidence** — a conservative false positive, not a silent pass. Mitigations already in place: language/runtime builtin allowlists, closest-match suggestions on every flag, and confidence capped at `medium` for exactly this class of miss. Treat medium-confidence symbol flags on very large files as "check the file" rather than "the AI hallucinated".
 
+Since the balanced scanner (v8.27) made JS/TS params exact, `verify` also runs **arity checks** (`arity-mismatch`, medium confidence) — but only where they can be trusted: uniquely-resolved top-level functions from exact-param languages (JS/TS + Python), non-variadic signatures, undotted calls. Method calls, ambiguous names, `...rest`/`*args` signatures, and every other Tier-2/3 language are deliberately not checked yet.
+
 ## Not limitations (frequently asked)
 
 - **Byte-stability** — regenerating on an unchanged repo produces byte-identical output; drift is a bug, not an expectation.

--- a/gen-context.js
+++ b/gen-context.js
@@ -19579,6 +19579,190 @@ __factories["./src/util/truncate"] = function(module, exports) {
   
 };
 
+// ── ./src/verify/arity ──
+__factories["./src/verify/arity"] = function(module, exports) {
+  
+  /**
+   * Arity-checked verification (D1, #529).
+   *
+   * With JS/TS params exact (v8.27 balanced scanner) and Python params from the
+   * AST, the signature index carries real parameter lists — so verification can
+   * check not just "does this function exist" but "is this call's argument
+   * count plausible". Deliberately conservative: only uniquely-resolved,
+   * non-variadic, top-level functions from exact-param languages are checked,
+   * and dotted method calls are never flagged.
+   */
+
+  const path = require('path');
+  const { maskCode, readBalanced } = __require('./src/extractors/scan');
+
+  // Files whose signature params are exact (JS/TS via scan.js, Python via AST).
+  const EXACT_PARAM_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.py']);
+
+  const CTRL_KEYWORDS = new Set([
+    'if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'await',
+    'do', 'else', 'try', 'finally', 'new', 'in', 'of', 'not', 'and', 'or',
+    'print', 'super', 'this',
+  ]);
+
+  // Top-level callable sig shapes (indented member sigs are excluded on purpose
+  // — method calls are dotted in answers and dotted calls are skipped anyway).
+  const CALLABLE_RES = [
+    /^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/,
+    /^(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?\(/,
+    /^(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(/,
+  ];
+
+  /** Strip the `  :start-end` anchor and `  # hint` tail from a sig line. */
+  function cleanSig(sig) {
+    return String(sig).replace(/\s{2}#\s.*$/, '').replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+  }
+
+  /**
+   * Parse a parameter-list string into an arity range.
+   * Depth- and quote-aware top-level comma split; `=` defaults and trailing `?`
+   * lower `min`; `...rest` / `*args` / `**kwargs` mark the signature variadic;
+   * destructuring patterns count as one parameter.
+   * @param {string} paramText text between the signature's parens
+   * @returns {{ min: number, max: number, variadic: boolean }}
+   */
+  function parseParams(paramText) {
+    const text = String(paramText || '').trim();
+    if (!text) return { min: 0, max: 0, variadic: false };
+    const masked = maskCode(text);
+    const pieces = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < masked.length; i++) {
+      const ch = masked[i];
+      if (ch === '(' || ch === '[' || ch === '{') depth++;
+      else if (ch === ')' || ch === ']' || ch === '}') depth--;
+      else if (ch === ',' && depth === 0) { pieces.push({ raw: text.slice(start, i), masked: masked.slice(start, i) }); start = i + 1; }
+    }
+    pieces.push({ raw: text.slice(start), masked: masked.slice(start) });
+
+    let min = 0;
+    let max = 0;
+    let variadic = false;
+    for (const piece of pieces) {
+      const p = piece.raw.trim();
+      if (!p) continue;
+      if (/^(\.\.\.|\*)/.test(p)) { variadic = true; continue; }
+      max++;
+      // Optional: a top-level `=` default (scan the masked piece at depth 0) or
+      // a `?`-suffixed name (TS optional, survives type stripping as `x?`).
+      let d = 0;
+      let optional = /^[A-Za-z_$][\w$]*\s*\?$/.test(p);
+      const pm = piece.masked;
+      for (let i = 0; i < pm.length && !optional; i++) {
+        const ch = pm[i];
+        if (ch === '(' || ch === '[' || ch === '{') d++;
+        else if (ch === ')' || ch === ']' || ch === '}') d--;
+        else if (ch === '=' && d === 0 && pm[i + 1] !== '>' && pm[i - 1] !== '=' && pm[i - 1] !== '!' && pm[i - 1] !== '<' && pm[i - 1] !== '>') optional = true;
+      }
+      if (!optional) min++;
+    }
+    return { min, max, variadic };
+  }
+
+  /**
+   * Build a per-name arity index from a SigMap signature index.
+   * Only top-level callables from exact-param languages are included; a name
+   * whose signatures disagree across files is marked ambiguous (never checked).
+   * @param {Map<string, string[]>} sigIndex Map<file, sigs[]>
+   * @returns {Map<string, { min, max, variadic, file, sig } | 'ambiguous'>}
+   */
+  function buildArityIndex(sigIndex) {
+    const index = new Map();
+    if (!sigIndex || !(sigIndex instanceof Map)) return index;
+    for (const [file, sigs] of sigIndex.entries()) {
+      if (!EXACT_PARAM_EXTS.has(path.extname(file))) continue;
+      for (const sig of sigs || []) {
+        const cleaned = cleanSig(sig);
+        let name = null;
+        for (const re of CALLABLE_RES) {
+          const m = cleaned.match(re);
+          if (m) { name = m[1]; break; }
+        }
+        if (!name) continue;
+        const openIdx = cleaned.indexOf('(', cleaned.indexOf(name));
+        if (openIdx === -1) continue;
+        const masked = maskCode(cleaned);
+        const closeIdx = readBalanced(masked, openIdx);
+        if (closeIdx === -1) continue;
+        const arity = parseParams(cleaned.slice(openIdx + 1, closeIdx));
+        const entry = { ...arity, file, sig: cleaned.trim() };
+        const existing = index.get(name);
+        if (existing === undefined) index.set(name, entry);
+        else if (existing === 'ambiguous') continue;
+        else if (existing.min !== entry.min || existing.max !== entry.max || existing.variadic !== entry.variadic) {
+          index.set(name, 'ambiguous');
+        }
+      }
+    }
+    return index;
+  }
+
+  /**
+   * Extract call sites with argument counts from answer code.
+   * Dotted/property calls and keyword-preceded definitions are skipped for
+   * precision; nested calls and comma-containing strings count correctly
+   * because the scan is over masked text.
+   * @param {string} code
+   * @returns {{ name: string, args: number, line: number }[]}
+   */
+  function extractCallArgCounts(code) {
+    const src = String(code || '');
+    const masked = maskCode(src);
+    const calls = [];
+    const re = /([A-Za-z_$][\w$]*)\s*\(/g;
+    let m;
+    while ((m = re.exec(masked)) !== null) {
+      const name = m[1];
+      if (CTRL_KEYWORDS.has(name)) continue;
+      let k = m.index - 1;
+      while (k >= 0 && (masked[k] === ' ' || masked[k] === '\t')) k--;
+      if (k >= 0 && (masked[k] === '.' || masked[k] === '$')) continue;
+      const before = masked.slice(Math.max(0, m.index - 12), m.index);
+      if (/(?:function|def|class|new)\s+$/.test(before)) continue;
+      const openIdx = m.index + m[0].length - 1;
+      const closeIdx = readBalanced(masked, openIdx);
+      if (closeIdx === -1) continue;
+      const inner = masked.slice(openIdx + 1, closeIdx);
+      let args = 0;
+      // Emptiness is judged on the ORIGINAL text — masking blanks string
+      // contents, so `f("a,b")` would otherwise look like zero arguments.
+      if (src.slice(openIdx + 1, closeIdx).trim()) {
+        args = 1;
+        let depth = 0;
+        for (let i = 0; i < inner.length; i++) {
+          const ch = inner[i];
+          if (ch === '(' || ch === '[' || ch === '{') depth++;
+          else if (ch === ')' || ch === ']' || ch === '}') depth--;
+          else if (ch === ',' && depth === 0) args++;
+        }
+      }
+      calls.push({ name, args, line: src.slice(0, m.index).split('\n').length });
+    }
+    return calls;
+  }
+
+  /**
+   * Check one call against the arity index.
+   * @returns {null | { min, max, variadic, file, sig }} the offended entry, or null when fine/unknowable
+   */
+  function checkArity(name, argCount, arityIndex) {
+    const entry = arityIndex.get(name);
+    if (!entry || entry === 'ambiguous') return null;
+    if (entry.variadic) return argCount < entry.min ? entry : null;
+    if (argCount < entry.min || argCount > entry.max) return entry;
+    return null;
+  }
+
+  module.exports = { parseParams, buildArityIndex, extractCallArgCounts, checkArity, cleanSig, EXACT_PARAM_EXTS };
+  
+};
+
 // ── ./src/verify/closest-match ──
 __factories["./src/verify/closest-match"] = function(module, exports) {
   
@@ -19753,6 +19937,7 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
   const parsers = __require('./src/verify/parsers');
   const { closestMatch, buildSymbolCandidates, formatSuggestion } = __require('./src/verify/closest-match');
   const { buildLibraryIndex } = __require('./src/verify/lib-index');
+  const { buildArityIndex, extractCallArgCounts, checkArity } = __require('./src/verify/arity');
 
   // A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
   // a tests/__tests__ directory). Used to flag fake-test-file separately.
@@ -19808,9 +19993,11 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
     const set = new Set();
     let fileKeys = [];
     let symbolCandidates = [];
+    let sigIndex = null;
     try {
       const { buildSigIndex } = __require('./src/retrieval/ranker');
       const idx = buildSigIndex(cwd);
+      sigIndex = idx;
       fileKeys = [...idx.keys()];
       for (const sigs of idx.values()) {
         for (const sig of sigs) {
@@ -19821,7 +20008,7 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
       }
       symbolCandidates = buildSymbolCandidates(idx);
     } catch (_) {}
-    return { set, fileKeys, symbolCandidates };
+    return { set, fileKeys, symbolCandidates, sigIndex };
   }
 
   /** Load declared dependency names from package.json. */
@@ -19910,6 +20097,7 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
     let fileBasenames = opts.fileBasenames;
     let symbolCandidates = opts.symbolCandidates || [];
     let fileCandidates = opts.fileCandidates || [];
+    let arityIndex = opts.arityIndex || null;
     if (!symbolSet) {
       const built = buildSymbolSet(cwd);
       symbolSet = built.set;
@@ -19918,6 +20106,9 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
       ));
       symbolCandidates = built.symbolCandidates;
       fileCandidates = built.fileKeys;
+      if (!arityIndex && built.sigIndex) {
+        try { arityIndex = buildArityIndex(built.sigIndex); } catch (_) {}
+      }
     }
     if (!fileBasenames) fileBasenames = new Set();
 
@@ -20033,6 +20224,32 @@ __factories["./src/verify/hallucination-guard"] = function(module, exports) {
           confidence: 'medium',
           suggestion: match ? formatSuggestion(match, true) : null,
         });
+      }
+    }
+
+    // 3b. arity-mismatch (D1, #529) — a call to a KNOWN repo function whose
+    // argument count falls outside the signature's [min, max]. Conservative by
+    // construction: only uniquely-resolved, top-level functions from
+    // exact-param languages (JS/TS via the balanced scanner, Python via AST);
+    // variadic signatures only flag too-few; dotted calls never flag.
+    if (arityIndex && arityIndex.size > 0) {
+      for (const block of parsers.extractCodeBlocks(answerText)) {
+        if (block.lang && !/^(js|jsx|ts|tsx|javascript|typescript|python|py)$/i.test(block.lang)) continue;
+        for (const call of extractCallArgCounts(block.content)) {
+          if (!symbolSet.has(call.name)) continue; // unknown symbols stay fake-symbol territory
+          const entry = checkArity(call.name, call.args, arityIndex);
+          if (!entry) continue;
+          const range = entry.variadic ? `at least ${entry.min}`
+            : (entry.min === entry.max ? String(entry.max) : `${entry.min}–${entry.max}`);
+          add({
+            type: 'arity-mismatch',
+            value: `${call.name}(${call.args} args)`,
+            line: block.line + call.line - 1,
+            message: `${call.name}() called with ${call.args} argument(s) — repo signature takes ${range}`,
+            confidence: 'medium',
+            suggestion: `${entry.sig}  (${entry.file})`,
+          });
+        }
       }
     }
 

--- a/src/verify/arity.js
+++ b/src/verify/arity.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * Arity-checked verification (D1, #529).
+ *
+ * With JS/TS params exact (v8.27 balanced scanner) and Python params from the
+ * AST, the signature index carries real parameter lists — so verification can
+ * check not just "does this function exist" but "is this call's argument
+ * count plausible". Deliberately conservative: only uniquely-resolved,
+ * non-variadic, top-level functions from exact-param languages are checked,
+ * and dotted method calls are never flagged.
+ */
+
+const path = require('path');
+const { maskCode, readBalanced } = require('../extractors/scan');
+
+// Files whose signature params are exact (JS/TS via scan.js, Python via AST).
+const EXACT_PARAM_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.py']);
+
+const CTRL_KEYWORDS = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'await',
+  'do', 'else', 'try', 'finally', 'new', 'in', 'of', 'not', 'and', 'or',
+  'print', 'super', 'this',
+]);
+
+// Top-level callable sig shapes (indented member sigs are excluded on purpose
+// — method calls are dotted in answers and dotted calls are skipped anyway).
+const CALLABLE_RES = [
+  /^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/,
+  /^(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?\(/,
+  /^(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(/,
+];
+
+/** Strip the `  :start-end` anchor and `  # hint` tail from a sig line. */
+function cleanSig(sig) {
+  return String(sig).replace(/\s{2}#\s.*$/, '').replace(/\s*:\d+(?:-\d+)?\s*$/, '');
+}
+
+/**
+ * Parse a parameter-list string into an arity range.
+ * Depth- and quote-aware top-level comma split; `=` defaults and trailing `?`
+ * lower `min`; `...rest` / `*args` / `**kwargs` mark the signature variadic;
+ * destructuring patterns count as one parameter.
+ * @param {string} paramText text between the signature's parens
+ * @returns {{ min: number, max: number, variadic: boolean }}
+ */
+function parseParams(paramText) {
+  const text = String(paramText || '').trim();
+  if (!text) return { min: 0, max: 0, variadic: false };
+  const masked = maskCode(text);
+  const pieces = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') depth--;
+    else if (ch === ',' && depth === 0) { pieces.push({ raw: text.slice(start, i), masked: masked.slice(start, i) }); start = i + 1; }
+  }
+  pieces.push({ raw: text.slice(start), masked: masked.slice(start) });
+
+  let min = 0;
+  let max = 0;
+  let variadic = false;
+  for (const piece of pieces) {
+    const p = piece.raw.trim();
+    if (!p) continue;
+    if (/^(\.\.\.|\*)/.test(p)) { variadic = true; continue; }
+    max++;
+    // Optional: a top-level `=` default (scan the masked piece at depth 0) or
+    // a `?`-suffixed name (TS optional, survives type stripping as `x?`).
+    let d = 0;
+    let optional = /^[A-Za-z_$][\w$]*\s*\?$/.test(p);
+    const pm = piece.masked;
+    for (let i = 0; i < pm.length && !optional; i++) {
+      const ch = pm[i];
+      if (ch === '(' || ch === '[' || ch === '{') d++;
+      else if (ch === ')' || ch === ']' || ch === '}') d--;
+      else if (ch === '=' && d === 0 && pm[i + 1] !== '>' && pm[i - 1] !== '=' && pm[i - 1] !== '!' && pm[i - 1] !== '<' && pm[i - 1] !== '>') optional = true;
+    }
+    if (!optional) min++;
+  }
+  return { min, max, variadic };
+}
+
+/**
+ * Build a per-name arity index from a SigMap signature index.
+ * Only top-level callables from exact-param languages are included; a name
+ * whose signatures disagree across files is marked ambiguous (never checked).
+ * @param {Map<string, string[]>} sigIndex Map<file, sigs[]>
+ * @returns {Map<string, { min, max, variadic, file, sig } | 'ambiguous'>}
+ */
+function buildArityIndex(sigIndex) {
+  const index = new Map();
+  if (!sigIndex || !(sigIndex instanceof Map)) return index;
+  for (const [file, sigs] of sigIndex.entries()) {
+    if (!EXACT_PARAM_EXTS.has(path.extname(file))) continue;
+    for (const sig of sigs || []) {
+      const cleaned = cleanSig(sig);
+      let name = null;
+      for (const re of CALLABLE_RES) {
+        const m = cleaned.match(re);
+        if (m) { name = m[1]; break; }
+      }
+      if (!name) continue;
+      const openIdx = cleaned.indexOf('(', cleaned.indexOf(name));
+      if (openIdx === -1) continue;
+      const masked = maskCode(cleaned);
+      const closeIdx = readBalanced(masked, openIdx);
+      if (closeIdx === -1) continue;
+      const arity = parseParams(cleaned.slice(openIdx + 1, closeIdx));
+      const entry = { ...arity, file, sig: cleaned.trim() };
+      const existing = index.get(name);
+      if (existing === undefined) index.set(name, entry);
+      else if (existing === 'ambiguous') continue;
+      else if (existing.min !== entry.min || existing.max !== entry.max || existing.variadic !== entry.variadic) {
+        index.set(name, 'ambiguous');
+      }
+    }
+  }
+  return index;
+}
+
+/**
+ * Extract call sites with argument counts from answer code.
+ * Dotted/property calls and keyword-preceded definitions are skipped for
+ * precision; nested calls and comma-containing strings count correctly
+ * because the scan is over masked text.
+ * @param {string} code
+ * @returns {{ name: string, args: number, line: number }[]}
+ */
+function extractCallArgCounts(code) {
+  const src = String(code || '');
+  const masked = maskCode(src);
+  const calls = [];
+  const re = /([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(masked)) !== null) {
+    const name = m[1];
+    if (CTRL_KEYWORDS.has(name)) continue;
+    let k = m.index - 1;
+    while (k >= 0 && (masked[k] === ' ' || masked[k] === '\t')) k--;
+    if (k >= 0 && (masked[k] === '.' || masked[k] === '$')) continue;
+    const before = masked.slice(Math.max(0, m.index - 12), m.index);
+    if (/(?:function|def|class|new)\s+$/.test(before)) continue;
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = readBalanced(masked, openIdx);
+    if (closeIdx === -1) continue;
+    const inner = masked.slice(openIdx + 1, closeIdx);
+    let args = 0;
+    // Emptiness is judged on the ORIGINAL text — masking blanks string
+    // contents, so `f("a,b")` would otherwise look like zero arguments.
+    if (src.slice(openIdx + 1, closeIdx).trim()) {
+      args = 1;
+      let depth = 0;
+      for (let i = 0; i < inner.length; i++) {
+        const ch = inner[i];
+        if (ch === '(' || ch === '[' || ch === '{') depth++;
+        else if (ch === ')' || ch === ']' || ch === '}') depth--;
+        else if (ch === ',' && depth === 0) args++;
+      }
+    }
+    calls.push({ name, args, line: src.slice(0, m.index).split('\n').length });
+  }
+  return calls;
+}
+
+/**
+ * Check one call against the arity index.
+ * @returns {null | { min, max, variadic, file, sig }} the offended entry, or null when fine/unknowable
+ */
+function checkArity(name, argCount, arityIndex) {
+  const entry = arityIndex.get(name);
+  if (!entry || entry === 'ambiguous') return null;
+  if (entry.variadic) return argCount < entry.min ? entry : null;
+  if (argCount < entry.min || argCount > entry.max) return entry;
+  return null;
+}
+
+module.exports = { parseParams, buildArityIndex, extractCallArgCounts, checkArity, cleanSig, EXACT_PARAM_EXTS };

--- a/src/verify/hallucination-guard.js
+++ b/src/verify/hallucination-guard.js
@@ -22,6 +22,7 @@ const path = require('path');
 const parsers = require('./parsers');
 const { closestMatch, buildSymbolCandidates, formatSuggestion } = require('./closest-match');
 const { buildLibraryIndex } = require('./lib-index');
+const { buildArityIndex, extractCallArgCounts, checkArity } = require('./arity');
 
 // A path that looks like a test file (JS/TS spec/test, Python test_/_test, or
 // a tests/__tests__ directory). Used to flag fake-test-file separately.
@@ -77,9 +78,11 @@ function buildSymbolSet(cwd) {
   const set = new Set();
   let fileKeys = [];
   let symbolCandidates = [];
+  let sigIndex = null;
   try {
     const { buildSigIndex } = require('../retrieval/ranker');
     const idx = buildSigIndex(cwd);
+    sigIndex = idx;
     fileKeys = [...idx.keys()];
     for (const sigs of idx.values()) {
       for (const sig of sigs) {
@@ -90,7 +93,7 @@ function buildSymbolSet(cwd) {
     }
     symbolCandidates = buildSymbolCandidates(idx);
   } catch (_) {}
-  return { set, fileKeys, symbolCandidates };
+  return { set, fileKeys, symbolCandidates, sigIndex };
 }
 
 /** Load declared dependency names from package.json. */
@@ -179,6 +182,7 @@ function verify(answerText, cwd, opts = {}) {
   let fileBasenames = opts.fileBasenames;
   let symbolCandidates = opts.symbolCandidates || [];
   let fileCandidates = opts.fileCandidates || [];
+  let arityIndex = opts.arityIndex || null;
   if (!symbolSet) {
     const built = buildSymbolSet(cwd);
     symbolSet = built.set;
@@ -187,6 +191,9 @@ function verify(answerText, cwd, opts = {}) {
     ));
     symbolCandidates = built.symbolCandidates;
     fileCandidates = built.fileKeys;
+    if (!arityIndex && built.sigIndex) {
+      try { arityIndex = buildArityIndex(built.sigIndex); } catch (_) {}
+    }
   }
   if (!fileBasenames) fileBasenames = new Set();
 
@@ -302,6 +309,32 @@ function verify(answerText, cwd, opts = {}) {
         confidence: 'medium',
         suggestion: match ? formatSuggestion(match, true) : null,
       });
+    }
+  }
+
+  // 3b. arity-mismatch (D1, #529) — a call to a KNOWN repo function whose
+  // argument count falls outside the signature's [min, max]. Conservative by
+  // construction: only uniquely-resolved, top-level functions from
+  // exact-param languages (JS/TS via the balanced scanner, Python via AST);
+  // variadic signatures only flag too-few; dotted calls never flag.
+  if (arityIndex && arityIndex.size > 0) {
+    for (const block of parsers.extractCodeBlocks(answerText)) {
+      if (block.lang && !/^(js|jsx|ts|tsx|javascript|typescript|python|py)$/i.test(block.lang)) continue;
+      for (const call of extractCallArgCounts(block.content)) {
+        if (!symbolSet.has(call.name)) continue; // unknown symbols stay fake-symbol territory
+        const entry = checkArity(call.name, call.args, arityIndex);
+        if (!entry) continue;
+        const range = entry.variadic ? `at least ${entry.min}`
+          : (entry.min === entry.max ? String(entry.max) : `${entry.min}–${entry.max}`);
+        add({
+          type: 'arity-mismatch',
+          value: `${call.name}(${call.args} args)`,
+          line: block.line + call.line - 1,
+          message: `${call.name}() called with ${call.args} argument(s) — repo signature takes ${range}`,
+          confidence: 'medium',
+          suggestion: `${entry.sig}  (${entry.file})`,
+        });
+      }
     }
   }
 

--- a/test/integration/arity-verify.test.js
+++ b/test/integration/arity-verify.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * D1 arity-checked verification (#529).
+ * Run: node test/integration/arity-verify.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { parseParams, buildArityIndex, extractCallArgCounts, checkArity } = require(path.join(ROOT, 'src/verify/arity.js'));
+const { verify } = require(path.join(ROOT, 'src/verify/hallucination-guard.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+// ── parseParams ─────────────────────────────────────────────────────────────
+
+test('parseParams: required, defaults, nested defaults, TS optionals, rest, destructuring', () => {
+  assert.deepStrictEqual(parseParams('a, b'), { min: 2, max: 2, variadic: false });
+  assert.deepStrictEqual(parseParams('a, b = g(x), c = ")"'), { min: 1, max: 3, variadic: false });
+  assert.deepStrictEqual(parseParams('...rest'), { min: 0, max: 0, variadic: true });
+  assert.deepStrictEqual(parseParams('x, y=1, *args'), { min: 1, max: 2, variadic: true });
+  assert.deepStrictEqual(parseParams('a, **kwargs'), { min: 1, max: 1, variadic: true });
+  assert.deepStrictEqual(parseParams('{ a, b }, [c]'), { min: 2, max: 2, variadic: false });
+  assert.deepStrictEqual(parseParams('q, filter?'), { min: 1, max: 2, variadic: false });
+  assert.deepStrictEqual(parseParams(''), { min: 0, max: 0, variadic: false });
+});
+
+// ── buildArityIndex ─────────────────────────────────────────────────────────
+
+function sampleIndex() {
+  return buildArityIndex(new Map([
+    ['src/a.js', ['export function add(a, b) → number  :5-5  # Adds two numbers', 'function only(x)  :9-9', 'export const spread = (...args) =>  :12-12']],
+    ['src/b.py', ['def greet(name, greeting="hi")  :3-8']],
+    ['src/c.js', ['function add(a, b, c)  :1-1']],
+    ['src/d.go', ['func Skip(a int)  :1-1']],
+    ['src/e.js', ['class Thing', '  method(a, b)  :4-6']],
+  ]));
+}
+
+test('buildArityIndex: exact-param languages only; conflicts → ambiguous; members excluded', () => {
+  const idx = sampleIndex();
+  assert.strictEqual(idx.get('add'), 'ambiguous', 'conflicting arities must be ambiguous');
+  assert.deepStrictEqual({ min: idx.get('only').min, max: idx.get('only').max }, { min: 1, max: 1 });
+  assert.deepStrictEqual({ min: idx.get('greet').min, max: idx.get('greet').max }, { min: 1, max: 2 });
+  assert.strictEqual(idx.get('spread').variadic, true);
+  assert.strictEqual(idx.get('Skip'), undefined, 'Go sigs must not enter the arity index');
+  assert.strictEqual(idx.get('method'), undefined, 'indented members must not enter the index');
+});
+
+// ── extractCallArgCounts ────────────────────────────────────────────────────
+
+test('extractCallArgCounts: nested calls, comma strings, dotted + definitions skipped', () => {
+  const calls = extractCallArgCounts('const r = only(1, g(2,3));\nobj.only(9);\nfunction only(a) {}\ngreet("a,b")\nnew Foo(1)\nif (only) {}');
+  const byName = {};
+  for (const c of calls) byName[c.name + '@' + c.line] = c.args;
+  assert.strictEqual(byName['only@1'], 2, 'nested call args miscounted');
+  assert.strictEqual(byName['g@1'], 2);
+  assert.strictEqual(byName['greet@4'], 1, 'comma-in-string miscounted');
+  assert.strictEqual(byName['only@2'], undefined, 'dotted call must be skipped');
+  assert.strictEqual(byName['only@3'], undefined, 'definition must be skipped');
+  assert.strictEqual(byName['Foo@5'], undefined, 'new-expression must be skipped');
+});
+
+// ── checkArity ──────────────────────────────────────────────────────────────
+
+test('checkArity: in-range/variadic/ambiguous never flag; out-of-range flags', () => {
+  const idx = sampleIndex();
+  assert.strictEqual(checkArity('only', 1, idx), null);
+  assert.ok(checkArity('only', 2, idx), 'too many args must flag');
+  assert.ok(checkArity('only', 0, idx), 'too few args must flag');
+  assert.strictEqual(checkArity('greet', 1, idx), null);
+  assert.strictEqual(checkArity('greet', 2, idx), null);
+  assert.ok(checkArity('greet', 3, idx));
+  assert.strictEqual(checkArity('add', 5, idx), null, 'ambiguous must never flag');
+  assert.strictEqual(checkArity('spread', 9, idx), null, 'variadic above min must never flag');
+  assert.strictEqual(checkArity('nosuch', 1, idx), null);
+});
+
+// ── verify() end-to-end (real context file, no opts injection) ──────────────
+
+function withRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-arity-'));
+  fs.mkdirSync(path.join(dir, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github', 'copilot-instructions.md'), [
+    '### src/billing.js',
+    '```',
+    'export function charge(amount, currency)  :3-9',
+    '```',
+    '',
+  ].join('\n'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+test('verify(): wrong-arity call flags arity-mismatch with the repo signature as suggestion', () => {
+  withRepo((dir) => {
+    const answer = 'Use it like this:\n```js\ncharge(100, "eur", true)\n```\n';
+    const res = verify(answer, dir, { libIndex: false });
+    const issue = res.issues.find((i) => i.type === 'arity-mismatch');
+    assert.ok(issue, `arity-mismatch missing: ${JSON.stringify(res.issues)}`);
+    assert.strictEqual(issue.confidence, 'medium');
+    assert.ok(issue.message.includes('3 argument(s)') && issue.message.includes('takes 2'), issue.message);
+    assert.ok(issue.suggestion.includes('charge(amount, currency)'), issue.suggestion);
+  });
+});
+
+test('verify(): in-range call is clean; unknown symbol stays fake-symbol, not arity', () => {
+  withRepo((dir) => {
+    const clean = verify('```js\ncharge(100, "eur")\n```\n', dir, { libIndex: false });
+    assert.ok(!clean.issues.find((i) => i.type === 'arity-mismatch'), JSON.stringify(clean.issues));
+    const unknown = verify('Call `chargeAll(1)` to bill.\n', dir, { libIndex: false });
+    assert.ok(unknown.issues.find((i) => i.type === 'fake-symbol'), 'unknown symbol must be fake-symbol');
+    assert.ok(!unknown.issues.find((i) => i.type === 'arity-mismatch'), 'unknown symbol must not be arity-checked');
+  });
+});
+
+console.log(`\n  arity-verify: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 135,
+  "tests": 136,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #529

## Summary
- **D1 lands** — the payoff of the tokenizer track: `verify`/`verify_suggestion`/`sigmap verify-ai-output` now check that calls to known repo functions use a plausible argument count, against the exact params the v8.27 balanced scanner (JS/TS) and the Python AST provide.

## Changes
- `src/verify/arity.js`: `parseParams` (defaults/optionals/variadics/destructuring → `{min,max,variadic}`) · `buildArityIndex` (exact-param languages only; cross-file conflicts → ambiguous, never checked; members excluded) · `extractCallArgCounts` (masked balanced scan — nested calls and comma-strings count right; dotted/definitions/`new`/keywords skipped) · `checkArity`
- `hallucination-guard.js`: detector 3b `arity-mismatch` (medium confidence, repo signature + file as suggestion); `opts.arityIndex` injectable; hermetic callers unchanged
- `KNOWN_LIMITATIONS.md`: arity checks + their conservative gates documented

## Conservatism by construction
Flags only: uniquely-resolved · top-level · non-variadic (variadic flags only too-few) · undotted calls · in JS/TS/Python code blocks · symbols already present in the index (unknowns stay `fake-symbol`).

## Test plan
- [x] `node test/integration/arity-verify.test.js` — 6/6 (incl. end-to-end through a real context file with no opts injection)
- [x] `node test/integration/all.js` — 130 files, 0 failed (existing verify behavior byte-unchanged)
- [x] Supply-chain local audit PASS (tarball +1 file: arity.js)