### PR TITLE
fix: Python absolute imports resolve through any ancestor root (#532)

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -11573,23 +11573,31 @@ __factories["./src/graph/builder"] = function(module, exports) {
         }
       }
 
-      // Absolute imports: from package.module import ... (infer from project structure)
+      // Absolute imports: from package.module import ... (infer from project
+      // structure). The module is resolved against EVERY ancestor of the
+      // importing file up to the project root, nearest first — any of them can
+      // be the source root on sys.path (src/ layouts, pytest rootdir). The old
+      // dir + one-parent probe silently dropped edges for files nested two or
+      // more directories below the source root (#532), and a false "zero
+      // importers" from get_impact is exactly the signal that says a change is
+      // safe to make.
       const reAbs = /^[ \t]*from\s+([\w.]+)\s+import/gm;
       while ((m = reAbs.exec(content)) !== null) {
         const modulePath = m[1].replace(/\./g, '/');
-        const candidates = [
-          path.join(dir, modulePath + '.py'),
-          path.join(dir, modulePath, '__init__.py'),
-          path.resolve(dir, '..', modulePath + '.py'),
-          path.resolve(dir, '..', modulePath, '__init__.py'),
-        ];
-        for (const c of candidates) {
-          const normC = normalizePath(c);
-          if (fileSet.has(normC)) {
-            found.push(normC);
-            break;
+        const normCwd = normalizePath(path.resolve(cwd));
+        let base = dir;
+        let hit = null;
+        for (let depth = 0; depth < 16 && !hit; depth++) {
+          for (const c of [path.join(base, modulePath + '.py'), path.join(base, modulePath, '__init__.py')]) {
+            const normC = normalizePath(c);
+            if (fileSet.has(normC)) { hit = normC; break; }
           }
+          if (normalizePath(base) === normCwd) break;
+          const parent = path.dirname(base);
+          if (parent === base) break;
+          base = parent;
         }
+        if (hit) found.push(hit);
       }
     }
 

--- a/src/graph/builder.js
+++ b/src/graph/builder.js
@@ -240,23 +240,31 @@ function extractFileDeps(filePath, content, fileSet, cwd, ctx) {
       }
     }
 
-    // Absolute imports: from package.module import ... (infer from project structure)
+    // Absolute imports: from package.module import ... (infer from project
+    // structure). The module is resolved against EVERY ancestor of the
+    // importing file up to the project root, nearest first — any of them can
+    // be the source root on sys.path (src/ layouts, pytest rootdir). The old
+    // dir + one-parent probe silently dropped edges for files nested two or
+    // more directories below the source root (#532), and a false "zero
+    // importers" from get_impact is exactly the signal that says a change is
+    // safe to make.
     const reAbs = /^[ \t]*from\s+([\w.]+)\s+import/gm;
     while ((m = reAbs.exec(content)) !== null) {
       const modulePath = m[1].replace(/\./g, '/');
-      const candidates = [
-        path.join(dir, modulePath + '.py'),
-        path.join(dir, modulePath, '__init__.py'),
-        path.resolve(dir, '..', modulePath + '.py'),
-        path.resolve(dir, '..', modulePath, '__init__.py'),
-      ];
-      for (const c of candidates) {
-        const normC = normalizePath(c);
-        if (fileSet.has(normC)) {
-          found.push(normC);
-          break;
+      const normCwd = normalizePath(path.resolve(cwd));
+      let base = dir;
+      let hit = null;
+      for (let depth = 0; depth < 16 && !hit; depth++) {
+        for (const c of [path.join(base, modulePath + '.py'), path.join(base, modulePath, '__init__.py')]) {
+          const normC = normalizePath(c);
+          if (fileSet.has(normC)) { hit = normC; break; }
         }
+        if (normalizePath(base) === normCwd) break;
+        const parent = path.dirname(base);
+        if (parent === base) break;
+        base = parent;
       }
+      if (hit) found.push(hit);
     }
   }
 

--- a/test/integration/py-absolute-imports.test.js
+++ b/test/integration/py-absolute-imports.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * #532 — Python absolute imports resolve through ANY ancestor source root,
+ * not just the importing file's dir + one parent. A silent zero-importer
+ * result from get_impact is a false "safe to change" signal.
+ * Run: node test/integration/py-absolute-imports.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { buildFromCwd } = require(path.join(ROOT, 'src/graph/builder.js'));
+const { analyzeImpact } = require(path.join(ROOT, 'src/graph/impact.js'));
+
+let pass = 0, fail = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); fail++; }
+}
+
+function repo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-py532-'));
+  for (const [rel, content] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+const rm = (dir) => fs.rmSync(dir, { recursive: true, force: true });
+const importersOf = (graph, needle) => {
+  for (const [k, v] of graph.reverse) if (k.includes(needle)) return v;
+  return [];
+};
+
+test('issue repro: src/ layout, importer two levels below the source root', () => {
+  const dir = repo({
+    'src/a/b/target.py': 'def hello():\n    return 1\n',
+    'src/a/b/consumer.py': 'from a.b.target import hello\n\ndef use():\n    return hello()\n',
+  });
+  const importers = importersOf(buildFromCwd(dir), 'target.py');
+  assert.strictEqual(importers.length, 1, `expected 1 importer, got ${importers.length}`);
+  assert.ok(importers[0].endsWith('consumer.py'));
+  rm(dir);
+});
+
+test('deeper nesting and package __init__ imports resolve through the root', () => {
+  const dir = repo({
+    'src/pkg/sub/deep/leaf.py': 'from pkg.util.helpers import fmt\n',
+    'src/pkg/util/helpers.py': 'def fmt(x):\n    return x\n',
+    'src/pkg/other/importer.py': 'from pkg.util import helpers\n',
+    'src/pkg/util/__init__.py': '',
+  });
+  const g = buildFromCwd(dir);
+  const helperImporters = importersOf(g, 'helpers.py');
+  assert.ok(helperImporters.some((f) => f.endsWith('leaf.py')), 'deep leaf import missing');
+  const initImporters = importersOf(g, path.join('util', '__init__.py'));
+  assert.ok(initImporters.some((f) => f.endsWith('importer.py')), 'package __init__ import missing');
+  rm(dir);
+});
+
+test('nearest-first: a same-dir module still wins over a root-level name clash', () => {
+  const dir = repo({
+    'src/app/config.py': 'VALUE = 1\n',
+    'config.py': 'VALUE = 2\n',
+    'src/app/main.py': 'from config import VALUE\n',
+  });
+  const g = buildFromCwd(dir);
+  let mainDeps = [];
+  for (const [k, v] of g.forward) if (k.endsWith('main.py')) mainDeps = v;
+  assert.strictEqual(mainDeps.length, 1);
+  assert.ok(mainDeps[0].includes(path.join('app', 'config.py').replace(/\\/g, '/')) || mainDeps[0].includes('app'), `nearest module must win: ${mainDeps[0]}`);
+  rm(dir);
+});
+
+test('get_impact no longer reports zero importers for the repro layout', () => {
+  const dir = repo({
+    'src/a/b/target.py': 'def hello():\n    return 1\n',
+    'src/a/b/consumer.py': 'from a.b.target import hello\n',
+  });
+  const res = analyzeImpact([path.join('src', 'a', 'b', 'target.py')], dir, {});
+  const direct = res[0] && res[0].impact ? (res[0].impact.direct || []) : [];
+  assert.ok(direct.some((f) => String(f).includes('consumer.py')), `consumer.py missing from impact: ${JSON.stringify(res[0] && res[0].impact)}`);
+  rm(dir);
+});
+
+console.log(`\n  py-absolute-imports: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 136,
+  "tests": 137,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #532

## Summary
- Fixes the silent zero-importer bug @ruurdboeke diagnosed: Python absolute imports (`from package.module import`) only probed the importing file's dir + one parent, so `src/` layouts lost every edge from files nested ≥2 levels below the source root — and `get_impact`'s false "zero importers" is exactly the signal that says a change is safe.

## Changes
- `src/graph/builder.js`: ancestor walk from the importing file up to the project root (nearest first, 16-level cap), probing `<module>.py` and `<module>/__init__.py` per level — old same-dir/one-parent resolutions keep identical first-match semantics
- `test/integration/py-absolute-imports.test.js`: the exact issue repro, deep nesting + `__init__` imports, nearest-first precedence on name clashes, and `get_impact` end-to-end

## Test plan
- [x] `node test/integration/py-absolute-imports.test.js` — 4/4 (repro fails on the old code)
- [x] `node test/integration/all.js` — 131 files, 0 failed